### PR TITLE
Use Local Repository

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.dependencies;
+
+import java.io.File;
+
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
+import org.eclipse.aether.impl.DefaultServiceLocator;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
+import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.transport.file.FileTransporterFactory;
+import org.eclipse.aether.transport.http.HttpTransporterFactory;
+
+import com.google.common.io.Files;
+
+/**
+ * Aether initialization.
+ */
+class RepositoryUtility {
+
+  static RepositorySystem newRepositorySystem() {
+    DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
+    locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
+    locator.addService(TransporterFactory.class, FileTransporterFactory.class);
+    locator.addService(TransporterFactory.class, HttpTransporterFactory.class);
+  
+    return locator.getService(RepositorySystem.class);
+  }
+
+  static RepositorySystemSession newSession(RepositorySystem system ) {
+    DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
+  
+    // TODO find the local repository
+    File temporaryDirectory = Files.createTempDir();
+    temporaryDirectory.deleteOnExit();
+    LocalRepository localRepository = new LocalRepository(temporaryDirectory.getAbsolutePath());
+    session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, localRepository));
+    session.setReadOnly();
+    return session;
+  }
+
+}

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -33,12 +33,12 @@ import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.transport.file.FileTransporterFactory;
 import org.eclipse.aether.transport.http.HttpTransporterFactory;
 
-import com.google.common.annotations.VisibleForTesting;
-
 /**
  * Aether initialization.
  */
-class RepositoryUtility {
+final class RepositoryUtility {
+  
+  private RepositoryUtility() {}
 
   static RepositorySystem newRepositorySystem() {
     DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
@@ -55,11 +55,11 @@ class RepositoryUtility {
     LocalRepository localRepository = new LocalRepository(findLocalRepository().getAbsolutePath());
     session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, localRepository));
     session.setReadOnly();
+    
     return session;
   }
 
-  @VisibleForTesting
-  static File findLocalRepository() {
+  private static File findLocalRepository() {
     Path home = Paths.get(System.getProperty("user.home"));
     Path localRepo = home.resolve(".m2").resolve("repository");
     if (Files.isDirectory(localRepo)) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -68,7 +68,7 @@ class RepositoryUtility {
       File temporaryDirectory = com.google.common.io.Files.createTempDir();
       temporaryDirectory.deleteOnExit();
       return temporaryDirectory; 
-    }
+   }
   }
 
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtilityTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtilityTest.java
@@ -18,6 +18,8 @@ package com.google.cloud.tools.opensource.dependencies;
 
 import java.io.File;
 
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -25,8 +27,13 @@ public class RepositoryUtilityTest {
 
   @Test
   public void testFindLocalRepository() {
-    File local = RepositoryUtility.findLocalRepository();
+    RepositorySystem system = RepositoryUtility.newRepositorySystem();
+    RepositorySystemSession session = RepositoryUtility.newSession(system);
+    
+    File local = session.getLocalRepository().getBasedir();
     Assert.assertTrue(local.exists());
+    Assert.assertTrue(local.canRead());
+    Assert.assertTrue(local.canWrite());
   }
   
   

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtilityTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtilityTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.dependencies;
+
+import java.io.File;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RepositoryUtilityTest {
+
+  @Test
+  public void testFindLocalRepository() {
+    File local = RepositoryUtility.findLocalRepository();
+    Assert.assertTrue(local.exists());
+  }
+  
+  
+}


### PR DESCRIPTION
@netdpb This can cut runtime on tests (and other usages) by a factor of 10. Test suite now runs in just over a minute.

Without local repo:
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Google Cloud Platform Supported Libraries .......... SUCCESS [  0.004 s]
[INFO] Cloud Platform Supported Libraries Upper Bounds Check SUCCESS [  2.891 s]
[INFO] BOM Parent ......................................... SUCCESS [  0.001 s]
[INFO] Cloud Tools Open Source Code Hygiene Tooling ....... SUCCESS [  0.001 s]
[INFO] Dependency Lister .................................. SUCCESS [08:09 min]
[INFO] Cloud Tools Open Source Code Hygiene Dashboard ..... SUCCESS [02:16 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 10:29 min
[INFO] Finished at: 2018-09-11T18:54:02-04:00
[INFO] Final Memory: 15M/224M
[INFO] ------------------------------------------------------------------------
```

With local repo:

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Google Cloud Platform Supported Libraries .......... SUCCESS [  0.003 s]
[INFO] Cloud Platform Supported Libraries Upper Bounds Check SUCCESS [  3.291 s]
[INFO] BOM Parent ......................................... SUCCESS [  0.001 s]
[INFO] Cloud Tools Open Source Code Hygiene Tooling ....... SUCCESS [  0.000 s]
[INFO] Dependency Lister .................................. SUCCESS [ 55.399 s]
[INFO] Cloud Tools Open Source Code Hygiene Dashboard ..... SUCCESS [  6.200 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:05 min
[INFO] Finished at: 2018-09-11T18:39:35-04:00
[INFO] Final Memory: 23M/198M
[INFO] ------------------------------------------------------------------------
```