### PR TITLE
Resolution exception to be shown in dashboard rather than stderr

### DIFF
--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/ArtifactResults.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/ArtifactResults.java
@@ -61,6 +61,7 @@ public final class ArtifactResults {
   /**
    *  @return message of exception occurred when running test, null for no exception
    */
+  @Nullable
   public String getExceptionMessage() {
     return exceptionMessage;
   }

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/ArtifactResults.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/ArtifactResults.java
@@ -32,9 +32,14 @@ public final class ArtifactResults {
 
   private final Map<String, Boolean> results = new HashMap<>();
   private final Artifact artifact;
-  
+  private String exceptionMessage;
+
   public ArtifactResults(Artifact artifact) {
     this.artifact = artifact;
+  }
+
+  public void setExceptionMessage(String exceptionMessage) {
+    this.exceptionMessage = exceptionMessage;
   }
 
   void addResult(String testName, boolean result) {
@@ -53,4 +58,10 @@ public final class ArtifactResults {
     return Artifacts.toCoordinates(artifact);
   }
 
+  /**
+   *  @return message of exception occurred when running test, null for no exception
+   */
+  public String getExceptionMessage() {
+    return exceptionMessage;
+  }
 }

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -16,17 +16,6 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
-import com.google.cloud.tools.opensource.dependencies.Artifacts;
-import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
-import com.google.cloud.tools.opensource.dependencies.DependencyGraphBuilder;
-import com.google.cloud.tools.opensource.dependencies.RepositoryUtility;
-import com.google.cloud.tools.opensource.dependencies.Update;
-import com.google.cloud.tools.opensource.dependencies.VersionComparator;
-import com.google.common.annotations.VisibleForTesting;
-import freemarker.template.Configuration;
-import freemarker.template.Template;
-import freemarker.template.TemplateException;
-import freemarker.template.Version;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -42,12 +31,25 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import freemarker.template.Version;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.DependencyCollectionException;
 import org.eclipse.aether.resolution.ArtifactDescriptorException;
 import org.eclipse.aether.resolution.DependencyResolutionException;
+
+import com.google.cloud.tools.opensource.dependencies.Artifacts;
+import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
+import com.google.cloud.tools.opensource.dependencies.DependencyGraphBuilder;
+import com.google.cloud.tools.opensource.dependencies.RepositoryUtility;
+import com.google.cloud.tools.opensource.dependencies.Update;
+import com.google.cloud.tools.opensource.dependencies.VersionComparator;
+import com.google.common.annotations.VisibleForTesting;
 
 public class DashboardMain {
   public static final String TEST_NAME_UPPER_BOUND = "Upper Bounds";

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -16,6 +16,13 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
+import com.google.cloud.tools.opensource.dependencies.Artifacts;
+import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
+import com.google.cloud.tools.opensource.dependencies.DependencyGraphBuilder;
+import com.google.cloud.tools.opensource.dependencies.RepositoryUtility;
+import com.google.cloud.tools.opensource.dependencies.Update;
+import com.google.cloud.tools.opensource.dependencies.VersionComparator;
+import com.google.common.annotations.VisibleForTesting;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
@@ -35,23 +42,18 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
+import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.DependencyCollectionException;
 import org.eclipse.aether.resolution.ArtifactDescriptorException;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 
-import com.google.cloud.tools.opensource.dependencies.Artifacts;
-import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
-import com.google.cloud.tools.opensource.dependencies.DependencyGraphBuilder;
-import com.google.cloud.tools.opensource.dependencies.RepositoryUtility;
-import com.google.cloud.tools.opensource.dependencies.Update;
-import com.google.cloud.tools.opensource.dependencies.VersionComparator;
-
 public class DashboardMain {
-  
-  public static void main(String[] args) 
+  public static final String TEST_NAME_UPPER_BOUND = "Upper Bounds";
+  public static final String TEST_NAME_DEPENDENCY_CONVERGENCE = "Dependency Convergence";
+
+  public static void main(String[] args)
       throws IOException, TemplateException, ArtifactDescriptorException {
 
     Path output = generate();
@@ -60,71 +62,71 @@ public class DashboardMain {
 
   public static Path generate() throws IOException, TemplateException, ArtifactDescriptorException {
     Configuration configuration = configureFreemarker();
-    
+
     Path relativePath = Paths.get("target", "dashboard");
     Path output = Files.createDirectories(relativePath);
-    
-    DefaultArtifact bom =
-        new DefaultArtifact("com.google.cloud:cloud-oss-bom:pom:0.62.0-SNAPSHOT");
+
+    DefaultArtifact bom = new DefaultArtifact("com.google.cloud:cloud-oss-bom:pom:0.62.0-SNAPSHOT");
     List<Artifact> managedDependencies = RepositoryUtility.readBom(bom);
-    
+
     List<ArtifactResults> table = generateReports(configuration, output, managedDependencies);
     generateDashboard(configuration, output, table);
-    
+
     return output;
   }
 
-  private static Configuration configureFreemarker() {
+  @VisibleForTesting
+  static Configuration configureFreemarker() {
     Configuration configuration = new Configuration(new Version("2.3.28"));
     configuration.setDefaultEncoding("UTF-8");
     configuration.setClassForTemplateLoading(DashboardMain.class, "/");
     return configuration;
   }
 
-  private static List<ArtifactResults> generateReports(Configuration configuration, Path output,
-      List<Artifact> artifacts) {
-    
+  @VisibleForTesting
+  static List<ArtifactResults> generateReports(
+      Configuration configuration, Path output, List<Artifact> artifacts) {
+
     List<ArtifactResults> table = new ArrayList<>();
 
-    for (Artifact artifact : artifacts ) {
+    for (Artifact artifact : artifacts) {
       try {
         ArtifactResults results = generateReport(configuration, output, artifact);
         table.add(results);
-      } catch (DependencyCollectionException | DependencyResolutionException | IOException
-          | TemplateException ex) {
-        // TODO the dashboard should somehow show that it failed to generate this report;
-        // not just silently drop it from the index
-        System.err.println("Error generating report for " + artifact);
-        System.err.println(ex.getMessage());
+      } catch (RepositoryException|IOException|TemplateException ex) {
+        ArtifactResults unavailableTestResult = new ArtifactResults(artifact);
+        unavailableTestResult.setExceptionMessage(ex.getMessage());
+        // Even when there's problem generating test result, show the error in the dashboard
+        table.add(unavailableTestResult);
       }
     }
-    
+
     return table;
   }
 
-  private static ArtifactResults generateReport(Configuration configuration, Path output,
-      Artifact artifact) throws IOException, TemplateException, DependencyCollectionException,
-      DependencyResolutionException {
-    
+  private static ArtifactResults generateReport(
+      Configuration configuration, Path output, Artifact artifact)
+      throws IOException, TemplateException, DependencyCollectionException,
+          DependencyResolutionException {
+
     String coordinates = Artifacts.toCoordinates(artifact);
     File outputFile = output.resolve(coordinates.replace(':', '_') + ".html").toFile();
- 
-    try (Writer out = new OutputStreamWriter(
-        new FileOutputStream(outputFile), StandardCharsets.UTF_8)) {
 
-      
+    try (Writer out =
+        new OutputStreamWriter(new FileOutputStream(outputFile), StandardCharsets.UTF_8)) {
+
       // includes all versions
       DependencyGraph completeDependencies =
           DependencyGraphBuilder.getCompleteDependencies(artifact);
-      List<Update> convergenceIssues = completeDependencies.findUpdates();      
-      
+      List<Update> convergenceIssues = completeDependencies.findUpdates();
+
       // picks versions according to Maven rules
       DependencyGraph transitiveDependencies =
           DependencyGraphBuilder.getTransitiveDependencies(artifact);
 
       Map<Artifact, Artifact> upperBoundFailures =
           findUpperBoundsFailures(completeDependencies, transitiveDependencies);
-      
+
       Template report = configuration.getTemplate("/templates/component.ftl");
 
       Map<String, Object> templateData = new HashMap<>();
@@ -137,9 +139,9 @@ public class DashboardMain {
 
       ArtifactResults results = new ArtifactResults(artifact);
       // TODO the keys/report names probably belong in named constants somewhere
-      results.addResult("Upper Bounds", upperBoundFailures.size() == 0);
-      results.addResult("Dependency Convergence", convergenceIssues.size() == 0);
-      
+      results.addResult(TEST_NAME_UPPER_BOUND, upperBoundFailures.size() == 0);
+      results.addResult(TEST_NAME_DEPENDENCY_CONVERGENCE, convergenceIssues.size() == 0);
+
       return results;
     }
   }
@@ -147,19 +149,19 @@ public class DashboardMain {
   // TODO may want to push this into DependencyGraph. However this probably first
   // needs some caching of the graphs so we don't end up traversing the dependency graph
   // extra times.
-  private static Map<Artifact, Artifact> findUpperBoundsFailures(DependencyGraph graph,
-      DependencyGraph transitiveDependencies) {
+  private static Map<Artifact, Artifact> findUpperBoundsFailures(
+      DependencyGraph graph, DependencyGraph transitiveDependencies) {
     Map<String, String> expectedVersionMap = graph.getHighestVersionMap();
     Map<String, String> actualVersionMap = transitiveDependencies.getHighestVersionMap();
-    
+
     VersionComparator comparator = new VersionComparator();
-    
+
     Map<Artifact, Artifact> upperBoundFailures = new LinkedHashMap<>();
-    
+
     for (String id : expectedVersionMap.keySet()) {
       String expectedVersion = expectedVersionMap.get(id);
       String actualVersion = actualVersionMap.get(id);
-      // Check that the actual version is not null because it is 
+      // Check that the actual version is not null because it is
       // possible for dependencies to appear or disappear from the tree
       // depending on which version of another dependency is loaded.
       // In both cases, no action is needed.
@@ -168,15 +170,16 @@ public class DashboardMain {
         // upperBoundFailures.add("Upgrade " + id + ":" + actualVersion + " to " + expectedVersion);
         DefaultArtifact lower = new DefaultArtifact(id + ":" + actualVersion);
         DefaultArtifact upper = new DefaultArtifact(id + ":" + expectedVersion);
-        upperBoundFailures.put(lower,  upper);
+        upperBoundFailures.put(lower, upper);
       }
     }
     return upperBoundFailures;
   }
 
-  private static void generateDashboard(Configuration configuration, Path output,
-      List<ArtifactResults> table) throws IOException, TemplateException {
-    
+  @VisibleForTesting
+  static void generateDashboard(Configuration configuration, Path output,
+      List<ArtifactResults> table)
+      throws IOException, TemplateException {
     File dashboardFile = output.resolve("dashboard.html").toFile();
     try (Writer out = new OutputStreamWriter(
         new FileOutputStream(dashboardFile), StandardCharsets.UTF_8)) {
@@ -188,5 +191,4 @@ public class DashboardMain {
       dashboard.process(templateData, out);
     }
   }
-  
 }

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -66,7 +66,8 @@ public class DashboardMain {
     Path relativePath = Paths.get("target", "dashboard");
     Path output = Files.createDirectories(relativePath);
 
-    DefaultArtifact bom = new DefaultArtifact("com.google.cloud:cloud-oss-bom:pom:0.62.0-SNAPSHOT");
+    DefaultArtifact bom =
+        new DefaultArtifact("com.google.cloud:cloud-oss-bom:pom:0.62.0-SNAPSHOT");
     List<Artifact> managedDependencies = RepositoryUtility.readBom(bom);
 
     List<ArtifactResults> table = generateReports(configuration, output, managedDependencies);
@@ -84,8 +85,8 @@ public class DashboardMain {
   }
 
   @VisibleForTesting
-  static List<ArtifactResults> generateReports(
-      Configuration configuration, Path output, List<Artifact> artifacts) {
+  static List<ArtifactResults> generateReports( Configuration configuration, Path output,
+      List<Artifact> artifacts) {
 
     List<ArtifactResults> table = new ArrayList<>();
 
@@ -93,7 +94,7 @@ public class DashboardMain {
       try {
         ArtifactResults results = generateReport(configuration, output, artifact);
         table.add(results);
-      } catch (RepositoryException|IOException|TemplateException ex) {
+      } catch (RepositoryException | IOException | TemplateException ex) {
         ArtifactResults unavailableTestResult = new ArtifactResults(artifact);
         unavailableTestResult.setExceptionMessage(ex.getMessage());
         // Even when there's problem generating test result, show the error in the dashboard
@@ -104,16 +105,15 @@ public class DashboardMain {
     return table;
   }
 
-  private static ArtifactResults generateReport(
-      Configuration configuration, Path output, Artifact artifact)
-      throws IOException, TemplateException, DependencyCollectionException,
+  private static ArtifactResults generateReport(Configuration configuration, Path output,
+      Artifact artifact) throws IOException, TemplateException, DependencyCollectionException,
           DependencyResolutionException {
 
     String coordinates = Artifacts.toCoordinates(artifact);
     File outputFile = output.resolve(coordinates.replace(':', '_') + ".html").toFile();
 
-    try (Writer out =
-        new OutputStreamWriter(new FileOutputStream(outputFile), StandardCharsets.UTF_8)) {
+    try (Writer out = new OutputStreamWriter(
+        new FileOutputStream(outputFile), StandardCharsets.UTF_8)) {
 
       // includes all versions
       DependencyGraph completeDependencies =
@@ -138,7 +138,6 @@ public class DashboardMain {
       report.process(templateData, out);
 
       ArtifactResults results = new ArtifactResults(artifact);
-      // TODO the keys/report names probably belong in named constants somewhere
       results.addResult(TEST_NAME_UPPER_BOUND, upperBoundFailures.size() == 0);
       results.addResult(TEST_NAME_DEPENDENCY_CONVERGENCE, convergenceIssues.size() == 0);
 
@@ -149,8 +148,8 @@ public class DashboardMain {
   // TODO may want to push this into DependencyGraph. However this probably first
   // needs some caching of the graphs so we don't end up traversing the dependency graph
   // extra times.
-  private static Map<Artifact, Artifact> findUpperBoundsFailures(
-      DependencyGraph graph, DependencyGraph transitiveDependencies) {
+  private static Map<Artifact, Artifact> findUpperBoundsFailures(DependencyGraph graph,
+      DependencyGraph transitiveDependencies) {
     Map<String, String> expectedVersionMap = graph.getHighestVersionMap();
     Map<String, String> actualVersionMap = transitiveDependencies.getHighestVersionMap();
 

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -94,11 +94,14 @@ public class DashboardMain {
       try {
         ArtifactResults results = generateReport(configuration, output, artifact);
         table.add(results);
-      } catch (RepositoryException | IOException | TemplateException ex) {
+      } catch (RepositoryException | IOException ex) {
         ArtifactResults unavailableTestResult = new ArtifactResults(artifact);
         unavailableTestResult.setExceptionMessage(ex.getMessage());
         // Even when there's problem generating test result, show the error in the dashboard
         table.add(unavailableTestResult);
+      } catch (TemplateException ex) {
+        // This failure is ours. No need to report it in dashboard for an artifact
+        throw new RuntimeException("Error in template setting in this project", ex);
       }
     }
 

--- a/dashboard/src/main/resources/templates/dashboard.ftl
+++ b/dashboard/src/main/resources/templates/dashboard.ftl
@@ -10,6 +10,10 @@
       background-color: red;
       font-weight: bold;
     }
+    .UNAVAILABLE {
+      background-color: gray;
+      font-weight: bold;
+    }
     </style>
   </head>
   <body>
@@ -21,9 +25,20 @@
       </tr>
       <#list table as row>
         <tr>
-          <td><a href='${row.getCoordinates()?replace(":", "_")}.html'>${row.getCoordinates()}</a></td>   
-          <td class='${row.getResult("Upper Bounds")?string('PASS', 'FAIL')}'>${row.getResult("Upper Bounds")?string('PASS', 'FAIL')}</td>
-          <td class='${row.getResult("Dependency Convergence")?string('PASS', 'FAIL')}'>${row.getResult("Dependency Convergence")?string('PASS', 'FAIL')}</td>
+          <#if row.getResult("Upper Bounds")?? >
+            <#assign upper_bound_test_label = row.getResult("Upper Bounds")?then('PASS', 'FAIL') >
+          <#else>
+            <#assign upper_bound_test_label = "UNAVAILABLE">
+          </#if>
+          <td><a href='${row.getCoordinates()?replace(":", "_")}.html'>${row.getCoordinates()}</a></td>
+          <td class='${upper_bound_test_label}' title="${row.getExceptionMessage()!""}">${upper_bound_test_label}</td>
+
+          <#if row.getResult("Dependency Convergence")?? >
+            <#assign dependency_convergence_test_label = row.getResult("Dependency Convergence")?then('PASS', 'FAIL') >
+          <#else>
+            <#assign dependency_convergence_test_label = "UNAVAILABLE">
+          </#if>
+          <td class='${dependency_convergence_test_label}' title="${row.getExceptionMessage()!""}">${dependency_convergence_test_label}</td>
         </tr>
       </#list>
       </table>

--- a/dashboard/src/main/resources/templates/dashboard.ftl
+++ b/dashboard/src/main/resources/templates/dashboard.ftl
@@ -25,9 +25,11 @@
       </tr>
       <#list table as row>
         <tr>
-          <#if row.getResult("Upper Bounds")?? >
+          <#if row.getResult("Upper Bounds")?? ><#-- checking isNotNull() -->
+            <#-- When it's not null, it means the test ran. It's either PASS or FAIL -->
             <#assign upper_bound_test_label = row.getResult("Upper Bounds")?then('PASS', 'FAIL') >
           <#else>
+            <#-- Null means there's an exception and test couldn't run -->
             <#assign upper_bound_test_label = "UNAVAILABLE">
           </#if>
           <td><a href='${row.getCoordinates()?replace(":", "_")}.html'>${row.getCoordinates()}</a></td>

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
-import freemarker.template.TemplateException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
@@ -32,6 +31,7 @@ import nu.xom.Nodes;
 import nu.xom.ParsingException;
 import nu.xom.ValidityException;
 
+import freemarker.template.TemplateException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.resolution.ArtifactDescriptorException;
@@ -52,7 +52,7 @@ public class DashboardTest {
   private Builder builder = new Builder();
 
   @BeforeClass
-  public static void setUp() throws ArtifactDescriptorException, IOException, TemplateException{
+  public static void setUp() throws ArtifactDescriptorException, IOException, TemplateException {
     // Creates "dashboard.html" in outputDirectory
     outputDirectory = DashboardMain.generate();
   }

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -16,12 +16,6 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
-import com.google.cloud.tools.opensource.dependencies.Artifacts;
-import com.google.common.io.MoreFiles;
-import com.google.common.io.RecursiveDeleteOption;
-import com.google.common.truth.Truth;
-import freemarker.template.Configuration;
-import freemarker.template.TemplateException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,6 +23,9 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import freemarker.template.Configuration;
+import freemarker.template.TemplateException;
 import nu.xom.Builder;
 import nu.xom.Document;
 import nu.xom.Element;
@@ -40,6 +37,12 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import com.google.cloud.tools.opensource.dependencies.Artifacts;
+import com.google.common.io.MoreFiles;
+import com.google.common.io.RecursiveDeleteOption;
+import com.google.common.truth.Truth;
+
 
 public class DashboardUnavailableArtifactTest {
 

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.dashboard;
+
+import com.google.cloud.tools.opensource.dependencies.Artifacts;
+import com.google.common.io.MoreFiles;
+import com.google.common.io.RecursiveDeleteOption;
+import com.google.common.truth.Truth;
+import freemarker.template.Configuration;
+import freemarker.template.TemplateException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import nu.xom.Builder;
+import nu.xom.Document;
+import nu.xom.Element;
+import nu.xom.Nodes;
+import nu.xom.ParsingException;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DashboardUnavailableArtifactTest {
+
+  private static Path outputDirectory;
+  private Builder builder = new Builder();
+
+  @BeforeClass
+  public static void setUp() throws IOException {
+    outputDirectory = Files.createDirectories(Paths.get("target", "dashboard"));
+  }
+
+  @AfterClass
+  public static void cleanUp() throws IOException {
+    MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
+  }
+  @Test
+  public void testDashboardForRepositoryException() {
+    Configuration configuration = DashboardMain.configureFreemarker();
+    Artifact validArtifact = new DefaultArtifact("io.grpc:grpc-context:1.15.0");
+    Artifact nonExistentArtifact = new DefaultArtifact("io.grpc:nonexistent:jar:1.15.0");
+
+    List<ArtifactResults> artifactResults =
+        DashboardMain.generateReports(
+            configuration, outputDirectory, Arrays.asList(validArtifact, nonExistentArtifact));
+
+    Assert.assertEquals(
+        "The length fo the ArtifactResults should match the length of artifacts",
+        2,
+        artifactResults.size());
+    Assert.assertEquals(
+        "The first artifact result should be valid",
+        true,
+        artifactResults.get(0).getResult(DashboardMain.TEST_NAME_UPPER_BOUND));
+    ArtifactResults errorArtifactResult = artifactResults.get(1);
+    Assert.assertNull(
+        "The second artifact result should be null",
+        errorArtifactResult.getResult(DashboardMain.TEST_NAME_UPPER_BOUND));
+    Assert.assertEquals(
+        "The error artifact result should contain error message",
+        "Could not find artifact io.grpc:nonexistent:jar:1.15.0 in central (http://repo1.maven.org/maven2/)",
+        errorArtifactResult.getExceptionMessage());
+  }
+
+  @Test
+  public void testDashboardWithRepositoryException()
+      throws IOException, TemplateException, ParsingException {
+    Configuration configuration = DashboardMain.configureFreemarker();
+
+    Artifact validArtifact = new DefaultArtifact("io.grpc:grpc-context:1.15.0");
+    ArtifactResults validArtifactResult = new ArtifactResults(validArtifact);
+    validArtifactResult.addResult(DashboardMain.TEST_NAME_UPPER_BOUND, true);
+    validArtifactResult.addResult(DashboardMain.TEST_NAME_DEPENDENCY_CONVERGENCE, true);
+
+    Artifact invalidArtifact = new DefaultArtifact("io.grpc:nonexistent:jar:1.15.0");
+    ArtifactResults errorArtifactResult = new ArtifactResults(invalidArtifact);
+    errorArtifactResult.setExceptionMessage(
+        "Could not find artifact io.grpc:nonexistent:jar:1.15.0 in central (http://repo1.maven.org/maven2/)");
+    List<ArtifactResults> table = new ArrayList<>();
+    table.add(validArtifactResult);
+    table.add(errorArtifactResult);
+
+    DashboardMain.generateDashboard(configuration, outputDirectory, table);
+
+    Path generatedDashboardHtml = outputDirectory.resolve("dashboard.html");
+    Assert.assertTrue(Files.isRegularFile(generatedDashboardHtml));
+    Document document = builder.build(generatedDashboardHtml.toFile());
+    Assert.assertEquals("en-US", document.getRootElement().getAttribute("lang").getValue());
+    Nodes tr = document.query("//tr");
+
+    Assert.assertEquals(
+        "The size of rows in table should match the number of artifacts + 1 (header)",
+        tr.size(),table.size() + 1);
+
+    Nodes tdForValidArtifact = tr.get(1).query("td");
+    Assert.assertEquals(
+        Artifacts.toCoordinates(validArtifact), tdForValidArtifact.get(0).getValue());
+    Element firstResult = (Element) (tdForValidArtifact.get(1));
+    Truth.assertThat(firstResult.getValue()).isEqualTo("PASS");
+    Truth.assertThat(firstResult.getAttributeValue("class")).isEqualTo("PASS");
+
+    Nodes tdForErrorArtifact = tr.get(2).query("td");
+    Assert.assertEquals(
+        Artifacts.toCoordinates(invalidArtifact), tdForErrorArtifact.get(0).getValue());
+    Element secondResult = (Element) (tdForErrorArtifact.get(1));
+    Truth.assertThat(secondResult.getValue()).isEqualTo("UNAVAILABLE");
+    Truth.assertThat(secondResult.getAttributeValue("class")).isEqualTo("UNAVAILABLE");
+  }
+}


### PR DESCRIPTION
Now ResolutionException is shown in dashboard rather than stderr

Dummy dashboard output generated by a test case:

![invalid_artifact_in_dashboard](https://user-images.githubusercontent.com/28604/46373268-8de94a00-c65b-11e8-852a-3c2f3688d3f8.png)

