### PR TITLE
assume there can be more than one version

### DIFF
--- a/library-best-practices/JLBP-3.md
+++ b/library-best-practices/JLBP-3.md
@@ -1,12 +1,12 @@
-[JLBP-3] Use Semantic versioning
+[JLBP-3] Use Semantic Versioning
 --------------------------------
 
-Definition of semver: https://semver.org
+Definition of semantic versioning (SemVer): https://semver.org
 
-- For the purpose of compliance with semver, the stable surface of a library
-  serves as its "Public API." Annotations can be used to mark features
-  (classes, methods, etc) as unstable, and thus not part of the Public API,
-  such that semver rules don't have to apply. 
+- For the purpose of semantic versioning, the stable surface of a library
+  serves as its "public API." Annotations can mark features
+  (classes, methods, etc) as unstable, and thus not part of the public API,
+  such that semantic versioning rules don't have to apply. 
   - Examples of annotations:
     - Guava uses `@Beta`
     - grpc-java uses `@ExperimentalApi`
@@ -15,7 +15,7 @@ Definition of semver: https://semver.org
   - Library documentation should point users to a tool (or tools) that can
     help them detect when they are using features marked with these
     annotations.
-  - Even though semver rules don't apply to unstable features, it is
+  - Even though semantic versioning rules don't apply to unstable features, it is
     recommended to bump a library's minor version if unstable features have
     surface breakages.
 - Tools are available to help identify accidental incompatibilities within a
@@ -24,24 +24,19 @@ Definition of semver: https://semver.org
   - http://www.mojohaus.org/clirr-maven-plugin/
   - Example compatibility report for grpc-core:
     https://abi-laboratory.pro/index.php?view=timeline&lang=java&l=grpc-core 
-- Examples of breaking changes to a Public API that require a new major
+- Examples of breaking changes to a public API that require a new major
   version:
-  - Upgrading to a non-compatible dependency that is exposed through a
-    library's Public API (for dependencies that follow semver, this happens
-    when a dependency is bumped to a higher major version)
+  - Upgrading to an incompatible dependency that is exposed through a
+    library's Public API. For dependencies that follow semantic versioning, this happens
+    when a dependency is bumped to a higher major version.
   - Changing a method signature
   - Removing a method (deprecated or not)
 - Examples of additions that require a new minor version:
   - Upgrading a dependency to a new minor version (compatible, but new
-    features) that is exposed through a library's Public API
+    features) that is exposed through a library's public API
   - Adding a new class
   - Adding a new method
 - Special case: Merely bumping up the minimum required Java version (and not
-  making any breaking surface changes) shouldn't necessarily mean that a
+  making any breaking surface changes) does not necessarily mean that a
   library should bump its major version, because new Java versions break
-  very little surface from prior versions. When considering a bump in the
-  minimum required Java version, prefer to wait until the abandoned version
-  has minimal usage, so that the splash damage of breakage is minimized.
-  If an obsoleted version has medium or high usage, a major version bump may
-  be warranted; however, it makes little sense to do this if it is the only
-  reason the major version is being bumped.
+  very little surface from prior versions.

--- a/library-best-practices/JLBP-4.md
+++ b/library-best-practices/JLBP-4.md
@@ -5,10 +5,10 @@
   public API within the same major version. For libraries following semantic
   versioning, this means libraries with a 0.x.y version. (See [JLBP-3](JLBP-3.md) 
   for more details on the recommendations for semantic versioning.)
-- Unstable features are not part of the public API of a
-  stable library. They are often marked with annotations like `@Beta`. (See
-  [JLBP-3](JLBP-3.md) for more details on the recommendations for annotating
-  unstable features.)
+- Features that are not part of the public API of a
+  stable library are called *unstable*. Unstable features in a stable library 
+  should be marked with annotations such as `@Beta`. (See
+  [JLBP-3](JLBP-3.md) for more details on annotating unstable features.)
 - If your library depends on an unstable library or feature, and that feature
   experiences a breaking change between versions, your library will be locked to
   a specific version of that dependency.

--- a/library-best-practices/JLBP-4.md
+++ b/library-best-practices/JLBP-4.md
@@ -1,17 +1,17 @@
 [JLBP-4] Avoid dependencies on unstable libraries and features
 --------------------------------------------------------------
 
-- Unstable libraries are libraries that allow for breaking changes to their
-  Public API within the same major version. For libraries following semver, this
-  means libraries with a 0.x.y version. (See [JLBP-3](JLBP-3.md) for more
-  details on the recommendations for following semver.)
-- Unstable features are features that are not part of the stable Public API of a
-  stable library, often marked with annotations like `@Beta`.  (See
+- Unstable libraries are libraries that allow breaking changes to their
+  public API within the same major version. For libraries following semantic
+  versioning, this means libraries with a 0.x.y version. (See [JLBP-3](JLBP-3.md) 
+  for more details on the recommendations for semantic versioning.)
+- Unstable features are not part of the public API of a
+  stable library. They are often marked with annotations like `@Beta`. (See
   [JLBP-3](JLBP-3.md) for more details on the recommendations for annotating
   unstable features.)
 - If your library depends on an unstable library or feature, and that feature
   experiences a breaking change between versions, your library will be locked to
-  a specific version of your dependency.
+  a specific version of that dependency.
   - If you expose the unstable feature on your library's surface, then your
     library's current major version will be permanently locked to the version
     you initially exposed, and you won't be able to upgrade without making a
@@ -28,4 +28,4 @@
     compatible versions of the submodules. Some strategies for library owners
     include:
     - Using the same version number for all submodules in a library
-    - Providing a [BOM](https://www.baeldung.com/spring-maven-bom)
+    - Providing a [BOM](http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies)

--- a/library-best-practices/JLBP-4.md
+++ b/library-best-practices/JLBP-4.md
@@ -6,8 +6,8 @@
   versioning, this means libraries with a 0.x.y version. (See [JLBP-3](JLBP-3.md) 
   for more details on the recommendations for semantic versioning.)
 - Features that are not part of the public API of a
-  stable library are called *unstable*. Unstable features in a stable library 
-  should be marked with annotations such as `@Beta`. (See
+  stable library are called *unstable*. To mark a feature as unstable and 
+  not part of the public API, use an annotation such as `@Beta`. (See
   [JLBP-3](JLBP-3.md) for more details on annotating unstable features.)
 - If your library depends on an unstable library or feature, and that feature
   experiences a breaking change between versions, your library will be locked to


### PR DESCRIPTION
@garrettjonesgoogle also bring into sync with SemVer spec terminology. I removed a warning about Java version bumps that:

A) is not about semantic versioning
B) Implicitly assumes only one version can be maintained. 