### PR TITLE
Static linkage check to be able to find package-private constructor

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -258,6 +258,7 @@ class StaticLinkageChecker {
   }
 
   @VisibleForTesting
+  @SuppressWarnings("unchecked")
   static boolean methodDefinitionExists(FullyQualifiedMethodSignature methodReference,
       ClassLoader classLoader, SyntheticRepository repository) throws ClassNotFoundException {
     String className = methodReference.getClassName();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -196,6 +196,23 @@ public class StaticLinkageCheckerTest {
   }
 
   @Test
+  public void testFindUnresolvedReferences_packagePrivateInnerClass()
+      throws RepositoryException {
+    List<Path> paths = StaticLinkageChecker.coordinateToJarPaths("io.grpc:grpc-auth:1.15.1");
+
+    FullyQualifiedMethodSignature constructorOfPrivateInnerClass =
+        new FullyQualifiedMethodSignature(
+            "io.opencensus.stats.View$AggregationWindow$Interval",
+            "<init>",
+            "()V");
+
+    List<FullyQualifiedMethodSignature> unresolvedReferences = StaticLinkageChecker
+        .findUnresolvedReferences(paths,
+            Arrays.asList(constructorOfPrivateInnerClass));
+    Truth.assertThat(unresolvedReferences).isEmpty();
+  }
+
+  @Test
   public void testNonExistentJarFileInput() throws ClassNotFoundException {
     try {
       StaticLinkageChecker.findUnresolvedMethodReferences(
@@ -291,23 +308,6 @@ public class StaticLinkageCheckerTest {
         StaticLinkageChecker.methodDefinitionExists(
             constructorInAbstract, classLoader, SyntheticRepository.getInstance());
     Assert.assertTrue(exist);
-  }
-
-  @Test
-  public void testMethodDefinitionExists_packagePrivateInnerClass()
-      throws RepositoryException {
-    List<Path> paths = StaticLinkageChecker.coordinateToJarPaths("io.grpc:grpc-auth:1.15.1");
-
-    FullyQualifiedMethodSignature constructorOfPrivateInnerClass =
-        new FullyQualifiedMethodSignature(
-            "io.opencensus.stats.View$AggregationWindow$Interval",
-            "<init>",
-            "()V");
-
-    List<FullyQualifiedMethodSignature> unresolvedReferences = StaticLinkageChecker
-        .findUnresolvedReferences(paths,
-            Arrays.asList(constructorOfPrivateInnerClass));
-    Truth.assertThat(unresolvedReferences).isEmpty();
   }
 
   @Test

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -104,14 +104,14 @@ public class StaticLinkageCheckerTest {
             "getListCollectionIdsMethodHelper",
             "()Lio/grpc/MethodDescriptor;");
 
-    FullyQualifiedMethodSignature externalMethodReference =
+    FullyQualifiedMethodSignature undefinedMethodReference =
         new FullyQualifiedMethodSignature(
-            "io.grpc.protobuf.ProtoUtils",
+            "dummy.ProtoUtils",
             "marshaller",
             "(Lcom/google/protobuf/Message;)Lio/grpc/MethodDescriptor$Marshaller;");
 
     List<FullyQualifiedMethodSignature> methodReferences = Arrays.asList(
-        internalMethodReference, externalMethodReference
+        internalMethodReference, undefinedMethodReference
     );
     List<FullyQualifiedMethodSignature> unresolvedMethodReferences =
         StaticLinkageChecker.findUnresolvedReferences(pathsForJar, methodReferences);
@@ -291,6 +291,23 @@ public class StaticLinkageCheckerTest {
         StaticLinkageChecker.methodDefinitionExists(
             constructorInAbstract, classLoader, SyntheticRepository.getInstance());
     Assert.assertTrue(exist);
+  }
+
+  @Test
+  public void testMethodDefinitionExists_packagePrivateInnerClass()
+      throws RepositoryException {
+    List<Path> paths = StaticLinkageChecker.coordinateToJarPaths("io.grpc:grpc-auth:1.15.1");
+
+    FullyQualifiedMethodSignature constructorOfPrivateInnerClass =
+        new FullyQualifiedMethodSignature(
+            "io.opencensus.stats.View$AggregationWindow$Interval",
+            "<init>",
+            "()V");
+
+    List<FullyQualifiedMethodSignature> unresolvedReferences = StaticLinkageChecker
+        .findUnresolvedReferences(paths,
+            Arrays.asList(constructorOfPrivateInnerClass));
+    Truth.assertThat(unresolvedReferences).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
Static linkage check to be able to find package-private constructor. Now there's no false positive for grpc-auth.

```
Starting to read 11 files: 
[/Users/suztomo/.m2/repository/io/grpc/grpc-auth/1.15.1/grpc-auth-1.15.1.jar, /Users/suztomo/.m2/repository/io/grpc/grpc-core/1.15.1/grpc-core-1.15.1.jar, /Users/suztomo/.m2/repository/io/grpc/grpc-context/1.15.1/grpc-context-1.15.1.jar, /Users/suztomo/.m2/repository/com/google/code/gson/gson/2.7/gson-2.7.jar, /Users/suztomo/.m2/repository/com/google/guava/guava/20.0/guava-20.0.jar, /Users/suztomo/.m2/repository/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar, /Users/suztomo/.m2/repository/com/google/code/findbugs/jsr305/3.0.0/jsr305-3.0.0.jar, /Users/suztomo/.m2/repository/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar, /Users/suztomo/.m2/repository/io/opencensus/opencensus-api/0.12.3/opencensus-api-0.12.3.jar, /Users/suztomo/.m2/repository/io/opencensus/opencensus-contrib-grpc-metrics/0.12.3/opencensus-contrib-grpc-metrics-0.12.3.jar, /Users/suztomo/.m2/repository/com/google/auth/google-auth-library-credentials/0.9.0/google-auth-library-credentials-0.9.0.jar]
There were no unresolved method references from the jar file(s) :[-c, io.grpc:grpc-auth:jar:1.15.1]
```