### PR TITLE
Adding JLBP-15: Produce a BOM for multi-module projects

### DIFF
--- a/library-best-practices/JLBP-15.md
+++ b/library-best-practices/JLBP-15.md
@@ -1,4 +1,4 @@
-[JLBP-16] Produce a BOM for multi-module projects
+[JLBP-15] Produce a BOM for multi-module projects
 -------------------------------------------------
 
 ### The BOM (Bill of Materials)

--- a/library-best-practices/JLBP-16.md
+++ b/library-best-practices/JLBP-16.md
@@ -3,7 +3,7 @@
 
 ### The BOM (Bill of Materials)
 
-- A BOM is a `pom.xml` file that has a `<dependencyManagement>` section that lists all the modules of a project. It does not have `<modules>` or `<dependencies>` elements itself. It also has `<type>pom</type>`.
+- A BOM is a `pom.xml` file that has a `<dependencyManagement>` section that lists all the modules of a project. It can omit the `<modules>` section, and it has no `<dependencies>` section. It also has `<packaging>pom</packaging>`.
   - All of the modules of the project should be included. Otherwise, a consumer who depends on an unspecified module must specify and upgrade the version of that module, defeating the purpose of the BOM.
 - The purpose of a BOM is to enable consumers of a library to select a consistent set of versions for artifacts released by a single project. When imported, a BOM operates as a filter. It does not cause any modules to be added as dependencies. Instead, for any dependency in a project's dependency tree, *if* that module appears in the BOM, the version from the BOM is used.
 - If all modules in a project use the same version as each other, use that same version for the BOM. Example: grpc-bom v1.15.0 would specify grpc-auth v1.15.0, gprc-core v1.15.0, etc.
@@ -14,7 +14,6 @@
 
 - Create a module containing only the BOM `pom.xml` file and add the BOM module to the parent `<modules>` list.
 - A BOM can inherit from a parent as long as the parent is not part of the build path.
-  - An example of such a parent is a BOM parent that orchestrates the releases of the BOM.
   - Unlike the module POMs of a Maven project, the BOM does not inherit from the parent POM that's used for building other modules of the library.
   - The reason is that a parent will have direct (and possibly transitive) dependencies in its `<dependencyManagement>` section to ensure that its build is consistent, but these dependency versions shouldn't be imported by consumers who import the BOM.
 - Example BOM: [google-cloud-bom](https://github.com/GoogleCloudPlatform/google-cloud-java/blob/master/google-cloud-bom/pom.xml).
@@ -23,6 +22,5 @@
 
 - A Gradle project can either maintain a pom.xml and release it using a specially configured module, or the project can generate the `pom.xml` file.
 - Example for maintaining a `pom.xml` file: gax-java - [build.gradle](https://github.com/googleapis/gax-java/blob/master/gax-bom/build.gradle) and [pom.xml](https://github.com/googleapis/gax-java/blob/master/gax-bom/pom.xml).
-  - If you want to automatically update the version in the `pom.xml` file instead of manually maintaining it, a version updating script is necessary.
 - There is not yet an example of a project that generates a `pom.xml` file.
   - Note: This approach has a limitation that the BOM cannot include any classifiers in the dependency specifications.

--- a/library-best-practices/JLBP-16.md
+++ b/library-best-practices/JLBP-16.md
@@ -4,6 +4,7 @@
 ### The BOM (Bill of Materials)
 
 - A BOM is a `pom.xml` file that has a `<dependencyManagement>` section that lists all the modules of a project. It can omit the `<modules>` section, and it has no `<dependencies>` section. It also has `<packaging>pom</packaging>`.
+  - Documentation is available at https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html .
   - All of the modules of the project should be included. Otherwise, a consumer who depends on an unspecified module must specify and upgrade the version of that module, defeating the purpose of the BOM.
 - The purpose of a BOM is to enable consumers of a library to select a consistent set of versions for artifacts released by a single project. When imported, a BOM operates as a filter. It does not cause any modules to be added as dependencies. Instead, for any dependency in a project's dependency tree, *if* that module appears in the BOM, the version from the BOM is used.
 - If all modules in a project use the same version as each other, use that same version for the BOM. Example: grpc-bom v1.15.0 would specify grpc-auth v1.15.0, gprc-core v1.15.0, etc.

--- a/library-best-practices/JLBP-16.md
+++ b/library-best-practices/JLBP-16.md
@@ -7,7 +7,7 @@
   - Documentation is available at https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html .
   - All of the modules of the project should be included. Otherwise, a consumer who depends on an unspecified module must specify and upgrade the version of that module, defeating the purpose of the BOM.
 - The purpose of a BOM is to enable consumers of a library to select a consistent set of versions for artifacts released by a single project. When imported, a BOM operates as a filter. It does not cause any modules to be added as dependencies. Instead, for any dependency in a project's dependency tree, *if* that module appears in the BOM, the version from the BOM is used.
-- If all modules in a project use the same version as each other, use that same version for the BOM. Example: grpc-bom v1.15.0 would specify grpc-auth v1.15.0, gprc-core v1.15.0, etc.
+- If all modules in a project have the same version, use that version for the BOM. Example: grpc-bom v1.15.0 would specify grpc-auth v1.15.0, gprc-core v1.15.0, etc.
 - A BOM is not necessary for projects that only have one module, since there is no consistency problem in that case.
 - See the details specific to each build system in the sections below.
 

--- a/library-best-practices/JLBP-16.md
+++ b/library-best-practices/JLBP-16.md
@@ -1,0 +1,28 @@
+[JLBP-16] Produce a BOM for multi-module projects
+-------------------------------------------------
+
+### The BOM (Bill of Materials)
+
+- A BOM is a `pom.xml` file that has a `<dependencyManagement>` section that lists all the modules of a project. It does not have `<modules>` or `<dependencies>` elements itself. It also has `<type>pom</type>` declared.
+  - All of the modules of the project should be included, otherwise a consumer trying to use an unspecified module will have to manually specify and upgrade the version of that module, defeating the purpose of the BOM.
+- The purpose of a BOM is to allow consumers of a library to ensure that they are using a consistent set of versions for artifacts released by a single project. When imported, a BOM operates as a filter. It does not cause any modules to be added as dependencies. Instead, for any dependency in a project's dependency tree, *if* that module appears in the BOM, the version from the BOM is used.
+- If all modules in a project use the same version as each other, use that same version for the BOM. Example: grpc-bom v1.15.0 would specify grpc-auth v1.15.0, gprc-core v1.15.0, etc.
+- A BOM is not necessary for projects having only one module, since there is no consistency problem in that case.
+- See the details specific to each build system in the sections below.
+
+### Libraries using Maven
+
+- Create a module containing only the BOM `pom.xml` file and add the BOM module to the parent `<modules>` list.
+- A BOM can inherit from a parent as long as the parent is not part of the build path.
+  - An example of such a parent is a BOM parent that orchestrates the releases of the BOM.
+  - Unlike the module POMs of a Maven project, the BOM does not inherit from the parent POM that's used for building other modules of the library.
+  - The reason is that a parent will have direct (and possibly transitive) dependencies in its `<dependencyManagement>` section to ensure that its build is consistent, but these dependency versions shouldn't be imported by consumers who import the BOM.
+- Example BOM: [google-cloud-bom](https://github.com/GoogleCloudPlatform/google-cloud-java/blob/master/google-cloud-bom/pom.xml).
+
+### Libraries using Gradle
+
+- A Gradle project can either maintain a pom.xml and release it using a specially configured module, or the project can generate the `pom.xml` file.
+- Example for maintaining a `pom.xml` file: gax-java - [build.gradle](https://github.com/googleapis/gax-java/blob/master/gax-bom/build.gradle) and [pom.xml](https://github.com/googleapis/gax-java/blob/master/gax-bom/pom.xml).
+  - If you want to automatically update the version in the `pom.xml` file instead of manually maintaining it, a version updating script is necessary.
+- There is not yet an example of a project that generates a `pom.xml` file.
+  - Note: This approach has a limitation that the BOM cannot include any classifiers in the dependency specifications.

--- a/library-best-practices/JLBP-16.md
+++ b/library-best-practices/JLBP-16.md
@@ -3,11 +3,11 @@
 
 ### The BOM (Bill of Materials)
 
-- A BOM is a `pom.xml` file that has a `<dependencyManagement>` section that lists all the modules of a project. It does not have `<modules>` or `<dependencies>` elements itself. It also has `<type>pom</type>` declared.
-  - All of the modules of the project should be included, otherwise a consumer trying to use an unspecified module will have to manually specify and upgrade the version of that module, defeating the purpose of the BOM.
-- The purpose of a BOM is to allow consumers of a library to ensure that they are using a consistent set of versions for artifacts released by a single project. When imported, a BOM operates as a filter. It does not cause any modules to be added as dependencies. Instead, for any dependency in a project's dependency tree, *if* that module appears in the BOM, the version from the BOM is used.
+- A BOM is a `pom.xml` file that has a `<dependencyManagement>` section that lists all the modules of a project. It does not have `<modules>` or `<dependencies>` elements itself. It also has `<type>pom</type>`.
+  - All of the modules of the project should be included. Otherwise, a consumer who depends on an unspecified module must specify and upgrade the version of that module, defeating the purpose of the BOM.
+- The purpose of a BOM is to enable consumers of a library to select a consistent set of versions for artifacts released by a single project. When imported, a BOM operates as a filter. It does not cause any modules to be added as dependencies. Instead, for any dependency in a project's dependency tree, *if* that module appears in the BOM, the version from the BOM is used.
 - If all modules in a project use the same version as each other, use that same version for the BOM. Example: grpc-bom v1.15.0 would specify grpc-auth v1.15.0, gprc-core v1.15.0, etc.
-- A BOM is not necessary for projects having only one module, since there is no consistency problem in that case.
+- A BOM is not necessary for projects that only have one module, since there is no consistency problem in that case.
 - See the details specific to each build system in the sections below.
 
 ### Libraries using Maven

--- a/library-best-practices/JLBP-16.md
+++ b/library-best-practices/JLBP-16.md
@@ -3,25 +3,50 @@
 
 ### The BOM (Bill of Materials)
 
-- A BOM is a `pom.xml` file that has a `<dependencyManagement>` section that lists all the modules of a project. It can omit the `<modules>` section, and it has no `<dependencies>` section. It also has `<packaging>pom</packaging>`.
-  - Documentation is available at https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html .
-  - All of the modules of the project should be included. Otherwise, a consumer who depends on an unspecified module must specify and upgrade the version of that module, defeating the purpose of the BOM.
-- The purpose of a BOM is to enable consumers of a library to select a consistent set of versions for artifacts released by a single project. When imported, a BOM operates as a filter. It does not cause any modules to be added as dependencies. Instead, for any dependency in a project's dependency tree, *if* that module appears in the BOM, the version from the BOM is used.
-- If all modules in a project have the same version, use that version for the BOM. Example: grpc-bom v1.15.0 would specify grpc-auth v1.15.0, gprc-core v1.15.0, etc.
-- A BOM is not necessary for projects that only have one module, since there is no consistency problem in that case.
+- A BOM is a `pom.xml` file that has a `<dependencyManagement>` section that
+  lists all the modules of a project. It can omit the `<modules>` section, and
+  it has no `<dependencies>` section. It also has `<packaging>pom</packaging>`.
+  - Documentation is available at
+    https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html
+    .
+  - All of the modules of the project should be included. Otherwise, a consumer
+    who depends on an unspecified module must specify and upgrade the version of
+    that module, defeating the purpose of the BOM.
+- The purpose of a BOM is to enable consumers of a library to select a
+  consistent set of versions for artifacts released by a single project. When
+  imported, a BOM operates as a filter. It does not cause any modules to be
+  added as dependencies. Instead, for any dependency in a project's dependency
+  tree, *if* that module appears in the BOM, the version from the BOM is used.
+- If all modules in a project have the same version, use that version for the
+  BOM. Example: grpc-bom v1.15.0 would specify grpc-auth v1.15.0, gprc-core
+  v1.15.0, etc.
+- A BOM is not necessary for projects that only have one module, since there is
+  no consistency problem in that case.
 - See the details specific to each build system in the sections below.
 
 ### Libraries using Maven
 
-- Create a module containing only the BOM `pom.xml` file and add the BOM module to the parent `<modules>` list.
-- A BOM can inherit from a parent as long as the parent is not part of the build path.
-  - Unlike the module POMs of a Maven project, the BOM does not inherit from the parent POM that's used for building other modules of the library.
-  - The reason is that a parent will have direct (and possibly transitive) dependencies in its `<dependencyManagement>` section to ensure that its build is consistent, but these dependency versions shouldn't be imported by consumers who import the BOM.
-- Example BOM: [google-cloud-bom](https://github.com/GoogleCloudPlatform/google-cloud-java/blob/master/google-cloud-bom/pom.xml).
+- Create a module containing only the BOM `pom.xml` file and add the BOM module
+  to the parent `<modules>` list.
+- A BOM can inherit from a parent as long as the parent is not part of the build
+  path.
+  - Unlike the module POMs of a Maven project, the BOM does not inherit from the
+    parent POM that's used for building other modules of the library.
+  - The reason is that a parent will have direct (and possibly transitive)
+    dependencies in its `<dependencyManagement>` section to ensure that its
+    build is consistent, but these dependency versions shouldn't be imported by
+    consumers who import the BOM.
+- Example BOM:
+  [google-cloud-bom](https://github.com/GoogleCloudPlatform/google-cloud-java/blob/master/google-cloud-bom/pom.xml).
 
 ### Libraries using Gradle
 
-- A Gradle project can either maintain a pom.xml and release it using a specially configured module, or the project can generate the `pom.xml` file.
-- Example for maintaining a `pom.xml` file: gax-java - [build.gradle](https://github.com/googleapis/gax-java/blob/master/gax-bom/build.gradle) and [pom.xml](https://github.com/googleapis/gax-java/blob/master/gax-bom/pom.xml).
+- A Gradle project can either maintain a pom.xml and release it using a
+  specially configured module, or the project can generate the `pom.xml` file.
+- Example for maintaining a `pom.xml` file: gax-java -
+  [build.gradle](https://github.com/googleapis/gax-java/blob/master/gax-bom/build.gradle)
+  and
+  [pom.xml](https://github.com/googleapis/gax-java/blob/master/gax-bom/pom.xml).
 - There is not yet an example of a project that generates a `pom.xml` file.
-  - Note: This approach has a limitation that the BOM cannot include any classifiers in the dependency specifications.
+  - Note: This approach has a limitation that the BOM cannot include any
+    classifiers in the dependency specifications.

--- a/library-best-practices/README.md
+++ b/library-best-practices/README.md
@@ -32,3 +32,4 @@ declared "Stable."
 - [JLBP-13](JLBP-13.md): Quickly remove references to deprecated features in
    dependencies
 - [JLBP-14](JLBP-14.md): Do not use version ranges
+- [JLBP-16](JLBP-16.md): Produce a BOM for multi-module projects

--- a/library-best-practices/README.md
+++ b/library-best-practices/README.md
@@ -32,4 +32,4 @@ or significantly changed before the set is classified as Beta.
 - [JLBP-13](JLBP-13.md): Quickly remove references to deprecated features in
    dependencies
 - [JLBP-14](JLBP-14.md): Do not use version ranges
-- [JLBP-16](JLBP-16.md): Produce a BOM for multi-module projects
+- [JLBP-15](JLBP-15.md): Produce a BOM for multi-module projects


### PR DESCRIPTION
This only includes instructions for the consumer-facing BOM; internal version management will be a separate JLBP. 
