### PR TITLE
levelOrder not to abort tree building upon cyclic dependency found.

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -222,7 +222,7 @@ public class DependencyGraphBuilder {
           System.err.println("Infinite recursion resolving " + dependencyNode);
           System.err.println("Likely cycle in " + parentNodes);
           System.err.println("Child " + dependencyNode);
-          return;
+          continue;
         }
         parentNodes.push(dependencyNode);
         graph.addPath(forPath);

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
@@ -104,7 +104,7 @@ public class DependencyGraphIntegrationTest {
     Truth.assertThat(updates).hasSize(5);
     
     List<DependencyPath> conflicts = graph.findConflicts();
-    Truth.assertThat(conflicts).hasSize(30);
+    Truth.assertThat(conflicts).hasSize(34);
     
     Map<String, String> versions = graph.getHighestVersionMap();
     Assert.assertEquals("2.6.2", versions.get("xerces:xercesImpl"));


### PR DESCRIPTION
levelOrder function stops tree building when it finds cyclic dependency at level N. Because there may be other (non-cyclic) dependency at level N+1 and deeper, let's not abort tree building upon cyclic dependency. 

Fixes #174 
