### PR TITLE
Readme for Static Linkage Checker

### DIFF
--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -92,7 +92,7 @@ There are three use cases for Static Linkage Checker:
 - **Reachability** is the attribute of static linkage errors to indicate whether a linkage
   error caused by a reference is _reachable_ from the _entry point classes_ of the class usage
   graph; in other words, when a static linkage error is _reachable_, there exists a path of
-  references in the graph between one of entry point classes and the reference causing linkage
+  references in the graph from one of entry point classes to the reference causing linkage
   error.
   The path helps to diagnose why static linkage errors are introduced to the dependencies.
 

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -1,7 +1,7 @@
 Static Linkage Checker
 ======================
 
-Static Linkage Checker is a tool that to find [static linkage errors](
+Static Linkage Checker is a tool that finds [static linkage errors](
 ../library-best-practices/glossary.md) on a classpath and reports the errors to the console.
 It scans the class files in a classpath provided as input for references
 to other classes. Each reference is verified to find linkage conflicts

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -1,7 +1,8 @@
 # Static Linkage Checker
 
 Static Linkage Checker is a tool that finds [static linkage errors](
-../library-best-practices/glossary.md) on a classpath and reports the errors to the console.
+../library-best-practices/glossary.md#types-of-conflicts-and-compatibility)
+on a classpath and reports the errors to the console.
 It scans the class files in a classpath for references to other classes and
 reports any reference that cannot be satisfied in the classpath.
 It can report all such missing references or only those that are reachable from
@@ -21,17 +22,14 @@ There are two use cases for Static Linkage Checker:
 
 ### Approach
 
-1. The tool takes a classpath as required input, through either a list of jar and
-  class files in filesystems, a list of Maven coordinates, or a Maven BOM.
-  A Maven BOM is converted to a list of Maven coordinates, and a list of Maven
-  coordinates is resolved to a list of jar files that consists of the artifacts
-  and their dependencies.
+1. The tool takes a classpath as required input.
+
   The classpath is called as _linkage classpath_ on which the tool operates
   to find linkage errors and is separated from the runtime classpath of the tool itself.
 
 2. The tool extracts all _references_ from the all class files in the classpath.
 
-3. The tool records references cannot be satisfied in the classpath as
+3. The tool records references that cannot be satisfied in the classpath as
   static linkage errors.
   
 4. Optionally, the user can specify a subset of the classpath as _entry points_.
@@ -39,6 +37,16 @@ There are two use cases for Static Linkage Checker:
   from the classes in the entry points.
 
 5. At the end, the tool outputs a report on the linkage errors.
+
+### Input
+
+The tool takes a classpath through either a list of class and
+jar files in filesystems, a list of Maven coordinates, or a Maven BOM.
+
+A Maven BOM specified as a Maven coordinate is converted to a list of Maven coordinates.
+A list of Maven coordinates is resolved to a list of jar files
+that consists of the artifacts and their dependencies.
+The list of jar files forms a classpath, on which the tool operate.
 
 ### Output
 
@@ -52,9 +60,9 @@ source class and the destination class of the reference, and has one of the thre
 
   - _Missing field type_: a field reference has a static linkage conflict.
      
-### Class Usage Graph and Reachability
+### Class Reference Graph and Reachability
 
-In order to provide a diagnosis on the output report, the tool builds _class usage graphs_,
+In order to provide a diagnosis on the output report, the tool builds _class reference graphs_,
 and annotates linkage errors with _reachability_ from _entry point classes_.
 The tool allows users to choose the scope of entry point classes:
 

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -1,9 +1,8 @@
 Static Linkage Checker
 ======================
 
-Static Linkage Checker is a tool that performs a [static linkage check](
-../library-best-practices/glossary.md#static-linkage-check) on a classpath
-and reports static linkage errors to the console.
+Static Linkage Checker is a tool that to find [static linkage errors](
+../library-best-practices/glossary.md) on a classpath and reports the errors to the console.
 It scans the class files in a classpath provided as input for references
 to other classes. Each reference is verified to find linkage conflicts
 in the classpath.
@@ -15,11 +14,11 @@ classes through class usage graphs.
 There are two use cases for Static Linkage Checker:
 
 -  **For organizations** that provide multiple libraries developed by different teams,
-  the tool helps to ensure that there are no static linkage conflicts among the libraries and their
+  the tool helps to ensure that there are no static linkage errors among the libraries and their
   dependencies.
 
-- **For library/application developers** the tool assesses the risk of static linkage
-  conflicts in their projects, and will help to avoid incompatible versions of libraries
+- **For library/application developers** the tool finds static linkage
+  errors in their projects, and will help to avoid incompatible versions of libraries
   in their dependencies.
 
 ### Approach
@@ -31,7 +30,7 @@ There are two use cases for Static Linkage Checker:
 2. The tool extracts all _references_ from the all class files in the classpath.
 
 3. The tool checks the linkage compatibility of the references through the classpath, and records
-  static linkage conflicts.
+  static linkage errors.
   
 4. The tool traverses a _class usage graph_ to annotate the linkage errors with _reachability_.
 
@@ -39,21 +38,15 @@ There are two use cases for Static Linkage Checker:
 
 ### Output
 
-The tool reports zero or more static linkage errors for the linkage classpath, annotated
+The tool reports static linkage errors for the input linkage classpath, annotated
 with _reachability_. Each of the static linkage errors contains the information on the
 source class and the destination class of the reference, and has one of the three types:
 
-  - _Missing class type_: the destination class of a
-    class reference does not exist in the classpath. This error
-    happens when a class is removed in a different version of a library,
-    or there is a dependency missed when constructing the classpath.
-    The reference that causes a missing class error is called a _dangling reference_.
+  - _Missing class type_: a class reference causes a static missing class error.
 
-  - _Missing method type_: a method reference has a static
-    linkage conflict.
+  - _Missing method type_: a method reference has a static linkage conflict.
 
-  - _Missing field type_: a field reference has a static
-     linkage conflict.
+  - _Missing field type_: a field reference has a static linkage conflict.
      
 ### Class Usage Graph and Reachability
 

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -1,38 +1,42 @@
-Static Linkage Checker
-======================
+# Static Linkage Checker
 
 Static Linkage Checker is a tool that finds [static linkage errors](
 ../library-best-practices/glossary.md) on a classpath and reports the errors to the console.
-It scans the class files in a classpath provided as input for references
-to other classes.
-It then verifies each of the references to find linkage errors in the classpath.
-The tool also provides analysis on reachability to the errors from entry point
-classes through class usage graphs.
+It scans the class files in a classpath for references to other classes and
+reports any reference that cannot be satisfied in the classpath.
+It can report all such missing references or only those that are reachable from
+a given set of entry point classes.
 
 ### Use Cases
 
 There are two use cases for Static Linkage Checker:
 
--  **For organizations** that provide multiple libraries developed by different teams,
-  the tool helps to ensure that there are no static linkage errors among the libraries and their
-  dependencies.
-
 - **For library/application developers** the tool finds static linkage
   errors in their projects, and will help to avoid incompatible versions of libraries
   in their dependencies.
 
+-  **For organizations** that provide multiple libraries developed by different teams,
+  the tool helps to ensure that users depending on the libraries will not see any
+  static linkage errors at runtime.
+
 ### Approach
 
-1. Given an input, the tool prepares a _linkage classpath_, from which the tool inspects Java
-  classes.
-  Note that the linkage classpath is different from the runtime classpath of the tool itself.
+1. The tool takes a classpath as required input, through either a list of jar and
+  class files in filesystems, a list of Maven coordinates, or a Maven BOM.
+  A Maven BOM is converted to a list of Maven coordinates, and a list of Maven
+  coordinates is resolved to a list of jar files that consists of the artifacts
+  and their dependencies.
+  The classpath is called as _linkage classpath_ on which the tool operates
+  to find linkage errors and is separated from the runtime classpath of the tool itself.
 
 2. The tool extracts all _references_ from the all class files in the classpath.
 
-3. The tool checks the linkage compatibility of the references through the classpath, and records
+3. The tool records references cannot be satisfied in the classpath as
   static linkage errors.
   
-4. The tool traverses a _class usage graph_ to annotate the linkage errors with _reachability_.
+4. Optionally, the user can specify a subset of the classpath as _entry points_.
+  In that case, the tool will list only those references that are reachable
+  from the classes in the entry points.
 
 5. At the end, the tool outputs a report on the linkage errors.
 

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -43,16 +43,16 @@ The tool reports zero or more static linkage errors for the linkage classpath, a
 with _reachability_. Each of the static linkage errors contains the information on the
 source class and the destination class of the reference, and has one of the three types:
 
-  - _Missing class type_ is for errors when where the destination class of a
+  - _Missing class type_: the destination class of a
     class reference does not exist in the classpath. This error
     happens when a class is removed in a different version of a library,
     or there is a dependency missed when constructing the classpath.
     The reference that causes a missing class error is called a _dangling reference_.
 
-  - _Missing method type_ is for errors when a method reference has a static
+  - _Missing method type_: a method reference has a static
     linkage conflict.
 
-  - _Missing field type_ is for errors when a field reference has a static
+  - _Missing field type_: a field reference has a static
      linkage conflict.
      
 ### Class Usage Graph and Reachability

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -1,9 +1,11 @@
 Static Linkage Checker
 ======================
 
-To solve linkage conflicts caused by dependencies, Static Linkage Checker identifies the linkage
-conflicts by reading the class files in jar files, and verifying availability of the implementation
-of classes, methods and fields referenced by the files.
+Static Linkage Checker identifies the
+[linkage conflicts](../library-best-practices/glossary.md#types-of-conflicts-and-compatibility)
+that would be caused by 3rd-party dependencies of Java projects at runtime. The tool scans
+the class files in dependencies, and verifies availability of the implementation of the classes,
+methods, and fields referenced by the files.
 
 ### Use Cases
 

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -2,7 +2,7 @@ Static Linkage Checker
 ======================
 
 Static Linkage Checker is the tool to perform [static linkage check](
-../library-best-practices/glossary.md#types-of-conflicts-and-compatibility#static_linkage_check).
+../library-best-practices/glossary.md#types-of-conflicts-and-compatibility#static-linkage-check).
 The tool identifies static linkage conflicts that would be caused by Java projects and their
 dependencies at runtime. Given a classpath provided from
 user (e.g., a Maven project and its dependency), it scans the class files in the classpath

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -1,27 +1,26 @@
 Static Linkage Checker
 ======================
 
-Static Linkage Checker is a tool that inspects classpaths for [static linkage check](
-../library-best-practices/glossary.md#static-linkage-check).
-The tool identifies static linkage errors that appear in Java projects at runtime.
+Static Linkage Checker is a tool that performs a [static linkage check](
+../library-best-practices/glossary.md#static-linkage-check) on a classpath
+and reports static linkage errors to the console.
 It scans the class files in a classpath provided as input for references
-to other classes. Then it verifies compatibility of the methods and fields
-in the referenced classes, with regard to their type signatures and accessors.
+to other classes. Each reference is verified to find linkage conflicts
+in the classpath.
+The tool also provides analysis on reachability to the errors from entry point
+classes through class usage graphs.
 
 ### Use Cases
 
-There are three use cases for Static Linkage Checker:
+There are two use cases for Static Linkage Checker:
 
 -  **For organizations** that provide multiple libraries developed by different teams,
   the tool helps to ensure that there are no static linkage conflicts among the libraries and their
-  dependencies when some of them are used at the same time.
+  dependencies.
 
-- **For library developers**, the tool ensures that the users of the library will not suffer
-  static linkage conflicts caused solely by the dependencies of the library.
-
-- (future plan) **For application developers** consuming libraries, the tool will
-  assess the risk of static linkage conflicts among the application's dependencies, and will help
-  to avoid incompatible versions of libraries.
+- **For library/application developers** the tool will assess the risk of static linkage
+  conflicts in their projects, and will help to avoid incompatible versions of libraries
+  in their dependencies.
 
 ### Approach
 
@@ -41,11 +40,24 @@ There are three use cases for Static Linkage Checker:
 ### Output
 
 The tool reports zero or more static linkage errors for the linkage classpath, annotated
-with _reachability_.
+with _reachability_. Each of the static linkage errors contains the information on the
+source class and the destination class of the reference, and has one of the three types:
 
+  - _Missing class type_ is for errors when where the destination class of a
+    class reference does not exist in the classpath. This error
+    happens when a class is removed in a different version of a library,
+    or there is a dependency missed when constructing the classpath.
+    The reference that causes a missing class error is called a _dangling reference_.
+
+  - _Missing method type_ is for errors when a method reference has a static
+    linkage conflict.
+
+  - _Missing field type_ is for errors when a field reference has a static
+     linkage conflict.
+     
 ### Class Usage Graph and Reachability
 
-In order to provide diagnosis on the output report, the tool builds _class usage graphs_,
+In order to provide a diagnosis on the output report, the tool builds _class usage graphs_,
 and annotates linkage errors with _reachability_ from _entry point classes_.
 The tool allows users to choose the scope of entry point classes:
 
@@ -53,10 +65,10 @@ The tool allows users to choose the scope of entry point classes:
     target project, it ensures that the current functionality used in the dependencies will not
     cause static linkage errors.
     The output may fail to report potential static linkage errors, which would be introduced
-    by starting to use a new class in one of the dependencies.
+    by starting to use a previously unreachable class in one of the dependencies.
 
   - **Direct dependencies of the target project**: when the scope of the entry point is the all
-    classes in direct dependencies of the target project, it ensures that functionality of the
+    classes in the direct dependencies of the target project, it ensures that functionality of the
     dependencies will not cause static linkage errors. The output may contain linkage errors for
-    unused classes from user's perspective.
+    unreachable classes from user's perspective.
 

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -18,7 +18,7 @@ There are two use cases for Static Linkage Checker:
   the tool helps to ensure that there are no static linkage conflicts among the libraries and their
   dependencies.
 
-- **For library/application developers** the tool will assess the risk of static linkage
+- **For library/application developers** the tool assesses the risk of static linkage
   conflicts in their projects, and will help to avoid incompatible versions of libraries
   in their dependencies.
 

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -1,0 +1,85 @@
+Static Linkage Checker
+======================
+
+To solve linkage conflicts caused by dependencies, Static Linkage Checker identifies the linkage
+conflicts by reading the class files in jar files, and verifying availability of the implementation
+of classes, methods and fields referenced by the files.
+
+### Use Cases
+
+There are three use cases for Static Linkage Checker:
+
+-  **For organizations** that provide multiple libraries (through BOM) developed by different teams,
+  the tool helps to ensure that there is no static linkage conflicts among the libraries and their
+  dependencies.
+
+- **For library developers**, the tool ensures that the users of the library will not suffer the
+  static linkage conflicts caused solely by the dependencies of the library.
+
+- (future plan) **For application developers** consuming 3rd-party libraries, the tool will
+  assess th risk of static linkage conflicts among the application's dependencies, and will help
+  to use appropriate versions of libraries to avoid runtime errors.
+
+### Approach
+
+1. Given an input, the tool prepares a _linkage classpath_, from which the tool inspects Java
+  classes.
+  
+
+2. The tool extracts all references from the class files in the classpath.
+
+3. The tool checks the linkage compatibility of the references through the classpath.
+  
+4. To annotate _reachability_ on the linkage errors, the tool traverses a _class usage graph_.
+
+5. Once the tool finishes traversal, then it outputs the report on linkage errors.
+
+
+### Class Usage Graph and Reachability
+
+In order to provide to better diagnosis on the output report, the tool builds _class usage
+graphs_ when running the analysis. The nodes (vertex) of the graph correspond to Java classes
+and the directed edges are references between classes. For example, when 'Class A' has reference
+to 'Class B' on calling a method X, the tool builds a graph holding an edge between the two nodes:
+
+    [Class A] --(method X of class B)-> [Class B]
+
+In this case, 'Class A' is called the _source class_ of the reference and 'Class B' is called
+the _destination class_.
+
+- **A reference** between two classes is either _class reference_, _method reference_
+  or _field reference_.
+
+  A _method reference_ indicates the source class uses the (static or non-static) method of
+  the destination class.
+
+  A _field reference_ indicates the source class accesses the (static or non-static) field of
+  the destination class.
+
+  A _class reference_ indicates the source class uses the destination class without specific field 
+  or method (e.g., inheritance).
+
+  A reference is called _linkage conflicting_ when there is a linkage conflict
+  (see [glossary.md](../library-best-practices/glossary.md)) caused by the reference.
+  When the destination class does not exist in the linkage classpath, the reference is called
+  _dangling reference_. When a reference does not have linkage error, then the reference is 
+  called _linkage compatible_,
+
+- **Reachability** is the attribute of static linkage errors to indicate whether a linkage
+  error caused by a reference is reachable from the _entry point classes_ of the class usage
+  graph; in other words, there exists a path of references in the graph between a entry point class
+  and the reference causing linkage error. The path helps to diagnose why static linkage
+  errors are introduced to the dependencies.
+
+- **Static Linkage Errors** are reported by the tool. A static linkage error is either
+  a _dangling reference_ or a _static linkage conflict_.
+
+  A _dangling reference_ is a reference where its destination class does not exist in the 
+  linkage classpath. This error happens when a class is removed in different version of a library or
+  there is a dependency missed when constructing the linkage classpath.
+  
+  A _static linkage conflict_ is described in [glossary.md](../library-best-practices/glossary.md).
+  In short, this error happens when the destination class's implementation is not compatible from
+  what it was available at the time of compilation of the source class, in a way that such 
+  incompatibility causes `NoSuchFieldException`, `MethodNotFoundException`, or `LinkageError` when
+  Java Virtual Machine tries to use the implementation.

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -17,7 +17,7 @@ There are three use cases for Static Linkage Checker:
   static linkage conflicts caused solely by the dependencies of the library.
 
 - (future plan) **For application developers** consuming 3rd-party libraries, the tool will
-  assess th risk of static linkage conflicts among the application's dependencies, and will help
+  assess the risk of static linkage conflicts among the application's dependencies, and will help
   to use appropriate versions of libraries to avoid runtime errors.
 
 ### Approach
@@ -26,7 +26,7 @@ There are three use cases for Static Linkage Checker:
   classes.
   
 
-2. The tool extracts all references from the class files in the classpath.
+2. The tool extracts all _references_ from the class files in the classpath.
 
 3. The tool checks the linkage compatibility of the references through the classpath.
   
@@ -35,17 +35,40 @@ There are three use cases for Static Linkage Checker:
 5. Once the tool finishes traversal, then it outputs the report on linkage errors.
 
 
+### Output
+
+- **Static Linkage Errors** are reported by the tool. A static linkage error is either
+  a _dangling reference_ or a _static linkage conflict_.
+
+  A _dangling reference_ is a reference where its destination class does not exist in the 
+  linkage classpath. This error happens when a class is removed in a different version of a library
+  , or there is a dependency missed when constructing the linkage classpath.
+  
+  A _static linkage conflict_ is described in [glossary.md](../library-best-practices/glossary.md).
+  In short, this error happens when the destination class's implementation is not compatible from
+  what it was available at the time of compilation of the source class, in a way that such 
+  incompatibility causes `NoSuchFieldException`, `MethodNotFoundException`, or `LinkageError` when
+  Java Virtual Machine tries to use the implementation.
+
+
 ### Class Usage Graph and Reachability
 
-In order to provide to better diagnosis on the output report, the tool builds _class usage
-graphs_ when running the analysis. The nodes (vertex) of the graph correspond to Java classes
-and the directed edges are references between classes. For example, when 'Class A' has reference
-to 'Class B' on calling a method X, the tool builds a graph holding an edge between the two nodes:
+- **Linkage Classpath** is a list of jar files from which the tool inspects Java classes when
+  running the tool against a project. A linkage classpath corresponds to the transitive dependencies
+  induced by the direct dependencies in the target project's pom.xml file. This includes the
+  dependencies marked as `provided` or `optional: true`.
+
+- **Class Usage Graph**
+
+  In order to provide better diagnosis on the output report, the tool builds _class usage
+  graphs_ when running the analysis. The nodes (vertex) of the graph correspond to Java classes
+  and the directed edges are references between classes. For example, when 'Class A' has reference
+  to 'Class B' on calling a method X, the tool builds a graph holding an edge between two nodes:
 
     [Class A] --(method X of class B)-> [Class B]
 
-In this case, 'Class A' is called the _source class_ of the reference and 'Class B' is called
-the _destination class_.
+  In this case, 'Class A' is called the _source class_ of the reference and 'Class B' is called
+  the _destination class_.
 
 - **A reference** between two classes is either _class reference_, _method reference_
   or _field reference_.
@@ -67,19 +90,19 @@ the _destination class_.
 
 - **Reachability** is the attribute of static linkage errors to indicate whether a linkage
   error caused by a reference is reachable from the _entry point classes_ of the class usage
-  graph; in other words, there exists a path of references in the graph between a entry point class
+  graph; in other words, there exists a path of references in the graph between an entry point class
   and the reference causing linkage error. The path helps to diagnose why static linkage
   errors are introduced to the dependencies.
 
-- **Static Linkage Errors** are reported by the tool. A static linkage error is either
-  a _dangling reference_ or a _static linkage conflict_.
+- **Entry Point Classes** are classes in the class usage graph and used to verify the reachability
+  of static linkage errors. Users have choices on the scope of entry point classes:
 
-  A _dangling reference_ is a reference where its destination class does not exist in the 
-  linkage classpath. This error happens when a class is removed in different version of a library or
-  there is a dependency missed when constructing the linkage classpath.
-  
-  A _static linkage conflict_ is described in [glossary.md](../library-best-practices/glossary.md).
-  In short, this error happens when the destination class's implementation is not compatible from
-  what it was available at the time of compilation of the source class, in a way that such 
-  incompatibility causes `NoSuchFieldException`, `MethodNotFoundException`, or `LinkageError` when
-  Java Virtual Machine tries to use the implementation.
+  - **Classes in the target project**: when entry point are only the classes in the target project,
+    it ensures the current functionality used in the dependencies will not cause static linkage 
+    errors. The output may fail to report potential static linkage errors, which would be introduced
+    by starting to use a new class in one of the dependencies.
+
+  - **Direct dependencies of the target project**: when entry point are all classes in direct
+    dependencies of the target project, it ensures that functionality of the dependencies will
+    not cause static linkage errors. The output may contain linkage error for unused classes from
+    user's perspective.

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -4,8 +4,8 @@ Static Linkage Checker
 Static Linkage Checker is a tool that finds [static linkage errors](
 ../library-best-practices/glossary.md) on a classpath and reports the errors to the console.
 It scans the class files in a classpath provided as input for references
-to other classes. Each reference is verified to find linkage conflicts
-in the classpath.
+to other classes.
+It then verifies each of the references to find linkage errors in the classpath.
 The tool also provides analysis on reachability to the errors from entry point
 classes through class usage graphs.
 

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -77,11 +77,10 @@ The tool allows users to choose the scope of entry point classes:
     by starting to use a previously unreachable class in one of the dependencies.
 
   - **With direct dependencies of the target project**: when the scope of the entry point is
-    the classes in the target project and the all
-    classes in the direct dependencies of the project, it ensures that functionality of the
-    dependencies will not cause static linkage errors. The output may contain linkage errors for
-    unreachable classes from user's perspective.
+    the classes in the target project and the all classes in the direct dependencies of the project,
+    it ensures that functionality of the dependencies will not cause static linkage errors.
+    The output may contain linkage errors for unreachable classes from user's perspective.
 
-  - **(All classes in the input class path)**: when reachability check is off, then
+  - **All classes in the input class path**: when reachability check is off, then
     all static linkage errors from all classes in the classpath, regardless of the reachability,
     are reported.

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -65,9 +65,9 @@ _missing class_, _missing method_, or _missing field_.
      
 ### Class Reference Graph and Reachability
 
-In order to provide a diagnosis on the output report, the tool builds _class reference graphs_,
+In order to provide a diagnosis in the output report, the tool builds a _class reference graph_,
 and annotates linkage errors with _reachability_ from _entry point classes_.
-Optionally the tool outputs a report only including _reachable_ static linkage errors.
+Optionally the tool outputs a report including only _reachable_ static linkage errors.
 The tool allows users to choose the scope of entry point classes:
 
   - **Classes in the target project**: when the scope of the entry point is only the classes in the
@@ -76,8 +76,12 @@ The tool allows users to choose the scope of entry point classes:
     The output may fail to report potential static linkage errors, which would be introduced
     by starting to use a previously unreachable class in one of the dependencies.
 
-  - **Direct dependencies of the target project**: when the scope of the entry point is the all
-    classes in the direct dependencies of the target project, it ensures that functionality of the
+  - **With direct dependencies of the target project**: when the scope of the entry point is
+    the classes in the target project and the all
+    classes in the direct dependencies of the project, it ensures that functionality of the
     dependencies will not cause static linkage errors. The output may contain linkage errors for
     unreachable classes from user's perspective.
 
+  - **(All classes in the input class path)**: when reachability check is off, then
+    all static linkage errors from all classes in the classpath, regardless of the reachability,
+    are reported.

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -1,10 +1,11 @@
 Static Linkage Checker
 ======================
 
-Static Linkage Checker identifies the [static linkage conflicts](
-../library-best-practices/glossary.md#types-of-conflicts-and-compatibility)
-that would be caused by dependencies of Java projects at runtime. Given a classpath provided from
-user (e.g., a Maven project and its dependency), the tool scans the class files in the classpath
+Static Linkage Checker is the tool to perform [static linkage check](
+../library-best-practices/glossary.md#types-of-conflicts-and-compatibility#static_linkage_check).
+The tool identifies static linkage conflicts that would be caused by Java projects and their
+dependencies at runtime. Given a classpath provided from
+user (e.g., a Maven project and its dependency), it scans the class files in the classpath
 for references to other classes, and verifies the availability of the implementation through
 the classpath.
 
@@ -13,7 +14,7 @@ the classpath.
 There are three use cases for Static Linkage Checker:
 
 -  **For organizations** that provide multiple libraries developed by different teams,
-  the tool helps to ensure that there is no static linkage conflicts among the libraries and their
+  the tool helps to ensure that there are no static linkage conflicts among the libraries and their
   dependencies when some of them are used at the same time.
 
 - **For library developers**, the tool ensures that the users of the library will not suffer
@@ -28,7 +29,7 @@ There are three use cases for Static Linkage Checker:
 1. Given an input, the tool prepares a _linkage classpath_, from which the tool inspects Java
   classes.
 
-2. The tool extracts all _references_ from the class files in the classpath.
+2. The tool extracts all _references_ from the all class files in the classpath.
 
 3. The tool checks the linkage compatibility of the references through the classpath, and records
   static linkage conflicts.
@@ -39,69 +40,14 @@ There are three use cases for Static Linkage Checker:
 
 ### Output
 
-- **Static Linkage Errors** are reported by the tool. A static linkage error is either
-  a _dangling reference_ or a _static linkage conflict_.
-
-  A _dangling reference_ is a reference where its destination class does not exist in the 
-  linkage classpath. This error happens when a class is removed in a different version of a library
-  , or there is a dependency missed when constructing the linkage classpath.
-  
-  A _static linkage conflict_ is described in [glossary.md](../library-best-practices/glossary.md).
-  In short, this error happens when the destination class's implementation is not compatible from
-  what it was available at the time of compilation of the source class, in a way that such 
-  incompatibility causes `NoSuchFieldException`, `MethodNotFoundException`, or `LinkageError` when
-  Java Virtual Machine tries to use the implementation.
-
+The tool reports zero or more static linkage errors for the linkage classpath, annotated
+with _reachability_.
 
 ### Class Usage Graph and Reachability
 
-- **Linkage Classpath** is a list of jar files from which the tool inspects Java classes when
-  running the tool against a project. A linkage classpath corresponds to the transitive dependencies
-  induced by the direct dependencies in the target project's pom.xml file. This includes the
-  dependencies marked as `provided` or `optional: true`.
-
-- **Class Usage Graph**
-
-  In order to provide better diagnosis on the output report, the tool builds _class usage
-  graphs_. The nodes (vertex) of the graph correspond to Java classes and the directed edges are
-  references between classes. For example, when 'Class A' has reference to 'Class B' on calling
-  a method X, the tool builds a graph holding an edge between two nodes:
-
-    [Class A] --(method X of class B)-> [Class B]
-
-  In this case, 'Class A' is called the _source class_ of the reference and 'Class B' is called
-  the _destination class_.
-
-- **A reference** between two classes is either _class reference_, _method reference_
-  or _field reference_.
-
-  A _method reference_ indicates that the source class uses the (static or non-static) method of
-  the destination class.
-
-  A _field reference_ indicates that the source class accesses the (static or non-static) field of
-  the destination class.
-
-  A _class reference_ indicates that the source class uses the destination class without
-  referencing a specific field or method (e.g., class inheritance).
-
-  A reference is called to have a _linkage conflict_
-  (see [glossary.md](../library-best-practices/glossary.md#types-of-conflicts-and-compatibility) )
-  when there is a static linkage conflict that is caused by the reference between the source
-  class and the destination class.
-  When the destination class does not exist in the linkage classpath, the reference is called a
-  _dangling reference_. When a reference does not have a linkage error, then the reference is 
-  called _linkage compatible_,
-
-- **Reachability** is the attribute of static linkage errors to indicate whether a linkage
-  error caused by a reference is _reachable_ from the _entry point classes_ of the class usage
-  graph. In other words, when a static linkage error is _reachable_, there exists a path of
-  references in the graph from one of entry point classes to the reference causing linkage
-  error.
-  The path helps to diagnose why static linkage errors are introduced to the dependencies.
-
-- **Entry Point Classes** are classes in the class usage graph that are used to verify the
-  reachability of static linkage errors. Users of the tool have choices on the scope of entry
-  point classes:
+In order to provide diagnosis on the output report, the tool builds _class usage graphs_,
+and annotates linkage errors with _reachability_ from _entry point classes_.
+The tool allows users to choose the scope of entry point classes:
 
   - **Classes in the target project**: when the scope of the entry point is only the classes in the
     target project, it ensures that the current functionality used in the dependencies will not

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -4,8 +4,8 @@ Static Linkage Checker
 Static Linkage Checker identifies the
 [linkage conflicts](../library-best-practices/glossary.md#types-of-conflicts-and-compatibility)
 that would be caused by 3rd-party dependencies of Java projects at runtime. The tool scans
-the class files in dependencies, and verifies availability of the implementation of the classes,
-methods, and fields referenced by the files.
+the class files for references to other classes, and verifies the availability of the implementation
+through the classpath of the dependencies.
 
 ### Use Cases
 
@@ -13,7 +13,7 @@ There are three use cases for Static Linkage Checker:
 
 -  **For organizations** that provide multiple libraries (through BOM) developed by different teams,
   the tool helps to ensure that there is no static linkage conflicts among the libraries and their
-  dependencies.
+  dependencies when some of them are used at the same time.
 
 - **For library developers**, the tool ensures that the users of the library will not suffer the
   static linkage conflicts caused solely by the dependencies of the library.
@@ -26,16 +26,14 @@ There are three use cases for Static Linkage Checker:
 
 1. Given an input, the tool prepares a _linkage classpath_, from which the tool inspects Java
   classes.
-  
 
 2. The tool extracts all _references_ from the class files in the classpath.
 
 3. The tool checks the linkage compatibility of the references through the classpath.
   
-4. To annotate _reachability_ on the linkage errors, the tool traverses a _class usage graph_.
+4. The tool traverses a _class usage graph_ to annotate the linkage errors with _reachability_.
 
-5. Once the tool finishes traversal, then it outputs the report on linkage errors.
-
+5. At the end, the tool outputs the report on linkage errors.
 
 ### Output
 
@@ -63,9 +61,9 @@ There are three use cases for Static Linkage Checker:
 - **Class Usage Graph**
 
   In order to provide better diagnosis on the output report, the tool builds _class usage
-  graphs_ when running the analysis. The nodes (vertex) of the graph correspond to Java classes
-  and the directed edges are references between classes. For example, when 'Class A' has reference
-  to 'Class B' on calling a method X, the tool builds a graph holding an edge between two nodes:
+  graphs_. The nodes (vertex) of the graph correspond to Java classes and the directed edges are
+  references between classes. For example, when 'Class A' has reference to 'Class B' on calling
+  a method X, the tool builds a graph holding an edge between two nodes:
 
     [Class A] --(method X of class B)-> [Class B]
 
@@ -85,26 +83,30 @@ There are three use cases for Static Linkage Checker:
   or method (e.g., inheritance).
 
   A reference is called _linkage conflicting_ when there is a linkage conflict
-  (see [glossary.md](../library-best-practices/glossary.md)) caused by the reference.
+  (see [glossary.md](../library-best-practices/glossary.md#types-of-conflicts-and-compatibility)
+  caused by the reference.
   When the destination class does not exist in the linkage classpath, the reference is called
   _dangling reference_. When a reference does not have linkage error, then the reference is 
   called _linkage compatible_,
 
 - **Reachability** is the attribute of static linkage errors to indicate whether a linkage
-  error caused by a reference is reachable from the _entry point classes_ of the class usage
-  graph; in other words, there exists a path of references in the graph between an entry point class
-  and the reference causing linkage error. The path helps to diagnose why static linkage
-  errors are introduced to the dependencies.
+  error caused by a reference is _reachable_ from the _entry point classes_ of the class usage
+  graph; in other words, when a static linkage error is _reachable_, there exists a path of
+  references in the graph between one of entry point classes and the reference causing linkage
+  error.
+  The path helps to diagnose why static linkage errors are introduced to the dependencies.
 
 - **Entry Point Classes** are classes in the class usage graph and used to verify the reachability
-  of static linkage errors. Users have choices on the scope of entry point classes:
+  of static linkage errors. Users of the tool have choices on the scope of entry point classes:
 
-  - **Classes in the target project**: when entry point are only the classes in the target project,
-    it ensures the current functionality used in the dependencies will not cause static linkage 
-    errors. The output may fail to report potential static linkage errors, which would be introduced
+  - **Classes in the target project**: when the scope of entry point is only the classes in the
+    target project, it ensures the current functionality used in the dependencies will not cause
+    static linkage errors.
+    The output may fail to report potential static linkage errors, which would be introduced
     by starting to use a new class in one of the dependencies.
 
-  - **Direct dependencies of the target project**: when entry point are all classes in direct
-    dependencies of the target project, it ensures that functionality of the dependencies will
-    not cause static linkage errors. The output may contain linkage error for unused classes from
-    user's perspective.
+  - **Direct dependencies of the target project**: when the scope of entry point is the all classes
+    in direct dependencies of the target project, it ensures that functionality of the dependencies
+    will not cause static linkage errors. The output may contain linkage error for unused classes
+    from user's perspective.
+

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -9,7 +9,7 @@ It can report all such unsatisfied references or only those that are reachable f
 a given set of entry point classes.
 
 ### Use Cases
-
+ 
 There are two use cases for Static Linkage Checker:
 
 - **For library/application developers** the tool finds static linkage
@@ -23,16 +23,15 @@ There are two use cases for Static Linkage Checker:
 ### Approach
 
 1. The tool takes a class path as required input.
+  This class path is called the _input class path_. The tool operates on this class path
+  to find linkage errors and it is separated from the runtime class path of the tool itself.
 
-  The class path is called as _linkage class path_ on which the tool operates
-  to find linkage errors and is separated from the runtime class path of the tool itself.
+2. The tool extracts all symbolic references from the all class files in the class path.
 
-2. The tool extracts all _references_ from the all class files in the class path.
-
-3. The tool records references that cannot be satisfied in the class path as
-  static linkage errors.
+3. The tool records static linkage errors for symbolic references which cannot be satisfied
+  in the class path.
   
-4. Optionally, the user can specify a subset of the class path as _entry points_.
+4. Optionally, the user can specify a subset of elements in the class path as _entry points_.
   In that case, the tool will list only those references that are reachable
   from the classes in the entry points.
 
@@ -40,25 +39,30 @@ There are two use cases for Static Linkage Checker:
 
 ### Input
 
-The tool takes a class path through either a list of class and
-jar files in filesystems, a list of Maven coordinates, or a Maven BOM.
+The tool takes a class path through either a BOM as a Maven coordinates, 
+a list of Maven coordinates, or a list of class and jar files in the filesystem.
 
-A Maven BOM specified as a Maven coordinate is converted to a list of Maven coordinates.
-A list of Maven coordinates is resolved to a list of jar files
+When the input is a Maven BOM, the elements in the BOM are
+converted to a list of Maven coordinates.
+If the BOM imports another BOM, the elements of the second BOM are recursively
+added to the list of Maven coordinates.
+
+When the input is a list of Maven coordinates, they are resolved to a list of jar files
 that consists of the artifacts and their dependencies.
-The list of jar files forms a class path, on which the tool operate.
+
+The list of class and jar files forms the _input class path_.
 
 ### Output
 
-The tool reports static linkage errors for the input linkage class path, annotated
+The tool reports static linkage errors for the input class path, annotated
 with _reachability_. Each of the static linkage errors contains the information on the
 source class and the destination class of the reference, and has one of the three types:
 
-  - _Missing class type_: a class reference causes a static missing class error.
+  - _Missing class_: a class reference causes a static missing class error.
 
-  - _Missing method type_: a method reference has a static linkage conflict.
+  - _Missing method_: a method reference has a static linkage conflict.
 
-  - _Missing field type_: a field reference has a static linkage conflict.
+  - _Missing field_: a field reference has a static linkage conflict.
      
 ### Class Reference Graph and Reachability
 

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -16,7 +16,7 @@ There are two use cases for Static Linkage Checker:
   errors in their projects, and will help to avoid incompatible versions of libraries
   in their dependencies.
 
--  **For organizations** that provide multiple libraries developed by different teams,
+- **For organizations** that provide multiple libraries developed by different teams,
   the tool helps to ensure that users depending on the libraries will not see any
   static linkage errors at runtime.
 

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -2,10 +2,10 @@
 
 Static Linkage Checker is a tool that finds [static linkage errors](
 ../library-best-practices/glossary.md#types-of-conflicts-and-compatibility)
-on a classpath and reports the errors to the console.
-It scans the class files in a classpath for references to other classes and
-reports any reference that cannot be satisfied in the classpath.
-It can report all such missing references or only those that are reachable from
+on a class path and reports the errors to the console.
+It scans the class files in the class path for references to other classes and
+reports any reference that cannot be satisfied in the class path.
+It can report all such unsatisfied references or only those that are reachable from
 a given set of entry point classes.
 
 ### Use Cases
@@ -22,17 +22,17 @@ There are two use cases for Static Linkage Checker:
 
 ### Approach
 
-1. The tool takes a classpath as required input.
+1. The tool takes a class path as required input.
 
-  The classpath is called as _linkage classpath_ on which the tool operates
-  to find linkage errors and is separated from the runtime classpath of the tool itself.
+  The class path is called as _linkage class path_ on which the tool operates
+  to find linkage errors and is separated from the runtime class path of the tool itself.
 
-2. The tool extracts all _references_ from the all class files in the classpath.
+2. The tool extracts all _references_ from the all class files in the class path.
 
-3. The tool records references that cannot be satisfied in the classpath as
+3. The tool records references that cannot be satisfied in the class path as
   static linkage errors.
   
-4. Optionally, the user can specify a subset of the classpath as _entry points_.
+4. Optionally, the user can specify a subset of the class path as _entry points_.
   In that case, the tool will list only those references that are reachable
   from the classes in the entry points.
 
@@ -40,17 +40,17 @@ There are two use cases for Static Linkage Checker:
 
 ### Input
 
-The tool takes a classpath through either a list of class and
+The tool takes a class path through either a list of class and
 jar files in filesystems, a list of Maven coordinates, or a Maven BOM.
 
 A Maven BOM specified as a Maven coordinate is converted to a list of Maven coordinates.
 A list of Maven coordinates is resolved to a list of jar files
 that consists of the artifacts and their dependencies.
-The list of jar files forms a classpath, on which the tool operate.
+The list of jar files forms a class path, on which the tool operate.
 
 ### Output
 
-The tool reports static linkage errors for the input linkage classpath, annotated
+The tool reports static linkage errors for the input linkage class path, annotated
 with _reachability_. Each of the static linkage errors contains the information on the
 source class and the destination class of the reference, and has one of the three types:
 

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -30,7 +30,7 @@ There are two use cases for Static Linkage Checker:
 
 3. The tool records static linkage errors for symbolic references which cannot be satisfied
   in the class path.
-  
+
 4. Optionally, the user can specify a subset of elements in the class path as _entry points_.
   In that case, the tool will list only those references that are reachable
   from the classes in the entry points.
@@ -39,30 +39,29 @@ There are two use cases for Static Linkage Checker:
 
 ### Input
 
-The tool takes a class path through either a BOM as a Maven coordinates, 
+The input of the tool is either the Maven coordinate of a BOM, 
 a list of Maven coordinates, or a list of class and jar files in the filesystem.
+All of these inputs are converted to a class path for the static linkage check,
+which is the _input class path_.
 
 When the input is a Maven BOM, the elements in the BOM are
 converted to a list of Maven coordinates.
 If the BOM imports another BOM, the elements of the second BOM are recursively
-added to the list of Maven coordinates.
+added to the list of Maven coordinates. This list of Maven coordinates is handled
+in the same way as a directly-provided list of coordinates (see below).
 
 When the input is a list of Maven coordinates, they are resolved to a list of jar files
-that consists of the artifacts and their dependencies.
+that consists of the artifacts and their dependencies. This list of jar files is
+handled in the same way as a directly-provided list of jar files (see below).
 
-The list of class and jar files forms the _input class path_.
+When the input is a list of class and jar files, they are used directly as the _input class path_.
 
 ### Output
 
 The tool reports static linkage errors for the input class path.
-Each of the static linkage errors contains the information on the
+Each of the static linkage errors contains information on the
 source class and the destination class of the reference, and has one of the three types:
-
-  - _Missing class_: a class reference causes a static missing class error.
-
-  - _Missing method_: a method reference has a static linkage conflict.
-
-  - _Missing field_: a field reference has a static linkage conflict.
+_missing class_, _missing method_, or _missing field_.
      
 ### Class Reference Graph and Reachability
 

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -1,26 +1,27 @@
 Static Linkage Checker
 ======================
 
-Static Linkage Checker identifies the
-[linkage conflicts](../library-best-practices/glossary.md#types-of-conflicts-and-compatibility)
-that would be caused by 3rd-party dependencies of Java projects at runtime. The tool scans
-the class files for references to other classes, and verifies the availability of the implementation
-through the classpath of the dependencies.
+Static Linkage Checker identifies the [static linkage conflicts](
+../library-best-practices/glossary.md#types-of-conflicts-and-compatibility)
+that would be caused by dependencies of Java projects at runtime. Given a classpath provided from
+user (e.g., a Maven project and its dependency), the tool scans the class files in the classpath
+for references to other classes, and verifies the availability of the implementation through
+the classpath.
 
 ### Use Cases
 
 There are three use cases for Static Linkage Checker:
 
--  **For organizations** that provide multiple libraries (through BOM) developed by different teams,
+-  **For organizations** that provide multiple libraries developed by different teams,
   the tool helps to ensure that there is no static linkage conflicts among the libraries and their
   dependencies when some of them are used at the same time.
 
-- **For library developers**, the tool ensures that the users of the library will not suffer the
+- **For library developers**, the tool ensures that the users of the library will not suffer
   static linkage conflicts caused solely by the dependencies of the library.
 
-- (future plan) **For application developers** consuming 3rd-party libraries, the tool will
+- (future plan) **For application developers** consuming libraries, the tool will
   assess the risk of static linkage conflicts among the application's dependencies, and will help
-  to use appropriate versions of libraries to avoid runtime errors.
+  to avoid incompatible versions of libraries.
 
 ### Approach
 
@@ -29,11 +30,12 @@ There are three use cases for Static Linkage Checker:
 
 2. The tool extracts all _references_ from the class files in the classpath.
 
-3. The tool checks the linkage compatibility of the references through the classpath.
+3. The tool checks the linkage compatibility of the references through the classpath, and records
+  static linkage conflicts.
   
 4. The tool traverses a _class usage graph_ to annotate the linkage errors with _reachability_.
 
-5. At the end, the tool outputs the report on linkage errors.
+5. At the end, the tool outputs a report on the linkage errors.
 
 ### Output
 
@@ -73,40 +75,42 @@ There are three use cases for Static Linkage Checker:
 - **A reference** between two classes is either _class reference_, _method reference_
   or _field reference_.
 
-  A _method reference_ indicates the source class uses the (static or non-static) method of
+  A _method reference_ indicates that the source class uses the (static or non-static) method of
   the destination class.
 
-  A _field reference_ indicates the source class accesses the (static or non-static) field of
+  A _field reference_ indicates that the source class accesses the (static or non-static) field of
   the destination class.
 
-  A _class reference_ indicates the source class uses the destination class without specific field 
-  or method (e.g., inheritance).
+  A _class reference_ indicates that the source class uses the destination class without
+  referencing a specific field or method (e.g., class inheritance).
 
-  A reference is called _linkage conflicting_ when there is a linkage conflict
-  (see [glossary.md](../library-best-practices/glossary.md#types-of-conflicts-and-compatibility)
-  caused by the reference.
-  When the destination class does not exist in the linkage classpath, the reference is called
-  _dangling reference_. When a reference does not have linkage error, then the reference is 
+  A reference is called to have a _linkage conflict_
+  (see [glossary.md](../library-best-practices/glossary.md#types-of-conflicts-and-compatibility) )
+  when there is a static linkage conflict that is caused by the reference between the source
+  class and the destination class.
+  When the destination class does not exist in the linkage classpath, the reference is called a
+  _dangling reference_. When a reference does not have a linkage error, then the reference is 
   called _linkage compatible_,
 
 - **Reachability** is the attribute of static linkage errors to indicate whether a linkage
   error caused by a reference is _reachable_ from the _entry point classes_ of the class usage
-  graph; in other words, when a static linkage error is _reachable_, there exists a path of
+  graph. In other words, when a static linkage error is _reachable_, there exists a path of
   references in the graph from one of entry point classes to the reference causing linkage
   error.
   The path helps to diagnose why static linkage errors are introduced to the dependencies.
 
-- **Entry Point Classes** are classes in the class usage graph and used to verify the reachability
-  of static linkage errors. Users of the tool have choices on the scope of entry point classes:
+- **Entry Point Classes** are classes in the class usage graph that are used to verify the
+  reachability of static linkage errors. Users of the tool have choices on the scope of entry
+  point classes:
 
-  - **Classes in the target project**: when the scope of entry point is only the classes in the
-    target project, it ensures the current functionality used in the dependencies will not cause
-    static linkage errors.
+  - **Classes in the target project**: when the scope of the entry point is only the classes in the
+    target project, it ensures that the current functionality used in the dependencies will not
+    cause static linkage errors.
     The output may fail to report potential static linkage errors, which would be introduced
     by starting to use a new class in one of the dependencies.
 
-  - **Direct dependencies of the target project**: when the scope of entry point is the all classes
-    in direct dependencies of the target project, it ensures that functionality of the dependencies
-    will not cause static linkage errors. The output may contain linkage error for unused classes
-    from user's perspective.
+  - **Direct dependencies of the target project**: when the scope of the entry point is the all
+    classes in direct dependencies of the target project, it ensures that functionality of the
+    dependencies will not cause static linkage errors. The output may contain linkage errors for
+    unused classes from user's perspective.
 

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -1,13 +1,12 @@
 Static Linkage Checker
 ======================
 
-Static Linkage Checker is the tool to perform [static linkage check](
+Static Linkage Checker is a tool that inspects classpaths for [static linkage check](
 ../library-best-practices/glossary.md#types-of-conflicts-and-compatibility#static-linkage-check).
-The tool identifies static linkage conflicts that would be caused by Java projects and their
-dependencies at runtime. Given a classpath provided from
-user (e.g., a Maven project and its dependency), it scans the class files in the classpath
-for references to other classes, and verifies the availability of the implementation through
-the classpath.
+The tool identifies static linkage errors that appear in Java projects at runtime.
+It scans the class files in a classpath provided as input for references
+to other classes. Then it verifies compatibility of the methods and fields
+in the referenced classes, with regard to their type signatures and accessors.
 
 ### Use Cases
 
@@ -28,6 +27,7 @@ There are three use cases for Static Linkage Checker:
 
 1. Given an input, the tool prepares a _linkage classpath_, from which the tool inspects Java
   classes.
+  Note that the linkage classpath is different from the runtime classpath of the tool itself.
 
 2. The tool extracts all _references_ from the all class files in the classpath.
 

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -2,7 +2,7 @@ Static Linkage Checker
 ======================
 
 Static Linkage Checker is a tool that inspects classpaths for [static linkage check](
-../library-best-practices/glossary.md#types-of-conflicts-and-compatibility#static-linkage-check).
+../library-best-practices/glossary.md#static-linkage-check).
 The tool identifies static linkage errors that appear in Java projects at runtime.
 It scans the class files in a classpath provided as input for references
 to other classes. Then it verifies compatibility of the methods and fields

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -54,8 +54,8 @@ The list of class and jar files forms the _input class path_.
 
 ### Output
 
-The tool reports static linkage errors for the input class path, annotated
-with _reachability_. Each of the static linkage errors contains the information on the
+The tool reports static linkage errors for the input class path.
+Each of the static linkage errors contains the information on the
 source class and the destination class of the reference, and has one of the three types:
 
   - _Missing class_: a class reference causes a static missing class error.
@@ -68,6 +68,7 @@ source class and the destination class of the reference, and has one of the thre
 
 In order to provide a diagnosis on the output report, the tool builds _class reference graphs_,
 and annotates linkage errors with _reachability_ from _entry point classes_.
+Optionally the tool outputs a report only including _reachable_ static linkage errors.
 The tool allows users to choose the scope of entry point classes:
 
   - **Classes in the target project**: when the scope of the entry point is only the classes in the

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -16,7 +16,8 @@ Java Dependency Glossary
     modifiers, or throws declaration of a non-private method, field, or class
     in a dependency has changed (or removed) in an incompatible way between
     the version supplied at compile time and the version invoked at runtime.
-    For example, a public method may be removed from a class or a class may be made final.
+    For example, a public method may be removed from a class or an extended
+    class may be made final.
     - Or, another perspective: In cases where binary compatibility and source
       compatibility are the same, a linkage conflict is when compilation would
       fail if the libraries in the classpath were all built together from their
@@ -32,7 +33,7 @@ Java Dependency Glossary
     version of a library, or there is a dependency missed when constructing the classpath.
 
   - **Static**: Said of a linkage error when the linkage error is caused by a
-    direct code reference (e.g., _static linkage error_ and _static linkage conflict_).
+    direct code reference (for example, _static linkage error_ and _static linkage conflict_).
     The references from a class is written in the class file when the class is compiled.
 
 - **Behavior conflict**: The class's implementation has changed in a way that
@@ -82,46 +83,43 @@ Java Dependency Glossary
   A and the version of B are linkage-compatible.
 
 
-### Class usage graph
+### Class reference graph
 
-- **Class usage graph**: a possibly cyclic directed graph of references
-  between classes. The nodes (vertices) of the graph correspond to
-  Java classes and the directed edges are references between classes.
+- **Method reference**: a reference indicating that the _source class_ links to a method of the
+  _target_ class.
+
+- **Field reference**: a reference indicating that the _source class_ accesses a field of the
+  target class.
+
+- **Class reference**: a reference indicating that the _source class_ uses the _target
+  class_ without referencing a specific field or method
+  (for example, by inheriting from the class).
+
+- **Class reference graph**: a possibly cyclic directed graph where each node represents
+  a class and each edge represents a method, field or class reference from the
+  source class to the target class.
+
   For example, when 'Class A' invokes method X on 'Class B',
-  the class usage graph holds an edge between the two nodes:
+  the class reference graph holds an edge between the two nodes:
 
   ```
   [Class A] --(method X of class B)-> [Class B]
   ```
 
   In this case, 'Class A' is called the _source class_ of the reference and
-  'Class B' is called the _destination class_.
+  'Class B' is called the _target class_.
 
-  In general, there can be multiple (parallel) edges between two nodes when
-  a class references two or more methods and fields of another class.
-  Self-loops (references between the same class) are possible and
+  In general, there can be multiple edges between two nodes when
+  a class references two or more members of another class.
+
+  Self-loops, references from a class to a member of the same class, are possible and
   common.
-
-- **Reference**: A relationship from one class to another class such that
-  the first class requires the presence of the second class in a particular
-  form in order to function. A reference is represented as an edge a class usage graph.
-  A reference is either a _class reference_, _method reference_ or _field reference_:
-
-  A _class reference_ indicates that the source class uses the destination
-  class without referencing a specific field or method (e.g., class inheritance).
-
-  A _method reference_ indicates that the source class invokes a method of the
-  destination class.
-
-  A _field reference_ indicates that the source class accesses a field of the
-  destination class.
-
 
 - **Reachability** is the attribute of classes (nodes in the graph)
   and references (edges in the graph) to indicate whether they are
   _reachable_ from a class. For example, when a reference that causes
   a linkage error is marked as _reachable_ from 'Class A', it means that
-  there exists a path of edges in the class usage graph from 'Class A'
+  there exists a path of edges in the class reference graph from 'Class A'
   to the reference causing a linkage error.
   The path helps to diagnose how linkage errors are introduced to the
   classpath from which the graph is built.

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -4,9 +4,9 @@ Java Dependency Glossary
 ### Types of conflicts and compatibility
 
 - **Linkage error**: an error when a Java class in a classpath has reference to
-  another class for inheritance, field or methods, and the reference can not be
+  another class file for a class, field or method, and the reference can not be
   satisfied with the available classes in the classpath.
-  A linkage error is caused by a reference to missing classes and a linkage conflict.
+  A linkage error is caused by a reference to missing classes or a linkage conflict.
   Linkage errors detected at runtime manifest as `ReflectiveOperationException`,
   `NoClassDefFoundError`, `NoSuchFieldException`, `MethodNotFoundException`,
   `LinkageError`, or other related exceptions.

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -12,7 +12,7 @@ Java Dependency Glossary
   - Sub-type: **Linkage conflict**
   - Sub-type: **Missing class error**
 
-  - **Linkage conflict**: an linkage error when the signature, return type,
+  - **Linkage conflict**: a linkage error when the signature, return type,
     modifiers, or throws declaration of a non-private method, field, or class
     in a dependency has changed (or removed) in an incompatible way between
     the version supplied at compile time and the version invoked at runtime.
@@ -126,7 +126,7 @@ Java Dependency Glossary
   The path helps to diagnose how linkage errors are introduced to the
   classpath from which the graph is built.
 
-- **Entry point classes** are a set of classes in the classpath in to analyze
+- **Entry point classes** are a set of classes in the classpath to analyze
   the reachability to a linkage errors. A graph traversal on the reachability
   of a linkage error starts with the nodes that correspond to the
   entry point classes.

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -77,24 +77,25 @@ Java Dependency Glossary
 - **Static linkage report**: the outcome of a static linkage check. It reports
   zero or more static linkage errors.
 
-- **Static linkage errors**: the error reported in a static linkage report.
+- **Static linkage errors**: a reported error for a reference as the result of
+  a static linkage check.
   A static linkage error contains the information on the source class and
   the destination class of the reference. Each static linkage error has
   one of the three types:
 
-  - _Missing class_ is the error when where the destination class of a
+  - _Missing class type_ is the error when where the destination class of a
     class reference does not exist in the linkage classpath. This error
     happens when a class is removed in a different version of a library,
     or there is a dependency missed when constructing the linkage classpath.
-    The reference is called _dangling reference_.
+    The reference that causes a missing class error is called a _dangling reference_.
 
-  - _Missing method_ is the error when a method reference has a  static
+  - _Missing method type_ is the error when a method reference has a  static
     linkage conflict.
 
-  - _Missing field_ is the error when a field reference has a static
+  - _Missing field type_ is the error when a field reference has a static
      linkage conflict.
 
-- **Linkage classpath**: a list of jar files which the static linkage check
+- **Linkage classpath**: the classpath which a static linkage check
   runs against. For a Maven project, a linkage classpath consists of the
   project's class files and the transitive dependencies induced by the direct
   dependencies in the project's pom.xml file.
@@ -105,7 +106,9 @@ Java Dependency Glossary
   For example, when 'Class A' has reference to 'Class B' on calling a method X,
   the class usage graph holds an edge between two nodes:
 
-    [Class A] --(method X of class B)-> [Class B]
+```
+[Class A] --(method X of class B)-> [Class B]
+```
 
   In this case, 'Class A' is called the _source class_ of the reference and
   'Class B' is called the _destination class_.

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -90,7 +90,7 @@ Java Dependency Glossary
   In general, there can be multiple (parallel) edges between two nodes when
   a class is calling two or more methods and fields on another class.
   Self-loops (references between the same class) are possible and
-  common, however, it is safe to omit such references in static linkage checks,
+  common, however, it is safe to omit such references during static linkage checks,
   because the self-loop references are ensured to be linkage compatible by Java compiler.
 
 - **A reference**: in the class usage graph, the relationship between two 

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -12,29 +12,29 @@ Java Dependency Glossary
   - Sub-type: **Linkage conflict**
   - Sub-type: **Missing class error**
 
-  - **Linkage conflict**: a linkage error when the signature, return type,
-    modifiers, or throws declaration of a non-private method, field, or class
-    in a dependency has changed (or removed) in an incompatible way between
-    the version supplied at compile time and the version invoked at runtime.
-    For example, a public method may be removed from a class or an extended
-    class may be made final.
-    - Or, another perspective: In cases where binary compatibility and source
-      compatibility are the same, a linkage conflict is when compilation would
-      fail if the libraries in the class path were all built together from their
-      originating source code, or when reflection would fail.
-    - Opposite: **Linkage-compatible**.
-    - Sub-type: **Static linkage conflict**: A linkage conflict caused by a direct
-      code reference (non-reflective).
-    - Sub-type: **Dynamic linkage conflict**: A linkage conflict caused by a
-      reflective reference.
+- **Linkage conflict**: a linkage error when the signature, return type,
+  modifiers, or throws declaration of a non-private method, field, or class
+  in a dependency has changed (or removed) in an incompatible way between
+  the version supplied at compile time and the version invoked at runtime.
+  For example, a public method may be removed from a class or an extended
+  class may be made final.
+  - Or, another perspective: In cases where binary compatibility and source
+    compatibility are the same, a linkage conflict is when compilation would
+    fail if the libraries in the class path were all built together from their
+    originating source code, or when reflection would fail.
+  - Opposite: **Linkage-compatible**.
+  - Sub-type: **Static linkage conflict**: A linkage conflict caused by a direct
+    code reference (non-reflective).
+  - Sub-type: **Dynamic linkage conflict**: A linkage conflict caused by a
+    reflective reference.
 
-  - **Missing class error**: an error when a class referenced does not exist
-    in the class path. This error happens when a class is removed in a different
-    version of a library, or there is a dependency missed when constructing the class path.
+- **Missing class error**: an error when a class referenced does not exist
+  in the class path. This error happens when a class is removed in a different
+  version of a library, or there is a dependency missed when constructing the class path.
 
-  - **Static**: Said of a linkage error when the linkage error is caused by a
-    direct code reference (for example, _static linkage error_ and _static linkage conflict_).
-    The references from a class is written in the class file when the class is compiled.
+- **Static**: Said of a linkage error when the linkage error is caused by a
+  direct code reference (for example, _static linkage error_ and _static linkage conflict_).
+  The references from a class is written in the class file when the class is compiled.
 
 - **Behavior conflict**: The class's implementation has changed in a way that
   can break clients at runtime although all signatures remain compatible. For

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -85,13 +85,13 @@ Java Dependency Glossary
 
 ### Class reference graph
 
-- **Method reference**: a reference indicating that the _source class_ links to a method of the
-  _target_ class.
+- **Method reference**: a reference indicating that a _source class_ links to a method of the
+  a _target_ class.
 
-- **Field reference**: a reference indicating that the _source class_ accesses a field of the
-  target class.
+- **Field reference**: a reference indicating that a _source class_ accesses a field of the
+  a target class.
 
-- **Class reference**: a reference indicating that the _source class_ uses the _target
+- **Class reference**: a reference indicating that a _source class_ uses a _target
   class_ without referencing a specific field or method
   (for example, by inheriting from the class).
 

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -106,9 +106,9 @@ Java Dependency Glossary
   For example, when 'Class A' has reference to 'Class B' on calling a method X,
   the class usage graph holds an edge between two nodes:
 
-```
-[Class A] --(method X of class B)-> [Class B]
-```
+  ```
+  [Class A] --(method X of class B)-> [Class B]
+  ```
 
   In this case, 'Class A' is called the _source class_ of the reference and
   'Class B' is called the _destination class_.

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -76,6 +76,11 @@ Java Dependency Glossary
 
 ### Static Linkage Checking
 
+- **Static linkage**: a reference from a class to another class that is
+  statically found in the Java class file of the former class.
+
+- **Static linkage error**: a linkage error for a static linkage.
+
 - **Static linkage check**: a process to identify the existence of _static
   linkage conflicts_ for a given classpath, by scanning Java classes and
   verifying the availability in the classpath.
@@ -94,11 +99,10 @@ Java Dependency Glossary
   'Class B' is called the _destination class_.
 
   In general, there can be multiple (parallel) edges between two nodes when
-  a class is calling two or more methods and fields on another class.
+  a class references two or more methods and fields of another class.
   Self-loops (references between the same class) are possible and
-  common, however, it is safe to omit such references during static linkage checks,
-  because the self-loop references are ensured to be linkage compatible
-  by the Java compiler.
+  common. However, it is safe to omit such references during static linkage checks,
+  because the Java compiler ensures that the self-loop references are linkage compatible.
 
 - **A reference**: in the class usage graph, the relationship between two 
   classes is either a _class reference_, _method reference_ or _field reference_.

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -86,10 +86,12 @@ Java Dependency Glossary
 
   In this case, 'Class A' is called the _source class_ of the reference and
   'Class B' is called the _destination class_.
-  There can be multiple (parallel) edges between two nodes when a class is calling two or
-  more methods and fields on another class.
-  To avoid unnecessary graph traversal, self-loops (references between the same class)
-  are omitted.
+
+  In general, there can be multiple (parallel) edges between two nodes when
+  a class is calling two or more methods and fields on another class.
+  Self-loops (references between the same class) are possible and
+  common, however, it is safe to omit such references in static linkage checks,
+  because the self-loop references are ensured to be linkage compatible by Java compiler.
 
 - **A reference**: in the class usage graph, the relationship between two 
   classes is either _class reference_, _method reference_ or _field reference_.

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -111,9 +111,7 @@ Java Dependency Glossary
 
   In general, there can be multiple edges between two nodes when
   a class references two or more members of another class.
-
-  Self-loops, references from a class to a member of the same class, are possible and
-  common.
+  Self-loops, references from a class to a member of the same class, are possible and common.
 
 - **Reachability** is the attribute of classes (nodes in the graph)
   and references (edges in the graph) to indicate whether they are

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -95,7 +95,7 @@ Java Dependency Glossary
      linkage conflict.
 
 - **Linkage classpath**: a list of jar files which the static linkage check
-  runs against. For a Maven project, a linkage classpath corresponds to the
+  runs against. For a Maven project, a linkage classpath consists of the
   project's class files and the transitive dependencies induced by the direct
   dependencies in the project's pom.xml file.
 

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -3,14 +3,20 @@ Java Dependency Glossary
 
 ### Types of conflicts and compatibility
 
+- **Linkage error**: an error when a Java class in a classpath has reference to
+  another class for inheritance, field or methods, and the reference can not be
+  satisfied with the available classes in the classpath.
+  A linkage error is caused by a reference to missing classes and a linkage conflict.
+  Linkage errors detected at runtime manifest as `ReflectiveOperationException`,
+  `NoClassDefFoundError`, `NoSuchFieldException`, `MethodNotFoundException`,
+  `LinkageError`, or other related exceptions.
+  - Sub-type: **Linkage conflict**
+
 - **Linkage conflict**: The signature, return type, modifiers, or throws
   declaration of a non-private method or class in a dependency has changed in an
   incompatible way between the version supplied at compile time and the version
   invoked at runtime. For example, a public method may be removed from a class
-  or a class may be made final. Linkage conflicts detected at runtime manifest
-  as `ReflectiveOperationException`, `NoClassDefFoundError`,
-  `NoSuchFieldException`, `MethodNotFoundException`, `LinkageError`, or other
-  related exceptions. 
+  or a class may be made final.
   - Or, another perspective: In cases where binary compatibility and source
     compatibility are the same, a linkage conflict is when compilation would
     fail if the libraries in the classpath were all built together from their
@@ -68,7 +74,7 @@ Java Dependency Glossary
   A and the version of B are linkage-compatible.
 
 
-### Static Linkage Check
+### Static Linkage Checking
 
 - **Static linkage check**: a process to identify the existence of _static
   linkage conflicts_ for a given classpath, by scanning Java classes and
@@ -91,10 +97,11 @@ Java Dependency Glossary
   a class is calling two or more methods and fields on another class.
   Self-loops (references between the same class) are possible and
   common, however, it is safe to omit such references during static linkage checks,
-  because the self-loop references are ensured to be linkage compatible by Java compiler.
+  because the self-loop references are ensured to be linkage compatible
+  by the Java compiler.
 
 - **A reference**: in the class usage graph, the relationship between two 
-  classes is either _class reference_, _method reference_ or _field reference_.
+  classes is either a _class reference_, _method reference_ or _field reference_.
 
   A _method reference_ indicates that the source class invokes a (static or
   non-static) method of the destination class.
@@ -105,33 +112,17 @@ Java Dependency Glossary
   A _class reference_ indicates that the source class uses the destination
   class without referencing a specific field or method (e.g., class inheritance).
 
-- **Static linkage error**: a reported error for a reference as the result of
-  a static linkage check.
-  A static linkage error contains the information on the source class and
-  the destination class of the reference. Each static linkage error has
-  one of the three types:
 
-  - _Missing class type_ is for errors when where the destination class of a
-    class reference does not exist in the classpath. This error
-    happens when a class is removed in a different version of a library,
-    or there is a dependency missed when constructing the classpath.
-    The reference that causes a missing class error is called a _dangling reference_.
-
-  - _Missing method type_ is for errors when a method reference has a static
-    linkage conflict.
-
-  - _Missing field type_ is for errors when a field reference has a static
-     linkage conflict.
-
-- **Reachability** is the attribute of static linkage errors to indicate
-  whether a linkage error caused by a reference is _reachable_ from the _entry
-  point classes_. In other words, when a static linkage error is marked as _reachable_,
-  there exists a path of references in the class usage graph from one of
-  the entry point classes to the reference causing linkage error.
-  The path helps to diagnose how static linkage errors are introduced to the
-  classpath.
+- **Reachability** is the attribute of classes (nodes in the graph)
+  and references (edges in the graph) to indicate whether they are
+  _reachable_ from a class. For example, when a reference that causes
+  a linkage error is marked as _reachable_ from 'Class A', it means that
+  there exists a path of edges in the class usage graph from 'Class A'
+  to the reference causing linkage error.
+  The path helps to diagnose how linkage errors are introduced to the
+  classpath from which the graph is built.
 
 - **Entry point classes** are classes in the class usage graph that are used
-  to analyze the reachability of static linkage errors. These are the initial
+  to analyze the reachability of linkage errors. These are the initial
   classes to start the graph traversal.
 

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -70,20 +70,12 @@ Java Dependency Glossary
 
 ### Static Linkage Check
 
-- **Static linkage check**:   a process to identify the existence of _static
+- **Static linkage check**: a process to identify the existence of _static
   linkage conflicts_ for a given classpath, by scanning Java classes and
   verifying the availability in the classpath.
 
-- **Static linkage report**: the outcome of a static linkage check. It reports
-  zero or more _static linkage errors_.
-
-- **Linkage classpath**: the classpath which a static linkage check
-  runs against. For a Maven project, a linkage classpath consists of the
-  project's class files and the transitive dependencies induced by the direct
-  dependencies in the project's pom.xml file.
-
-- **Class usage graph**: a directed graph that represents the relationship between
-  classes in the linkage classpath. The nodes (vertex) of the graph correspond to
+- **Class usage graph**: a possibly cyclic directed graph of references between classes
+  in the classpath. The nodes (vertices) of the graph correspond to
   Java classes and the directed edges are references between classes.
   For example, when 'Class A' has reference to 'Class B' on calling a method X,
   the class usage graph holds an edge between two nodes:
@@ -94,21 +86,22 @@ Java Dependency Glossary
 
   In this case, 'Class A' is called the _source class_ of the reference and
   'Class B' is called the _destination class_.
+  There can be multiple (parallel) edges between two nodes when a class is calling two or
+  more methods and fields on another class.
+  To avoid unnecessary graph traversal, self-loops (references between the same class)
+  are omitted.
 
 - **A reference**: in the class usage graph, the relationship between two 
   classes is either _class reference_, _method reference_ or _field reference_.
 
-  A _method reference_ indicates that the source class uses the (static or
+  A _method reference_ indicates that the source class invokes a (static or
   non-static) method of the destination class.
 
-  A _field reference_ indicates that the source class accesses the (static or
+  A _field reference_ indicates that the source class accesses a (static or
   non-static) field of the destination class.
 
   A _class reference_ indicates that the source class uses the destination
   class without referencing a specific field or method (e.g., class inheritance).
-
-  A reference is called to have a _linkage conflict_
-  when there is a static linkage conflict caused by the reference.
 
 - **Static linkage error**: a reported error for a reference as the result of
   a static linkage check.
@@ -117,12 +110,12 @@ Java Dependency Glossary
   one of the three types:
 
   - _Missing class type_ is for errors when where the destination class of a
-    class reference does not exist in the linkage classpath. This error
+    class reference does not exist in the classpath. This error
     happens when a class is removed in a different version of a library,
-    or there is a dependency missed when constructing the linkage classpath.
+    or there is a dependency missed when constructing the classpath.
     The reference that causes a missing class error is called a _dangling reference_.
 
-  - _Missing method type_ is for errors when a method reference has a  static
+  - _Missing method type_ is for errors when a method reference has a static
     linkage conflict.
 
   - _Missing field type_ is for errors when a field reference has a static
@@ -130,11 +123,11 @@ Java Dependency Glossary
 
 - **Reachability** is the attribute of static linkage errors to indicate
   whether a linkage error caused by a reference is _reachable_ from the _entry
-  point classes_ of the class usage graph. In other words, when a static
-  linkage error is _reachable_, there exists a path of references in the graph
-  from one of the entry point classes to the reference causing linkage error.
-  The path helps to diagnose why static linkage errors are introduced to the
-  linkage classpath.
+  point classes_. In other words, when a static linkage error is marked as _reachable_,
+  there exists a path of references in the class usage graph from one of
+  the entry point classes to the reference causing linkage error.
+  The path helps to diagnose how static linkage errors are introduced to the
+  classpath.
 
 - **Entry point classes** are classes in the class usage graph that are used
   to analyze the reachability of static linkage errors. These are the initial

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -128,7 +128,8 @@ Java Dependency Glossary
   The path helps to diagnose how linkage errors are introduced to the
   classpath from which the graph is built.
 
-- **Entry point classes** are classes in the class usage graph that are used
-  to analyze the reachability of linkage errors. These are the initial
-  classes to start the graph traversal.
+- **Entry point classes** are a set of classes in the classpath in to analyze
+  the reachability to a linkage errors. A graph traversal on the reachability
+  of a linkage error starts with the nodes that correspond to the entry point classes.
+  
 

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -3,9 +3,9 @@ Java Dependency Glossary
 
 ### Types of conflicts and compatibility
 
-- **Linkage error**: an error when a Java class in a classpath references
+- **Linkage error**: an error when a Java class in a class path references
   another class (as a class literal, a field access, or a method invocation),
-  and the reference cannot be satisfied with the available classes in the classpath.
+  and the reference cannot be satisfied with the available classes in the class path.
   Linkage errors detected at runtime manifest as `ReflectiveOperationException`,
   `NoClassDefFoundError`, `NoSuchFieldException`, `MethodNotFoundException`,
   `LinkageError`, or other related exceptions.
@@ -20,7 +20,7 @@ Java Dependency Glossary
     class may be made final.
     - Or, another perspective: In cases where binary compatibility and source
       compatibility are the same, a linkage conflict is when compilation would
-      fail if the libraries in the classpath were all built together from their
+      fail if the libraries in the class path were all built together from their
       originating source code, or when reflection would fail.
     - Opposite: **Linkage-compatible**.
     - Sub-type: **Static linkage conflict**: A linkage conflict caused by a direct
@@ -29,8 +29,8 @@ Java Dependency Glossary
       reflective reference.
 
   - **Missing class error**: an error when a class referenced does not exist
-    in the classpath. This error happens when a class is removed in a different
-    version of a library, or there is a dependency missed when constructing the classpath.
+    in the class path. This error happens when a class is removed in a different
+    version of a library, or there is a dependency missed when constructing the class path.
 
   - **Static**: Said of a linkage error when the linkage error is caused by a
     direct code reference (for example, _static linkage error_ and _static linkage conflict_).
@@ -85,10 +85,10 @@ Java Dependency Glossary
 
 ### Class reference graph
 
-- **Method reference**: a reference indicating that a _source class_ links to a method of the
+- **Method reference**: a reference indicating that a _source class_ links to a method of
   a _target_ class.
 
-- **Field reference**: a reference indicating that a _source class_ accesses a field of the
+- **Field reference**: a reference indicating that a _source class_ accesses a field of
   a target class.
 
 - **Class reference**: a reference indicating that a _source class_ uses a _target
@@ -120,9 +120,9 @@ Java Dependency Glossary
   there exists a path of edges in the class reference graph from 'Class A'
   to the reference causing a linkage error.
   The path helps to diagnose how linkage errors are introduced to the
-  classpath from which the graph is built.
+  class path from which the graph is built.
 
-- **Entry point classes** are a set of classes in the classpath to analyze
+- **Entry point classes** are a set of classes in the class path to analyze
   the reachability to a linkage errors. A graph traversal on the reachability
   of a linkage error starts with the nodes that correspond to the
   entry point classes.

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -4,20 +4,19 @@ Java Dependency Glossary
 ### Types of conflicts and compatibility
 
 - **Linkage error**: an error when a Java class in a classpath references
-  another class (for the class itself, its field, or its method), and the reference
-  cannot be satisfied with the available classes in the classpath.
-  A linkage error is caused by a reference to missing classes or a linkage conflict.
+  another class (as a class literal, a field access, or a method invocation),
+  and the reference cannot be satisfied with the available classes in the classpath.
   Linkage errors detected at runtime manifest as `ReflectiveOperationException`,
   `NoClassDefFoundError`, `NoSuchFieldException`, `MethodNotFoundException`,
   `LinkageError`, or other related exceptions.
   - Sub-type: **Linkage conflict**
   - Sub-type: **Missing class error**
 
-  - **Linkage conflict**: The signature, return type, modifiers, or throws
-    declaration of a non-private method or class in a dependency has changed in an
-    incompatible way between the version supplied at compile time and the version
-    invoked at runtime. For example, a public method may be removed from a class
-    or a class may be made final.
+  - **Linkage conflict**: an linkage error when the signature, return type,
+    modifiers, or throws declaration of a non-private method, field, or class
+    in a dependency has changed (or removed) in an incompatible way between
+    the version supplied at compile time and the version invoked at runtime.
+    For example, a public method may be removed from a class or a class may be made final.
     - Or, another perspective: In cases where binary compatibility and source
       compatibility are the same, a linkage conflict is when compilation would
       fail if the libraries in the classpath were all built together from their
@@ -25,7 +24,7 @@ Java Dependency Glossary
     - Opposite: **Linkage-compatible**.
     - Sub-type: **Static linkage conflict**: A linkage conflict caused by a direct
       code reference (non-reflective).
-    - Sub-type: **Reflective linkage conflict**: A linkage conflict caused by a
+    - Sub-type: **Dynamic linkage conflict**: A linkage conflict caused by a
       reflective reference.
 
   - **Missing class error**: an error when a class referenced does not exist
@@ -33,7 +32,7 @@ Java Dependency Glossary
     version of a library, or there is a dependency missed when constructing the classpath.
 
   - **Static**: Said of a linkage error when the linkage error is caused by a
-    direct code reference (e.g., _static linkage error_ and _static linkage conflict_').
+    direct code reference (e.g., _static linkage error_ and _static linkage conflict_).
     The references from a class is written in the class file when the class is compiled.
 
 - **Behavior conflict**: The class's implementation has changed in a way that
@@ -85,8 +84,8 @@ Java Dependency Glossary
 
 ### Class usage graph
 
-- **Class usage graph**: a possibly cyclic directed graph of references between classes
-  in the classpath. The nodes (vertices) of the graph correspond to
+- **Class usage graph**: a possibly cyclic directed graph of references
+  between classes. The nodes (vertices) of the graph correspond to
   Java classes and the directed edges are references between classes.
   For example, when 'Class A' invokes method X on 'Class B',
   the class usage graph holds an edge between the two nodes:
@@ -101,12 +100,11 @@ Java Dependency Glossary
   In general, there can be multiple (parallel) edges between two nodes when
   a class references two or more methods and fields of another class.
   Self-loops (references between the same class) are possible and
-  common. However, it is safe to omit such references when checking the reachability
-  to static linkage errors, because the Java compiler ensures that the self-loop
-  references are linkage compatible.
+  common.
 
-- **Reference**: a relationship from a class to another class on how the former
-  uses the latter. A reference is represented as an edge a class usage graph.
+- **Reference**: A relationship from one class to another class such that
+  the first class requires the presence of the second class in a particular
+  form in order to function. A reference is represented as an edge a class usage graph.
   A reference is either a _class reference_, _method reference_ or _field reference_:
 
   A _class reference_ indicates that the source class uses the destination
@@ -130,6 +128,7 @@ Java Dependency Glossary
 
 - **Entry point classes** are a set of classes in the classpath in to analyze
   the reachability to a linkage errors. A graph traversal on the reachability
-  of a linkage error starts with the nodes that correspond to the entry point classes.
+  of a linkage error starts with the nodes that correspond to the
+  entry point classes.
   
 

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -66,3 +66,74 @@ Java Dependency Glossary
 - **Linkage-matchable version** (said of a particular version of A in relation
   to all versions of B): There exists some version of B such that the version of
   A and the version of B are linkage-compatible.
+
+
+### Static Linkage Check
+
+- **Static linkage check**: a process to identify the existence of static
+  linkage errors for a given classpath, by scanning Java classes and
+  verifying the availability in the classpath.
+
+- **Static linkage report**: the outcome of a static linkage check. It reports
+  zero or more static linkage errors.
+
+- **Static linkage errors**: the error reported in a static linkage report.
+  A static linkage error contains the information on the source class and
+  the destination class of the reference. Each static linkage error has
+  one of the three types:
+
+  - _Missing class_ is the error when where the destination class of a
+    class reference does not exist in the linkage classpath. This error
+    happens when a class is removed in a different version of a library,
+    or there is a dependency missed when constructing the linkage classpath.
+    The reference is called _dangling reference_.
+
+  - _Missing method_ is the error when a method reference has a  static
+    linkage conflict.
+
+  - _Missing field_ is the error when a field reference has a static
+     linkage conflict.
+
+- **Linkage classpath**: a list of jar files which the static linkage check
+  runs against. For a Maven project, a linkage classpath corresponds to the
+  project's class files and the transitive dependencies induced by the direct
+  dependencies in the project's pom.xml file.
+
+- **Class usage graph**: a directed graph that represents the relationship between
+  classes in the linkage classpath. The nodes (vertex) of the graph correspond to
+  Java classes and the directed edges are references between classes.
+  For example, when 'Class A' has reference to 'Class B' on calling a method X,
+  the class usage graph holds an edge between two nodes:
+
+    [Class A] --(method X of class B)-> [Class B]
+
+  In this case, 'Class A' is called the _source class_ of the reference and
+  'Class B' is called the _destination class_.
+
+- **A reference**: in the class usage graph, the relationship between two 
+  classes is either _class reference_, _method reference_ or _field reference_.
+
+  A _method reference_ indicates that the source class uses the (static or
+  non-static) method of the destination class.
+
+  A _field reference_ indicates that the source class accesses the (static or
+  non-static) field of the destination class.
+
+  A _class reference_ indicates that the source class uses the destination
+  class without referencing a specific field or method (e.g., class inheritance).
+
+  A reference is called to have a _linkage conflict_
+  when there is a static linkage conflict caused by the reference.
+
+- **Reachability** is the attribute of static linkage errors to indicate
+  whether a linkage error caused by a reference is _reachable_ from the _entry
+  point classes_ of the class usage graph. In other words, when a static
+  linkage error is _reachable_, there exists a path of references in the graph
+  from one of the entry point classes to the reference causing linkage error.
+  The path helps to diagnose why static linkage errors are introduced to the
+  linkage classpath.
+
+- **Entry point Classes** are classes in the class usage graph that are used
+  to analyze the reachability of static linkage errors. These are the initial
+  classes to start the graph traversal.
+

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -70,30 +70,12 @@ Java Dependency Glossary
 
 ### Static Linkage Check
 
-- **Static linkage check**: a process to identify the existence of static
-  linkage errors for a given classpath, by scanning Java classes and
+- **Static linkage check**:   a process to identify the existence of _static
+  linkage conflicts_ for a given classpath, by scanning Java classes and
   verifying the availability in the classpath.
 
 - **Static linkage report**: the outcome of a static linkage check. It reports
-  zero or more static linkage errors.
-
-- **Static linkage error**: a reported error for a reference as the result of
-  a static linkage check.
-  A static linkage error contains the information on the source class and
-  the destination class of the reference. Each static linkage error has
-  one of the three types:
-
-  - _Missing class type_ is for errors when where the destination class of a
-    class reference does not exist in the linkage classpath. This error
-    happens when a class is removed in a different version of a library,
-    or there is a dependency missed when constructing the linkage classpath.
-    The reference that causes a missing class error is called a _dangling reference_.
-
-  - _Missing method type_ is for errors when a method reference has a  static
-    linkage conflict.
-
-  - _Missing field type_ is for errors when a field reference has a static
-     linkage conflict.
+  zero or more _static linkage errors_.
 
 - **Linkage classpath**: the classpath which a static linkage check
   runs against. For a Maven project, a linkage classpath consists of the
@@ -128,6 +110,24 @@ Java Dependency Glossary
   A reference is called to have a _linkage conflict_
   when there is a static linkage conflict caused by the reference.
 
+- **Static linkage error**: a reported error for a reference as the result of
+  a static linkage check.
+  A static linkage error contains the information on the source class and
+  the destination class of the reference. Each static linkage error has
+  one of the three types:
+
+  - _Missing class type_ is for errors when where the destination class of a
+    class reference does not exist in the linkage classpath. This error
+    happens when a class is removed in a different version of a library,
+    or there is a dependency missed when constructing the linkage classpath.
+    The reference that causes a missing class error is called a _dangling reference_.
+
+  - _Missing method type_ is for errors when a method reference has a  static
+    linkage conflict.
+
+  - _Missing field type_ is for errors when a field reference has a static
+     linkage conflict.
+
 - **Reachability** is the attribute of static linkage errors to indicate
   whether a linkage error caused by a reference is _reachable_ from the _entry
   point classes_ of the class usage graph. In other words, when a static
@@ -136,7 +136,7 @@ Java Dependency Glossary
   The path helps to diagnose why static linkage errors are introduced to the
   linkage classpath.
 
-- **Entry point Classes** are classes in the class usage graph that are used
+- **Entry point classes** are classes in the class usage graph that are used
   to analyze the reachability of static linkage errors. These are the initial
   classes to start the graph traversal.
 

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -77,22 +77,22 @@ Java Dependency Glossary
 - **Static linkage report**: the outcome of a static linkage check. It reports
   zero or more static linkage errors.
 
-- **Static linkage errors**: a reported error for a reference as the result of
+- **Static linkage error**: a reported error for a reference as the result of
   a static linkage check.
   A static linkage error contains the information on the source class and
   the destination class of the reference. Each static linkage error has
   one of the three types:
 
-  - _Missing class type_ is the error when where the destination class of a
+  - _Missing class type_ is for errors when where the destination class of a
     class reference does not exist in the linkage classpath. This error
     happens when a class is removed in a different version of a library,
     or there is a dependency missed when constructing the linkage classpath.
     The reference that causes a missing class error is called a _dangling reference_.
 
-  - _Missing method type_ is the error when a method reference has a  static
+  - _Missing method type_ is for errors when a method reference has a  static
     linkage conflict.
 
-  - _Missing field type_ is the error when a field reference has a static
+  - _Missing field type_ is for errors when a field reference has a static
      linkage conflict.
 
 - **Linkage classpath**: the classpath which a static linkage check


### PR DESCRIPTION
I added concept of "class, method, and field reference", "entry point classes", "reachability", "dangling reference", and "static linkage error". They were useful when we discussed the concept of Static Linkage Checker.

Although this README introduces "static linkage error" specific to the tool, I tried to make it compatible with "static linkage conflict" (it's subclass of static linkage error).

Fixes #212 
