### PR TITLE
add global upper bounds to front page

### DIFF
--- a/dashboard/src/main/resources/templates/dashboard.ftl
+++ b/dashboard/src/main/resources/templates/dashboard.ftl
@@ -52,10 +52,12 @@
     <h2>Artifact Details</h2>
     <table>
       <tr>
-        <th>Artifact</th><th>Upper Bounds</th><th>Dependency Convergence</th>
+        <th>Artifact</th><th>Upper Bounds</th><th>Dependency Convergence</th><th>Global Upper Bounds</th>
       </tr>
       <#list table as row>
+        <!-- TODO use a macro to remove duplicate code for each td --> 
         <tr>
+          <td><a href='${row.getCoordinates()?replace(":", "_")}.html'>${row.getCoordinates()}</a></td>
           <#if row.getResult("Upper Bounds")?? ><#-- checking isNotNull() -->
             <#-- When it's not null, it means the test ran. It's either PASS or FAIL -->
             <#assign upper_bound_test_label = row.getResult("Upper Bounds")?then('PASS', 'FAIL')>
@@ -64,7 +66,6 @@
             <#-- Null means there's an exception and test couldn't run -->
             <#assign upper_bound_test_label = "UNAVAILABLE">
           </#if>
-          <td><a href='${row.getCoordinates()?replace(":", "_")}.html'>${row.getCoordinates()}</a></td>
           <td class='${upper_bound_test_label}' title="${row.getExceptionMessage()!""}">
             <#if row.getResult("Upper Bounds")?? >
               <#if upper_bound_failure_count == 1>1 FAILURE
@@ -84,6 +85,23 @@
             <#if row.getResult("Dependency Convergence")?? >
               <#if dependency_convergence_failure_count == 1>1 FAILURE
               <#elseif dependency_convergence_failure_count gt 1>${dependency_convergence_failure_count} FAILURES
+              <#else>PASS
+              </#if>
+            <#else>UNAVAILABLE
+            </#if>
+          </td>
+          <#if row.getResult("Global Upper Bounds")?? ><#-- checking isNotNull() -->
+            <#-- When it's not null, it means the test ran. It's either PASS or FAIL -->
+            <#assign global_upper_bound_test_label = row.getResult("Global Upper Bounds")?then('PASS', 'FAIL')>
+            <#assign global_upper_bound_failure_count = row.getFailureCount("Global Upper Bounds")>
+          <#else>
+            <#-- Null means there's an exception and test couldn't run -->
+            <#assign upper_bound_test_label = "UNAVAILABLE">
+          </#if>
+          <td class='${global_upper_bound_test_label}' title="${row.getExceptionMessage()!""}">
+            <#if row.getResult("Upper Bounds")?? >
+              <#if global_upper_bound_failure_count == 1>1 FAILURE
+              <#elseif global_upper_bound_failure_count gt 1>${global_upper_bound_failure_count} FAILURES
               <#else>PASS
               </#if>
             <#else>UNAVAILABLE

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -105,6 +105,10 @@ public class DashboardTest {
         Element secondResult = (Element) (td.get(2));
         Truth.assertThat(secondResult.getValue().replaceAll("\\s","")).containsMatch("PASS|\\d+FAILURES?");
         Truth.assertThat(secondResult.getAttributeValue("class")).isAnyOf("PASS", "FAIL");
+        
+        Element thirdResult = (Element) (td.get(3));
+        Truth.assertThat(thirdResult.getValue().replaceAll("\\s","")).containsMatch("PASS|\\d+FAILURES?");
+        Truth.assertThat(thirdResult.getAttributeValue("class")).isAnyOf("PASS", "FAIL");
       }
       Nodes href = document.query("//tr/td/a/@href");
       for (int i = 0; i < href.size(); i++) {

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -107,6 +107,7 @@ public class DashboardUnavailableArtifactTest {
     ArtifactResults validArtifactResult = new ArtifactResults(validArtifact);
     validArtifactResult.addResult(DashboardMain.TEST_NAME_UPPER_BOUND, 0);
     validArtifactResult.addResult(DashboardMain.TEST_NAME_DEPENDENCY_CONVERGENCE, 0);
+    validArtifactResult.addResult(DashboardMain.TEST_NAME_GLOBAL_UPPER_BOUND, 0);
 
     Artifact invalidArtifact = new DefaultArtifact("io.grpc:nonexistent:jar:1.15.0");
     ArtifactResults errorArtifactResult = new ArtifactResults(invalidArtifact);

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -78,7 +78,7 @@ public class DashboardUnavailableArtifactTest {
     ArtifactCache cache = new ArtifactCache();
     cache.setInfoMap(map);
     List<ArtifactResults> artifactResults =
-        DashboardMain.generateReports(configuration, outputDirectory, cache );
+        DashboardMain.generateReports(configuration, outputDirectory, cache);
 
     Assert.assertEquals(
         "The length of the ArtifactResults should match the length of artifacts",

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -75,8 +75,10 @@ public class DashboardUnavailableArtifactTest {
     map.put(validArtifact, new ArtifactInfo(graph1, graph2));
     map.put(nonExistentArtifact, new ArtifactInfo(new RepositoryException("foo")));
     
+    ArtifactCache cache = new ArtifactCache();
+    cache.setInfoMap(map);
     List<ArtifactResults> artifactResults =
-        DashboardMain.generateReports(configuration, outputDirectory, map);
+        DashboardMain.generateReports(configuration, outputDirectory, cache );
 
     Assert.assertEquals(
         "The length of the ArtifactResults should match the length of artifacts",


### PR DESCRIPTION
@suztomo @garrettjonesgoogle This code adds a global upper bounds (how many dependencies should be upgraded to a more recent release used somewhere in the BOM's full dependency tree) result to the front page. 

Next step is to add details about suggested upgrades to the individual artifact pages. 