### PR TITLE
Refactor to do all parsing and querying of POMs before rather than du…

### DIFF
--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/ArtifactCache.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/ArtifactCache.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.dashboard;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.aether.artifact.Artifact;
+
+import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
+
+/**
+ * Unified return type to bundle a lot of information  about multiple artifacts together.
+ */
+class ArtifactCache {
+
+  private Map<Artifact, ArtifactInfo> infoMap;
+  private List<DependencyGraph> globalDependencies;
+
+  void setInfoMap(Map<Artifact, ArtifactInfo> infoMap) {
+    this.infoMap = infoMap;
+  }
+
+  void setGlobalDependencies(List<DependencyGraph> globalDependencies) {
+    this.globalDependencies = globalDependencies;
+  }
+
+  Map<Artifact, ArtifactInfo> getInfoMap() {
+    return infoMap;
+  }
+
+  List<DependencyGraph> getGlobalDependencies() {
+    return globalDependencies;
+  }
+
+}

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/ArtifactInfo.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/ArtifactInfo.java
@@ -35,7 +35,7 @@ class ArtifactInfo {
     this.transitiveDependencies = transitiveDependencies;
   }
 
-  public ArtifactInfo(RepositoryException ex) {
+  ArtifactInfo(RepositoryException ex) {
     this.exception = ex;
   }
 

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/ArtifactInfo.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/ArtifactInfo.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.dashboard;
+
+import org.eclipse.aether.RepositoryException;
+
+import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
+
+/** 
+ * Cache of info looked up for an artifact.
+ */
+class ArtifactInfo {
+
+  private DependencyGraph completeDependencies;
+  private DependencyGraph transitiveDependencies;
+  private RepositoryException exception;
+
+  ArtifactInfo(DependencyGraph completeDependencies,
+      DependencyGraph transitiveDependencies) {
+    this.completeDependencies = completeDependencies;
+    this.transitiveDependencies = transitiveDependencies;
+  }
+
+  public ArtifactInfo(RepositoryException ex) {
+    this.exception = ex;
+  }
+
+  DependencyGraph getCompleteDependencies() {
+    return completeDependencies;
+  }
+
+  DependencyGraph getTransitiveDependencies() {
+    return transitiveDependencies;
+  }
+
+  RepositoryException getException() {
+    return exception;
+  }
+
+}

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -37,7 +37,9 @@ import nu.xom.ValidityException;
 import freemarker.template.TemplateException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.DependencyCollectionException;
 import org.eclipse.aether.resolution.ArtifactDescriptorException;
+import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -55,7 +57,8 @@ public class DashboardTest {
   private Builder builder = new Builder();
 
   @BeforeClass
-  public static void setUp() throws ArtifactDescriptorException, IOException, TemplateException {
+  public static void setUp() throws ArtifactDescriptorException, IOException, TemplateException,
+      DependencyCollectionException, DependencyResolutionException {
     // Creates "dashboard.html" in outputDirectory
     outputDirectory = DashboardMain.generate();
   }
@@ -66,7 +69,8 @@ public class DashboardTest {
   }
 
   @Test
-  public void testMain() throws IOException, TemplateException, ArtifactDescriptorException {
+  public void testMain() throws IOException, TemplateException, ArtifactDescriptorException,
+      DependencyCollectionException, DependencyResolutionException {
     // Ensuring normal execution doesn't cause any exception
     DashboardMain.main(null);
   }

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -114,7 +114,7 @@ public class DashboardUnavailableArtifactTest {
     table.add(validArtifactResult);
     table.add(errorArtifactResult);
 
-    DashboardMain.generateDashboard(configuration, outputDirectory, table);
+    DashboardMain.generateDashboard(configuration, outputDirectory, table, null);
 
     Path generatedDashboardHtml = outputDirectory.resolve("dashboard.html");
     Assert.assertTrue(Files.isRegularFile(generatedDashboardHtml));

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -21,8 +21,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import freemarker.template.Configuration;
 import freemarker.template.TemplateException;
@@ -31,6 +32,8 @@ import nu.xom.Document;
 import nu.xom.Element;
 import nu.xom.Nodes;
 import nu.xom.ParsingException;
+
+import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.AfterClass;
@@ -39,6 +42,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
+import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
 import com.google.common.truth.Truth;
@@ -65,9 +69,14 @@ public class DashboardUnavailableArtifactTest {
     Artifact validArtifact = new DefaultArtifact("io.grpc:grpc-context:1.15.0");
     Artifact nonExistentArtifact = new DefaultArtifact("io.grpc:nonexistent:jar:1.15.0");
 
+    Map<Artifact, ArtifactInfo> map = new LinkedHashMap<>();
+    DependencyGraph graph1 = new DependencyGraph();
+    DependencyGraph graph2 = new DependencyGraph();
+    map.put(validArtifact, new ArtifactInfo(graph1, graph2));
+    map.put(nonExistentArtifact, new ArtifactInfo(new RepositoryException("foo")));
+    
     List<ArtifactResults> artifactResults =
-        DashboardMain.generateReports(
-            configuration, outputDirectory, Arrays.asList(validArtifact, nonExistentArtifact));
+        DashboardMain.generateReports(configuration, outputDirectory, map);
 
     Assert.assertEquals(
         "The length of the ArtifactResults should match the length of artifacts",
@@ -83,7 +92,7 @@ public class DashboardUnavailableArtifactTest {
         errorArtifactResult.getResult(DashboardMain.TEST_NAME_UPPER_BOUND));
     Assert.assertEquals(
         "The error artifact result should contain error message",
-        "Could not find artifact io.grpc:nonexistent:jar:1.15.0 in central (http://repo1.maven.org/maven2/)",
+        "foo",
         errorArtifactResult.getExceptionMessage());
   }
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import org.eclipse.aether.artifact.Artifact;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.TreeMultimap;
@@ -58,8 +59,8 @@ public class DependencyGraph {
   // map of groupId:artifactId:version to paths
   private SetMultimap<String, DependencyPath> paths = HashMultimap.create();
   
-  // hide constructor
-  DependencyGraph() {
+  @VisibleForTesting
+  public DependencyGraph() {
   }
 
   void addPath(DependencyPath path) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -34,8 +34,8 @@ import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 
 /**
- * Based on the <a href="https://maven.apache.org/resolver/index.html">Apache Maven Artifact Resolver</a>
- * (formerly known as Eclipse Aether).
+ * Based on the <a href="https://maven.apache.org/resolver/index.html">Apache Maven Artifact
+ * Resolver</a> (formerly known as Eclipse Aether).
  */
 public class DependencyGraphBuilder {
   


### PR DESCRIPTION
@suztomo Refactor to do all parsing and querying of POMs before rather than during report generation. This will enable us to produce more reports, especially global reports, without hitting Maven central repeatedly to retrieve the same information.