### PR TITLE
Classes to represent references between classes

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -16,10 +16,10 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -62,7 +62,7 @@ import org.apache.bcel.util.ClassPath;
 import org.apache.bcel.util.SyntheticRepository;
 
 /**
- * Class to read symbolic references in Java class files and to verify the availability
+ * Class to read symbol references in Java class files and to verify the availability
  * of references in them, through the input class path for a static linkage check.
  */
 class ClassDumper {
@@ -157,16 +157,15 @@ class ClassDumper {
 
   /**
    * Scans class files in the jar file and returns a {@link SymbolReferenceSet} populated with
-   * symbolic references.
+   * symbol references.
    *
    * @param jarFilePath absolute path to a jar file
-   * @return symbol references and classes defined in the jar file
    */
   static SymbolReferenceSet scanSymbolReferencesInJar(Path jarFilePath)
       throws ClassNotFoundException, IOException {
-    Preconditions.checkArgument(
+    checkArgument(
         jarFilePath.isAbsolute(), "The input jar file path is not an absolute path");
-    Preconditions.checkArgument(
+    checkArgument(
         Files.isReadable(jarFilePath), "The input jar file path is not readable");
 
     SymbolReferenceSet.Builder symbolTableBuilder = SymbolReferenceSet.builder();
@@ -217,7 +216,7 @@ class ClassDumper {
     return symbolTableBuilder.build();
   }
 
-  private static ConstantNameAndType constantNameAndTypeFromConstantCP(
+  private static ConstantNameAndType constantNameAndType(
       ConstantCP constantCP, ConstantPool constantPool) {
     int nameAndTypeIndex = constantCP.getNameAndTypeIndex();
     Constant constantAtNameAndTypeIndex = constantPool.getConstant(nameAndTypeIndex);
@@ -237,7 +236,7 @@ class ClassDumper {
       ConstantMethodref constantMethodref, ConstantPool constantPool, String sourceClassName) {
     String classNameInMethodReference = constantMethodref.getClass(constantPool);
     ConstantNameAndType constantNameAndType =
-        constantNameAndTypeFromConstantCP(constantMethodref, constantPool);
+        constantNameAndType(constantMethodref, constantPool);
     String methodName = constantNameAndType.getName(constantPool);
     String descriptor = constantNameAndType.getSignature(constantPool);
     MethodSymbolReference methodReference = MethodSymbolReference.builder()
@@ -254,7 +253,7 @@ class ClassDumper {
     // Either a class type or an interface type
     String classNameInFieldReference = constantFieldref.getClass(constantPool);
     ConstantNameAndType constantNameAndType =
-        constantNameAndTypeFromConstantCP(constantFieldref, constantPool);
+        constantNameAndType(constantFieldref, constantPool);
     String fieldName = constantNameAndType.getName(constantPool);
 
     FieldSymbolReference fieldSymbolReference = FieldSymbolReference.builder()

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -23,6 +23,7 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Sets;
 import com.google.common.reflect.ClassPath.ClassInfo;
 import java.io.File;
 import java.io.IOException;
@@ -176,15 +177,18 @@ class ClassDumper {
           fieldReferences.add(constantToFieldReference(constantFieldref, constantPool,
               sourceClassName));
           break;
+        case Const.CONSTANT_Class:
+          // TODO(suztomo): handle class reference
+          break;
         default:
           break;
       }
     }
-    ImmutableSet.Builder<String> definedClassNameBuilder =
-        symbolTableBuilder.definedClassNamesBuilder();
-    definedClassNameBuilder.add(sourceClassName).addAll(listInnerClassNames(javaClass));
 
-    return symbolTableBuilder.build();
+    Set<String> definedClassNames = Sets.newHashSet(listInnerClassNames(javaClass));
+    definedClassNames.add(sourceClassName);
+
+    return symbolTableBuilder.setDefinedClassNames(definedClassNames).build();
   }
 
   static ConstantNameAndType constantNameAndTypeFromConstantCP(
@@ -202,7 +206,7 @@ class ClassDumper {
     return (ConstantNameAndType) constantAtNameAndTypeIndex;
   }
 
-  static MethodSymbolReference constantToMethodReference(ConstantMethodref constantMethodref,
+  private static MethodSymbolReference constantToMethodReference(ConstantMethodref constantMethodref,
       ConstantPool constantPool, String sourceClassName) {
     String classNameInMethodReference = constantMethodref.getClass(constantPool);
     ConstantNameAndType constantNameAndType =
@@ -218,7 +222,7 @@ class ClassDumper {
     return methodReference;
   }
 
-  static FieldSymbolReference constantToFieldReference(ConstantFieldref constantFieldref,
+  private static FieldSymbolReference constantToFieldReference(ConstantFieldref constantFieldref,
       ConstantPool constantPool, String sourceClassName) {
     // Either a class type or an interface type
     String classNameInFieldReference = constantFieldref.getClass(constantPool);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -146,8 +146,8 @@ class ClassDumper {
     return methodReferences.build();
   }
 
-  static SymbolsInFile scanClassSymbolTable(JavaClass javaClass) {
-    SymbolsInFile.Builder symbolTableBuilder = SymbolsInFile.builder();
+  static SymbolReferenceSet scanSymbolReferencesInClass(JavaClass javaClass) {
+    SymbolReferenceSet.Builder symbolTableBuilder = SymbolReferenceSet.builder();
     ImmutableSet.Builder<MethodSymbolReference> methodReferences =
         symbolTableBuilder.methodReferencesBuilder();
     ImmutableSet.Builder<FieldSymbolReference> fieldReferences =

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -225,8 +225,8 @@ class ClassDumper {
     return (ConstantNameAndType) constantAtNameAndTypeIndex;
   }
 
-  private static MethodSymbolReference constantToMethodReference(ConstantMethodref constantMethodref,
-      ConstantPool constantPool, String sourceClassName) {
+  private static MethodSymbolReference constantToMethodReference(
+      ConstantMethodref constantMethodref, ConstantPool constantPool, String sourceClassName) {
     String classNameInMethodReference = constantMethodref.getClass(constantPool);
     ConstantNameAndType constantNameAndType =
         constantNameAndTypeFromConstantCP(constantMethodref, constantPool);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -170,7 +170,7 @@ class ClassDumper {
 
     SymbolReferenceSet.Builder symbolTableBuilder = SymbolReferenceSet.builder();
     for (JavaClass javaClass : topLevelJavaClassesInJar(jarFilePath)) {
-      symbolTableBuilder.merge(scanSymbolReferencesInClass(javaClass));
+      symbolTableBuilder.addAll(scanSymbolReferencesInClass(javaClass));
     }
     return symbolTableBuilder.build();
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -23,7 +23,6 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Sets;
 import com.google.common.reflect.ClassPath.ClassInfo;
 import java.io.File;
 import java.io.IOException;
@@ -185,10 +184,7 @@ class ClassDumper {
       }
     }
 
-    Set<String> definedClassNames = Sets.newHashSet(listInnerClassNames(javaClass));
-    definedClassNames.add(sourceClassName);
-
-    return symbolTableBuilder.setDefinedClassNames(definedClassNames).build();
+    return symbolTableBuilder.build();
   }
 
   static ConstantNameAndType constantNameAndTypeFromConstantCP(
@@ -471,10 +467,8 @@ class ClassDumper {
         ImmutableSetMultimap.builder();
 
     for (Path jarFilePath : jarFilePaths) {
-      String pathToJar = jarFilePath.toString();
-      SyntheticRepository repository = SyntheticRepository.getInstance(new ClassPath(pathToJar));
       try {
-        for (JavaClass javaClass: topLevelJavaClassesInJar(jarFilePath, repository)) {
+        for (JavaClass javaClass: topLevelJavaClassesInJar(jarFilePath)) {
           pathToClasses.put(jarFilePath, javaClass.getClassName());
           // This does not take double-nested classes. As long as such classes are accessed
           // only from the outer class, static linkage checker does not report false positives
@@ -504,8 +498,10 @@ class ClassDumper {
     return allClassesInJar;
   }
 
-  static ImmutableSet<JavaClass> topLevelJavaClassesInJar(Path jarFilePath,
-      SyntheticRepository repository) throws IOException, ClassNotFoundException {
+  static ImmutableSet<JavaClass> topLevelJavaClassesInJar(Path jarFilePath)
+      throws IOException, ClassNotFoundException {
+    String pathToJar = jarFilePath.toString();
+    SyntheticRepository repository = SyntheticRepository.getInstance(new ClassPath(pathToJar));
     ImmutableSet.Builder<JavaClass> javaClasses = ImmutableSet.builder();
     URL jarFileUrl = jarFilePath.toUri().toURL();
     for (ClassInfo classInfo : listTopLevelClassesFromJar(jarFileUrl)) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -147,8 +147,8 @@ class ClassDumper {
     return methodReferences.build();
   }
 
-  static SymbolTable scanClassSymbolTable(JavaClass javaClass) {
-    SymbolTable.Builder symbolTableBuilder = SymbolTable.builder();
+  static SymbolsInFile scanClassSymbolTable(JavaClass javaClass) {
+    SymbolsInFile.Builder symbolTableBuilder = SymbolsInFile.builder();
     ImmutableSet.Builder<MethodSymbolReference> methodReferences =
         symbolTableBuilder.methodReferencesBuilder();
     ImmutableSet.Builder<FieldSymbolReference> fieldReferences =

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -155,21 +155,18 @@ class ClassDumper {
    * @param jarFilePath absolute path to a jar file
    * @return symbol references and classes defined in the jar file
    */
-  static SymbolReferenceSet scanSymbolReferencesInJar(Path jarFilePath) {
+  static SymbolReferenceSet scanSymbolReferencesInJar(Path jarFilePath)
+      throws ClassNotFoundException, IOException {
     Preconditions.checkArgument(
         jarFilePath.isAbsolute(), "The input jar file path is not an absolute path");
     Preconditions.checkArgument(
         Files.isReadable(jarFilePath), "The input jar file path is not readable");
 
     SymbolReferenceSet.Builder symbolTableBuilder = SymbolReferenceSet.builder();
-    try {
-      for (JavaClass javaClass : topLevelJavaClassesInJar(jarFilePath)) {
-        symbolTableBuilder.merge(scanSymbolReferencesInClass(javaClass));
-      }
-      return symbolTableBuilder.build();
-    } catch (ClassNotFoundException | IOException ex) {
-      throw new RuntimeException("Failed to scan jar file", ex);
+    for (JavaClass javaClass : topLevelJavaClassesInJar(jarFilePath)) {
+      symbolTableBuilder.merge(scanSymbolReferencesInClass(javaClass));
     }
+    return symbolTableBuilder.build();
   }
 
   private static SymbolReferenceSet scanSymbolReferencesInClass(JavaClass javaClass) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -217,7 +217,7 @@ class ClassDumper {
     return symbolTableBuilder.build();
   }
 
-  static ConstantNameAndType constantNameAndTypeFromConstantCP(
+  private static ConstantNameAndType constantNameAndTypeFromConstantCP(
       ConstantCP constantCP, ConstantPool constantPool) {
     int nameAndTypeIndex = constantCP.getNameAndTypeIndex();
     Constant constantAtNameAndTypeIndex = constantPool.getConstant(nameAndTypeIndex);
@@ -225,9 +225,10 @@ class ClassDumper {
       // This constant_pool entry must be a CONSTANT_NameAndType_info
       // as specified https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.2
       throw new ClassFormatException(
-          "Failed to lookup nameAndType constant indexed "
+          "Failed to lookup nameAndType constant indexed at "
               + nameAndTypeIndex
-              + ". This class file is not compliant with CONSTANT_Methodref_info specification");
+              + ". However, the content is not ConstantNameAndType. It is "
+              + constantAtNameAndTypeIndex);
     }
     return (ConstantNameAndType) constantAtNameAndTypeIndex;
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.opensource.classpath;
 import com.google.auto.value.AutoValue;
 
 /**
- * A symbolic reference to {@code targetClass} referenced from {@code sourceClass}.
+ * A symbolic reference to {@code targetClass} itself referenced from {@code sourceClass}.
  */
 @AutoValue
 abstract class ClassSymbolReference implements SymbolReference {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.opensource.classpath;
 import com.google.auto.value.AutoValue;
 
 /**
- * A symbolic reference to {@code targetClass} itself referenced from {@code sourceClass}.
+ * A symbolic reference to {@code targetClass} referenced from {@code sourceClass}.
  */
 @AutoValue
 abstract class ClassSymbolReference implements SymbolReference {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
@@ -23,11 +23,6 @@ import com.google.auto.value.AutoValue;
  */
 @AutoValue
 abstract class ClassSymbolReference implements SymbolReference {
-  @Override
-  public abstract String getTargetClassName();
-  @Override
-  public abstract String getSourceClassName();
-
   static Builder builder() {
     return new AutoValue_ClassSymbolReference.Builder();
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
@@ -29,8 +29,8 @@ abstract class ClassSymbolReference {
 
   @AutoValue.Builder
   abstract static class Builder {
-    abstract Builder setTargetClassName(String value);
-    abstract Builder setSourceClassName(String value);
+    abstract Builder setTargetClassName(String className);
+    abstract Builder setSourceClassName(String className);
     abstract ClassSymbolReference build();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.opensource.classpath;
 import com.google.auto.value.AutoValue;
 
 /**
- * A symbolic reference to {@code targetClass} referenced from {@code sourceClass}.
+ * A symbol reference to {@code targetClass} referenced from {@code sourceClass}.
  */
 @AutoValue
 abstract class ClassSymbolReference implements SymbolReference {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
@@ -18,20 +18,19 @@ package com.google.cloud.tools.opensource.classpath;
 
 import com.google.auto.value.AutoValue;
 
-/**
- * A missing method linkage error.
- */
 @AutoValue
-abstract class LinkageErrorMissingMethod {
-  abstract MethodSymbolReference getReference();
+abstract class ClassSymbolReference {
+  abstract String getTargetClassName();
+  abstract String getSourceClassName();
 
   static Builder builder() {
-    return new AutoValue_LinkageErrorMissingMethod.Builder();
+    return new AutoValue_ClassSymbolReference.Builder();
   }
 
   @AutoValue.Builder
   abstract static class Builder {
-    abstract Builder setReference(MethodSymbolReference value);
-    abstract LinkageErrorMissingMethod build();
+    abstract Builder setTargetClassName(String value);
+    abstract Builder setSourceClassName(String value);
+    abstract ClassSymbolReference build();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
@@ -18,20 +18,21 @@ package com.google.cloud.tools.opensource.classpath;
 
 import com.google.auto.value.AutoValue;
 
-/**
- * A missing method linkage error.
- */
 @AutoValue
-abstract class LinkageErrorMissingMethod {
-  abstract MethodSymbolReference getReference();
+abstract class FieldSymbolReference {
+  abstract String getTargetClassName();
+  abstract String getFieldName();
+  abstract String getSourceClassName();
 
   static Builder builder() {
-    return new AutoValue_LinkageErrorMissingMethod.Builder();
+    return new AutoValue_FieldSymbolReference.Builder();
   }
 
   @AutoValue.Builder
   abstract static class Builder {
-    abstract Builder setReference(MethodSymbolReference value);
-    abstract LinkageErrorMissingMethod build();
+    abstract Builder setTargetClassName(String value);
+    abstract Builder setFieldName(String value);
+    abstract Builder setSourceClassName(String value);
+    abstract FieldSymbolReference build();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
@@ -23,11 +23,6 @@ import com.google.auto.value.AutoValue;
  * */
 @AutoValue
 abstract class FieldSymbolReference implements SymbolReference {
-  @Override
-  public abstract String getTargetClassName();
-  @Override
-  public abstract String getSourceClassName();
-
   /**
    * Returns field name of the reference.
    */

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
@@ -19,12 +19,12 @@ package com.google.cloud.tools.opensource.classpath;
 import com.google.auto.value.AutoValue;
 
 /**
- * A symbolic reference to a field of {@code targetClass} referenced from {@code sourceClass}.
- * */
+ * A symbol reference to a field of {@code targetClass} referenced from {@code sourceClass}.
+ */
 @AutoValue
 abstract class FieldSymbolReference implements SymbolReference {
   /**
-   * Returns field name of the reference.
+   * Returns the field name of the reference.
    */
   abstract String getFieldName();
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
@@ -30,9 +30,9 @@ abstract class FieldSymbolReference {
 
   @AutoValue.Builder
   abstract static class Builder {
-    abstract Builder setTargetClassName(String value);
-    abstract Builder setFieldName(String value);
-    abstract Builder setSourceClassName(String value);
+    abstract Builder setTargetClassName(String className);
+    abstract Builder setFieldName(String fieldName);
+    abstract Builder setSourceClassName(String className);
     abstract FieldSymbolReference build();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
@@ -18,14 +18,20 @@ package com.google.cloud.tools.opensource.classpath;
 
 import com.google.auto.value.AutoValue;
 
-/** A symbolic reference to a field of {@code targetClass} referenced from {@code sourceClass}. */
+/**
+ * A symbolic reference to a field of {@code targetClass} referenced from {@code sourceClass}.
+ * */
 @AutoValue
 abstract class FieldSymbolReference implements SymbolReference {
   @Override
   public abstract String getTargetClassName();
-  abstract String getFieldName();
   @Override
   public abstract String getSourceClassName();
+
+  /**
+   * Returns field name of the reference.
+   */
+  abstract String getFieldName();
 
   static Builder builder() {
     return new AutoValue_FieldSymbolReference.Builder();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
@@ -18,11 +18,14 @@ package com.google.cloud.tools.opensource.classpath;
 
 import com.google.auto.value.AutoValue;
 
+/** A symbolic reference to a field of {@code targetClass} referenced from {@code sourceClass}. */
 @AutoValue
-abstract class FieldSymbolReference {
-  abstract String getTargetClassName();
+abstract class FieldSymbolReference implements SymbolReference {
+  @Override
+  public abstract String getTargetClassName();
   abstract String getFieldName();
-  abstract String getSourceClassName();
+  @Override
+  public abstract String getSourceClassName();
 
   static Builder builder() {
     return new AutoValue_FieldSymbolReference.Builder();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FullyQualifiedMethodSignature.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FullyQualifiedMethodSignature.java
@@ -25,6 +25,8 @@ import java.util.Objects;
  * class name.
  */
 class FullyQualifiedMethodSignature implements Comparable<FullyQualifiedMethodSignature> {
+  // TODO(suztomo): remove FullyQualifiedMethodSignature in favor of MethodSymbolReference
+
   private static final Comparator<FullyQualifiedMethodSignature> COMPARATOR =
       Comparator.comparing(FullyQualifiedMethodSignature::getClassName)
           .thenComparing(

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingClass.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingClass.java
@@ -17,14 +17,12 @@
 package com.google.cloud.tools.opensource.classpath;
 
 import com.google.auto.value.AutoValue;
-
 /**
  * A missing class linkage error.
  */
 @AutoValue
 abstract class LinkageErrorMissingClass {
-  abstract String getTargetClassName();
-  abstract String getSourceClassName();
+  abstract ClassSymbolReference getReference();
 
   static Builder builder() {
     return new AutoValue_LinkageErrorMissingClass.Builder();
@@ -32,8 +30,7 @@ abstract class LinkageErrorMissingClass {
 
   @AutoValue.Builder
   abstract static class Builder {
-    abstract Builder setTargetClassName(String value);
-    abstract Builder setSourceClassName(String value);
+    abstract Builder setReference(ClassSymbolReference value);
     abstract LinkageErrorMissingClass build();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingField.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingField.java
@@ -23,9 +23,7 @@ import com.google.auto.value.AutoValue;
  */
 @AutoValue
 abstract class LinkageErrorMissingField {
-  abstract String getTargetClassName();
-  abstract String getFieldName();
-  abstract String getSourceClassName();
+  abstract FieldSymbolReference getReference();
 
   static Builder builder() {
     return new AutoValue_LinkageErrorMissingField.Builder();
@@ -33,9 +31,7 @@ abstract class LinkageErrorMissingField {
 
   @AutoValue.Builder
   abstract static class Builder {
-    abstract Builder setTargetClassName(String value);
-    abstract Builder setFieldName(String value);
-    abstract Builder setSourceClassName(String value);
+    abstract Builder setReference(FieldSymbolReference value);
     abstract LinkageErrorMissingField build();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
@@ -18,20 +18,23 @@ package com.google.cloud.tools.opensource.classpath;
 
 import com.google.auto.value.AutoValue;
 
-/**
- * A missing method linkage error.
- */
 @AutoValue
-abstract class LinkageErrorMissingMethod {
-  abstract MethodSymbolReference getReference();
+abstract class MethodSymbolReference {
+  abstract String getTargetClassName();
+  abstract String getMethodName();
+  abstract String getDescriptor();
+  abstract String getSourceClassName();
 
   static Builder builder() {
-    return new AutoValue_LinkageErrorMissingMethod.Builder();
+    return new AutoValue_MethodSymbolReference.Builder();
   }
 
   @AutoValue.Builder
   abstract static class Builder {
-    abstract Builder setReference(MethodSymbolReference value);
-    abstract LinkageErrorMissingMethod build();
+    abstract Builder setTargetClassName(String value);
+    abstract Builder setMethodName(String value);
+    abstract Builder setDescriptor(String value);
+    abstract Builder setSourceClassName(String value);
+    abstract MethodSymbolReference build();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
@@ -23,11 +23,6 @@ import com.google.auto.value.AutoValue;
  */
 @AutoValue
 abstract class MethodSymbolReference implements SymbolReference  {
-  @Override
-  public abstract String getTargetClassName();
-  @Override
-  public abstract String getSourceClassName();
-
   /**
    * Returns method name of the reference. Example: {@code marshaller}
    */
@@ -36,7 +31,8 @@ abstract class MethodSymbolReference implements SymbolReference  {
   /**
    * Returns the descriptor of the method. A descriptor holds type information for its parameters
    * and return value. Example: {@code
-   * (Lcom/google/protobuf/Message;)Lio/grpc/MethodDescriptor$Marshaller;}
+   * '(Lcom/google/protobuf/Message;)Lio/grpc/MethodDescriptor$Marshaller;}', where {@code Message}
+   * class is the parameter and {@code MethodDescriptor$Marshaller} class is the return type.
    *
    * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3.3">Java
    *     Virtual Machine Specification: Method Descriptors</a>

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
@@ -19,12 +19,12 @@ package com.google.cloud.tools.opensource.classpath;
 import com.google.auto.value.AutoValue;
 
 /**
- * A symbolic reference to a method of {@code targetClass} referenced from {@code sourceClass}.
+ * A symbol reference to a method of {@code targetClass} referenced from {@code sourceClass}.
  */
 @AutoValue
 abstract class MethodSymbolReference implements SymbolReference  {
   /**
-   * Returns method name of the reference. Example: {@code marshaller}
+   * Returns the method name of the reference. Example: {@code marshaller}
    */
   abstract String getMethodName();
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
@@ -18,12 +18,17 @@ package com.google.cloud.tools.opensource.classpath;
 
 import com.google.auto.value.AutoValue;
 
+/**
+ * A symbolic reference to a method of {@code targetClass} referenced from {@code sourceClass}.
+ */
 @AutoValue
-abstract class MethodSymbolReference {
-  abstract String getTargetClassName();
+abstract class MethodSymbolReference implements SymbolReference  {
+  @Override
+  public abstract String getTargetClassName();
+  @Override
+  public abstract String getSourceClassName();
   abstract String getMethodName();
   abstract String getDescriptor();
-  abstract String getSourceClassName();
 
   static Builder builder() {
     return new AutoValue_MethodSymbolReference.Builder();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
@@ -31,10 +31,10 @@ abstract class MethodSymbolReference {
 
   @AutoValue.Builder
   abstract static class Builder {
-    abstract Builder setTargetClassName(String value);
-    abstract Builder setMethodName(String value);
-    abstract Builder setDescriptor(String value);
-    abstract Builder setSourceClassName(String value);
+    abstract Builder setTargetClassName(String className);
+    abstract Builder setMethodName(String methodName);
+    abstract Builder setDescriptor(String descriptor);
+    abstract Builder setSourceClassName(String className);
     abstract MethodSymbolReference build();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
@@ -27,7 +27,19 @@ abstract class MethodSymbolReference implements SymbolReference  {
   public abstract String getTargetClassName();
   @Override
   public abstract String getSourceClassName();
+
+  /**
+   * Returns method name of the reference.
+   */
   abstract String getMethodName();
+
+  /**
+   * Returns the descriptor of the method. A descriptor holds type information for its parameters
+   * and return value.
+   *
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3.3">Java
+   *     Virtual Machine Specification: Method Descriptors</a>
+   */
   abstract String getDescriptor();
 
   static Builder builder() {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
@@ -29,13 +29,14 @@ abstract class MethodSymbolReference implements SymbolReference  {
   public abstract String getSourceClassName();
 
   /**
-   * Returns method name of the reference.
+   * Returns method name of the reference. Example: {@code marshaller}
    */
   abstract String getMethodName();
 
   /**
    * Returns the descriptor of the method. A descriptor holds type information for its parameters
-   * and return value.
+   * and return value. Example: {@code
+   * (Lcom/google/protobuf/Message;)Lio/grpc/MethodDescriptor$Marshaller;}
    *
    * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3.3">Java
    *     Virtual Machine Specification: Method Descriptors</a>

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
@@ -64,13 +64,12 @@ abstract class StaticLinkageCheckOption {
   abstract ImmutableList<String> getMavenCoordinates();
 
   /**
-   * Returns list of absolute paths for jar files in the filesystem if specified; otherwise an empty
-   * list.
+   * Returns absolute paths for jar files in the filesystem if specified; otherwise an empty list.
    */
   abstract ImmutableList<Path> getJarFileList();
 
   /**
-   * Returns flag to report only reachable linkage errors.
+   * Returns {@code true} if only reachable linkage errors should be reported.
    */
   abstract boolean isReportOnlyReachable();
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
@@ -38,7 +38,7 @@ import org.apache.commons.cli.ParseException;
  *
  * <ul>
  *   <li>{@code bomCoordinate}: a Maven coordinate for a BOM
- *   <li>{@code mavenCoordinates}: list of the coordinates of Maven artifacts
+ *   <li>{@code mavenCoordinates}: list of the coordinates of Maven artifacts to check
  *   <li>{@code jarFileList}: list of jar files in the filesystem
  * </ul>
  *

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
@@ -47,9 +47,9 @@ abstract class StaticLinkageCheckOption {
 
   @AutoValue.Builder
   abstract static class Builder {
-    abstract Builder setBomCoordinate(@Nullable String value);
-    abstract Builder setMavenCoordinates(List<String> value);
-    abstract Builder setJarFileList(List<Path> value);
+    abstract Builder setBomCoordinate(@Nullable String coordinate);
+    abstract Builder setMavenCoordinates(List<String> coordinates);
+    abstract Builder setJarFileList(List<Path> paths);
     abstract Builder setReportOnlyReachable(boolean value);
     abstract StaticLinkageCheckOption build();
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
@@ -37,7 +37,7 @@ import org.apache.commons.cli.ParseException;
  * exactly one of the following types of input:
  *
  * <ul>
- *   <li>{@code bomCoordinate}: a Maven coordinate for a BOM
+ *   <li>{@code bomCoordinates}: Maven coordinates for a BOM
  *   <li>{@code mavenCoordinates}: list of the coordinates of Maven artifacts to check
  *   <li>{@code jarFileList}: list of jar files in the filesystem
  * </ul>
@@ -55,10 +55,10 @@ abstract class StaticLinkageCheckOption {
    * com.google.cloud:cloud-oss-bom:pom:1.0.0-SNAPSHOT}
    */
   @Nullable
-  abstract String getBomCoordinate();
+  abstract String getBomCoordinates();
 
   /**
-   * Returns the coordinates of Maven artifacts if specified; otherwise an empty list. Example
+   * Returns list of coordinates of Maven artifacts if specified; otherwise an empty list. Example
    * element: {@code com.google.cloud:google-cloud-bigtable:0.66.0-alpha}
    */
   abstract ImmutableList<String> getMavenCoordinates();
@@ -80,7 +80,7 @@ abstract class StaticLinkageCheckOption {
 
   @AutoValue.Builder
   abstract static class Builder {
-    abstract Builder setBomCoordinate(@Nullable String coordinate);
+    abstract Builder setBomCoordinates(@Nullable String coordinates);
     abstract Builder setMavenCoordinates(List<String> coordinates);
     abstract Builder setJarFileList(List<Path> paths);
     abstract Builder setReportOnlyReachable(boolean value);
@@ -125,19 +125,19 @@ abstract class StaticLinkageCheckOption {
         jarFilePaths.addAll(jarFilesInArguments);
       }
 
-      String mavenBomCoordinate = commandLine.getOptionValue("b");
+      String mavenBomCoordinates = commandLine.getOptionValue("b");
 
       boolean reportOnlyReachable = commandLine.hasOption("r");
 
       return builder()
-          .setBomCoordinate(mavenBomCoordinate)
+          .setBomCoordinates(mavenBomCoordinates)
           .setMavenCoordinates(mavenCoordinates.build())
           .setJarFileList(jarFilePaths)
           .setReportOnlyReachable(reportOnlyReachable)
           .build();
     } catch (ParseException ex) {
-      HelpFormatter helpFormetter = new HelpFormatter();
-      helpFormetter.printHelp("StaticLinkageChecker", options);
+      HelpFormatter helpFormatter = new HelpFormatter();
+      helpFormatter.printHelp("StaticLinkageChecker", options);
       throw ex;
     }
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
@@ -38,7 +38,7 @@ import org.apache.commons.cli.ParseException;
  *
  * <ul>
  *   <li>{@code bomCoordinates}: Maven coordinates for a BOM
- *   <li>{@code mavenCoordinates}: list of the coordinates of Maven artifacts to check
+ *   <li>{@code mavenCoordinatesList}: list of the coordinates of Maven artifacts to check
  *   <li>{@code jarFileList}: list of jar files in the filesystem
  * </ul>
  *
@@ -61,7 +61,7 @@ abstract class StaticLinkageCheckOption {
    * Returns list of coordinates of Maven artifacts if specified; otherwise an empty list. Example
    * element: {@code com.google.cloud:google-cloud-bigtable:0.66.0-alpha}
    */
-  abstract ImmutableList<String> getMavenCoordinates();
+  abstract ImmutableList<String> getMavenCoordinatesList();
 
   /**
    * Returns absolute paths for jar files in the filesystem if specified; otherwise an empty list.
@@ -80,7 +80,7 @@ abstract class StaticLinkageCheckOption {
   @AutoValue.Builder
   abstract static class Builder {
     abstract Builder setBomCoordinates(@Nullable String coordinates);
-    abstract Builder setMavenCoordinates(List<String> coordinates);
+    abstract Builder setMavenCoordinatesList(List<String> coordinates);
     abstract Builder setJarFileList(List<Path> paths);
     abstract Builder setReportOnlyReachable(boolean value);
     abstract StaticLinkageCheckOption build();
@@ -130,7 +130,7 @@ abstract class StaticLinkageCheckOption {
 
       return builder()
           .setBomCoordinates(mavenBomCoordinates)
-          .setMavenCoordinates(mavenCoordinates.build())
+          .setMavenCoordinatesList(mavenCoordinates.build())
           .setJarFileList(jarFilePaths)
           .setReportOnlyReachable(reportOnlyReachable)
           .build();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
@@ -74,7 +74,9 @@ abstract class StaticLinkageCheckOption {
   abstract boolean isReportOnlyReachable();
 
   static Builder builder() {
-    return new AutoValue_StaticLinkageCheckOption.Builder();
+    return new AutoValue_StaticLinkageCheckOption.Builder()
+        .setArtifacts(ImmutableList.of())
+        .setJarFiles(ImmutableList.of());
   }
 
   @AutoValue.Builder

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
@@ -32,13 +32,43 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
+/**
+ * Option for {@link StaticLinkageChecker}. To construct an input class path, the checker requires
+ * either one of the following types of input:
+ *
+ * <ul>
+ *   <li>{@code bomCoordinate}: a Maven coordinate for a BOM
+ *   <li>{@code mavenCoordinates}: list of Maven artifact coordinates
+ *   <li>{@code jarFileList}: list of jar files in the filesystem
+ * </ul>
+ *
+ * @see <a
+ *     href="https://github.com/GoogleCloudPlatform/cloud-opensource-java/tree/master/dependencies#input">Static
+ *     Linkage Checker: Input</a>
+ */
 @AutoValue
 abstract class StaticLinkageCheckOption {
   // TODO(suztomo): Add option to specify entry point classes
 
+  /**
+   * Returns a Maven coordinate for a BOM if specified; otherwise null.
+   */
   @Nullable abstract String getBomCoordinate();
+
+  /**
+   * Returns Maven coordinates if specified; otherwise an empty list.
+   */
   abstract ImmutableList<String> getMavenCoordinates();
+
+  /**
+   * Returns list of absolute paths for jar files in the filesystem if specified; otherwise an empty
+   * list.
+   */
   abstract ImmutableList<Path> getJarFileList();
+
+  /**
+   * Returns flag to report only reachable linkage errors.
+   */
   abstract boolean isReportOnlyReachable();
 
   static Builder builder() {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
@@ -38,7 +38,7 @@ import org.apache.commons.cli.ParseException;
  *
  * <ul>
  *   <li>{@code bomCoordinate}: a Maven coordinate for a BOM
- *   <li>{@code mavenCoordinates}: list of Maven artifact coordinates
+ *   <li>{@code mavenCoordinates}: list of the coordinates of Maven artifacts
  *   <li>{@code jarFileList}: list of jar files in the filesystem
  * </ul>
  *
@@ -51,12 +51,15 @@ abstract class StaticLinkageCheckOption {
   // TODO(suztomo): Add option to specify entry point classes
 
   /**
-   * Returns a Maven coordinate for a BOM if specified; otherwise null.
+   * Returns a Maven coordinate for a BOM if specified; otherwise null. Example value: {@code
+   * com.google.cloud:cloud-oss-bom:pom:1.0.0-SNAPSHOT}
    */
-  @Nullable abstract String getBomCoordinate();
+  @Nullable
+  abstract String getBomCoordinate();
 
   /**
-   * Returns Maven coordinates if specified; otherwise an empty list.
+   * Returns the coordinates of Maven artifacts if specified; otherwise an empty list. Example
+   * element: {@code com.google.cloud:google-cloud-bigtable:0.66.0-alpha}
    */
   abstract ImmutableList<String> getMavenCoordinates();
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
@@ -54,7 +54,7 @@ abstract class StaticLinkageCheckOption {
     abstract StaticLinkageCheckOption build();
   }
 
-  static StaticLinkageCheckOption parseArgument(String[] arguments) throws ParseException {
+  static StaticLinkageCheckOption parseArguments(String[] arguments) throws ParseException {
     Options options = new Options();
     options.addOption(
         "b", "bom", true, "BOM to generate a classpath");

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -144,10 +144,10 @@ class StaticLinkageChecker {
     ImmutableList.Builder<Path> jarFileBuilder = ImmutableList.builder();
 
     // TODO(suztomo): add logic to convert Maven BOM to list of Maven coordinates as per README.md
-    if (!linkageCheckOption.getJarFileList().isEmpty()) {
-      jarFileBuilder.addAll(linkageCheckOption.getJarFileList());
-    } else if (!linkageCheckOption.getMavenCoordinatesList().isEmpty()) {
-      for (String mavenCoordinates : linkageCheckOption.getMavenCoordinatesList()) {
+    if (!linkageCheckOption.getJarFiles().isEmpty()) {
+      jarFileBuilder.addAll(linkageCheckOption.getJarFiles());
+    } else if (!linkageCheckOption.getArtifacts().isEmpty()) {
+      for (String mavenCoordinates : linkageCheckOption.getArtifacts()) {
         jarFileBuilder.addAll(coordinatesToClasspath(mavenCoordinates));
       }
     }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -248,12 +248,12 @@ class StaticLinkageChecker {
 
     try {
       for (JavaClass javaClass : ClassDumper.topLevelJavaClassesInJar(jarFilePath, repository)) {
-        SymbolsInFile partialSymbolsInFile = ClassDumper.scanClassSymbolTable(javaClass);
+        SymbolsInFile symbolsInClassFile = ClassDumper.scanClassSymbolTable(javaClass);
 
-        classSymbolReferences.addAll(partialSymbolsInFile.getClassReferences());
-        methodSymbolReferences.addAll(partialSymbolsInFile.getMethodReferences());
-        fieldSymbolReferences.addAll(partialSymbolsInFile.getFieldReferences());
-        symbolTableClassNameBuilder.addAll(partialSymbolsInFile.getDefinedClassNames());
+        classSymbolReferences.addAll(symbolsInClassFile.getClassReferences());
+        methodSymbolReferences.addAll(symbolsInClassFile.getMethodReferences());
+        fieldSymbolReferences.addAll(symbolsInClassFile.getFieldReferences());
+        symbolTableClassNameBuilder.addAll(symbolsInClassFile.getDefinedClassNames());
       }
       ImmutableSet<String> classesDefinedInJar = symbolTableClassNameBuilder.build();
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -188,7 +188,7 @@ class StaticLinkageChecker {
   }
 
   /**
-   * Finds linkage errors in the input classpath and generates report
+   * Finds linkage errors in the input classpath and generates a static linkage check report.
    */
   StaticLinkageCheckReport findLinkageErrors() {
     ImmutableList<Path> jarFilePaths = classDumper.getInputClasspath();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
@@ -23,7 +24,6 @@ import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraphBuilder;
 import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -56,7 +56,7 @@ class StaticLinkageChecker {
   static StaticLinkageChecker create(
       boolean reportOnlyReachable, List<Path> jarFilePaths, Iterable<Path> entryPoints)
       throws IOException, ClassNotFoundException {
-    Preconditions.checkArgument(
+    checkArgument(
         !jarFilePaths.isEmpty(),
         "The linkage classpath is empty. Specify input to supply one or more jar files");
     return new StaticLinkageChecker(
@@ -192,8 +192,6 @@ class StaticLinkageChecker {
 
   /**
    * Finds linkage errors in the input classpath and generates a static linkage check report.
-   *
-   * @return a static linkage check report for the input class path
    */
   StaticLinkageCheckReport findLinkageErrors() throws ClassNotFoundException, IOException {
     ImmutableList<Path> jarFilePaths = classDumper.getInputClasspath();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -212,7 +212,8 @@ class StaticLinkageChecker {
     return StaticLinkageCheckReport.create(jarLinkageReports.build());
   }
 
-  private JarLinkageReport findInvalidReferences(Path jarPath, SymbolReferenceSet symbolReferenceSet) {
+  private JarLinkageReport findInvalidReferences(
+      Path jarPath, SymbolReferenceSet symbolReferenceSet) {
     JarLinkageReport.Builder reportBuilder = JarLinkageReport.builder().setJarPath(jarPath);
 
     // TODO(suztomo): implement validation for field, method and class references in the table

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -197,7 +197,7 @@ class StaticLinkageChecker {
 
     ImmutableMap<Path, SymbolReferenceSet> jarToSymbols =
         jarFilePaths.stream().collect(toImmutableMap(
-            jarPath -> jarPath, jarPath -> scanSymbolReferencesInJar(jarPath)));
+            jarPath -> jarPath, ClassDumper::scanSymbolReferencesInJar));
 
     // Validate linkage error of each reference
     ImmutableList<JarLinkageReport> jarLinkageReports =
@@ -218,30 +218,6 @@ class StaticLinkageChecker {
 
     // TODO(suztomo): implement validation for field, method and class references in the table
     return reportBuilder.build();
-  }
-
-  /**
-   * Scans class files in the jar file and returns a {@link SymbolReferenceSet} populated with
-   * symbolic references.
-   *
-   * @param jarFilePath absolute path to a jar file
-   * @return symbol references and classes defined in the jar file
-   */
-  static SymbolReferenceSet scanSymbolReferencesInJar(Path jarFilePath) {
-    Preconditions.checkArgument(
-        jarFilePath.isAbsolute(), "The input jar file path is not an absolute path");
-    Preconditions.checkArgument(
-        Files.isReadable(jarFilePath), "The input jar file path is not readable");
-
-    SymbolReferenceSet.Builder symbolTableBuilder = SymbolReferenceSet.builder();
-    try {
-      for (JavaClass javaClass : ClassDumper.topLevelJavaClassesInJar(jarFilePath)) {
-        symbolTableBuilder.merge(ClassDumper.scanSymbolReferencesInClass(javaClass));
-      }
-      return symbolTableBuilder.build();
-    } catch (ClassNotFoundException | IOException ex) {
-      throw new RuntimeException("Failed to scan jar file", ex);
-    }
   }
 
   /**

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -146,8 +146,8 @@ class StaticLinkageChecker {
     // TODO(suztomo): add logic to convert Maven BOM to list of Maven coordinates as per README.md
     if (!linkageCheckOption.getJarFileList().isEmpty()) {
       jarFileBuilder.addAll(linkageCheckOption.getJarFileList());
-    } else if (!linkageCheckOption.getMavenCoordinates().isEmpty()) {
-      for (String mavenCoordinates : linkageCheckOption.getMavenCoordinates()) {
+    } else if (!linkageCheckOption.getMavenCoordinatesList().isEmpty()) {
+      for (String mavenCoordinates : linkageCheckOption.getMavenCoordinatesList()) {
         jarFileBuilder.addAll(coordinatesToClasspath(mavenCoordinates));
       }
     }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -102,29 +102,28 @@ class StaticLinkageChecker {
     // TODO(suztomo): print the report
     StaticLinkageCheckReport report = staticLinkageChecker.findLinkageErrors();
 
-    printStaticLinkageErrors(unresolvedMethodReferences);
+    printStaticLinkageReport(report);
   }
 
-  private static void printStaticLinkageErrors(
-      List<FullyQualifiedMethodSignature> unresolvedMethodReferences) {
-    if (unresolvedMethodReferences.isEmpty()) {
-      System.out.println("There were no unresolved method references");
-      return;
+  private static void printStaticLinkageReport(StaticLinkageCheckReport report) {
+    for (JarLinkageReport jarLinkageReport : report.getJarLinkageReports()) {
+      int totalErrors =
+          jarLinkageReport.getMissingClassErrors().size()
+              + jarLinkageReport.getMissingMethodErrors().size()
+              + jarLinkageReport.getMissingFieldErrors().size();
+      System.out.println(
+          jarLinkageReport.getJarPath().getFileName() + "(" + totalErrors + " errors):");
+      String indent = "  ";
+      for (LinkageErrorMissingClass missingClass : jarLinkageReport.getMissingClassErrors()) {
+        System.out.println(indent + missingClass.getReference());
+      }
+      for (LinkageErrorMissingMethod missingMethod : jarLinkageReport.getMissingMethodErrors()) {
+        System.out.println(indent + missingMethod.getReference());
+      }
+      for (LinkageErrorMissingField missingField : jarLinkageReport.getMissingFieldErrors()) {
+        System.out.println(indent + missingField.getReference());
+      }
     }
-    ImmutableSortedSet<FullyQualifiedMethodSignature> sortedUnresolvedMethodReferences =
-        ImmutableSortedSet.copyOf(unresolvedMethodReferences);
-    int count = sortedUnresolvedMethodReferences.size();
-    Formatter formatter = new Formatter();
-    formatter.format(
-        "There were %,d unresolved method references from the jar file(s):\n", count);
-    for (FullyQualifiedMethodSignature methodReference : sortedUnresolvedMethodReferences) {
-      formatter.format(
-          "Class: '%s', method: '%s' with descriptor %s\n",
-          methodReference.getClassName(),
-          methodReference.getMethodSignature().getMethodName(),
-          methodReference.getMethodSignature().getDescriptor());
-    }
-    System.out.println(formatter);
   }
 
   /**
@@ -208,6 +207,7 @@ class StaticLinkageChecker {
     if (reportOnlyReachable) {
       // TODO: Optionally, report errors only reachable from entry point classes
       logger.warning("reportOnlyReachable is not yet implemented");
+      throw new UnsupportedOperationException("reportOnlyReachable is not yet implemented");
     }
 
     return StaticLinkageCheckReport.create(jarLinkageReports);
@@ -217,7 +217,7 @@ class StaticLinkageChecker {
     JarLinkageReport.Builder reportBuilder = JarLinkageReport.builder().setJarPath(jarPath);
 
     // TODO(suztomo): implement validation for field, method and class references in the table
-    return reportBuilder.build();
+    throw new UnsupportedOperationException("The report generation is not yet implemented");
   }
 
   /**

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -86,7 +86,7 @@ class StaticLinkageChecker {
    *
    * @throws IOException when there is a problem in reading a jar file
    * @throws ClassNotFoundException when there is a problem in reading a class from a jar file
-   * @throws RepositoryException when there is a problem in resolving the Maven coordinate to jar
+   * @throws RepositoryException when there is a problem in resolving the Maven coordinates to jar
    *     files
    * @throws ParseException when the arguments are invalid for the tool
    */
@@ -136,7 +136,7 @@ class StaticLinkageChecker {
    *
    * @param linkageCheckOption option through command-line arguments
    * @return input class path resolved as a list of absolute paths to jar files
-   * @throws RepositoryException when there is a problem in resolving the Maven coordinate to jar
+   * @throws RepositoryException when there is a problem in resolving the Maven coordinates to jar
    */
   @VisibleForTesting
   static ImmutableList<Path> generateInputClasspathFromLinkageCheckOption(
@@ -148,7 +148,7 @@ class StaticLinkageChecker {
       jarFileBuilder.addAll(linkageCheckOption.getJarFileList());
     } else if (!linkageCheckOption.getMavenCoordinates().isEmpty()) {
       for (String mavenCoordinates : linkageCheckOption.getMavenCoordinates()) {
-        jarFileBuilder.addAll(coordinateToClasspath(mavenCoordinates));
+        jarFileBuilder.addAll(coordinatesToClasspath(mavenCoordinates));
       }
     }
     return jarFileBuilder.build();
@@ -157,13 +157,13 @@ class StaticLinkageChecker {
   /**
    * Finds jar file paths for the dependencies of the Maven coordinate.
    *
-   * @param coordinate Maven coordinate of an artifact to check its dependencies
+   * @param coordinates Maven coordinates of an artifact to check its dependencies
    * @return list of absolute paths to jar files
    * @throws RepositoryException when there is a problem in retrieving jar files
    */
   @VisibleForTesting
-  static ImmutableList<Path> coordinateToClasspath(String coordinate) throws RepositoryException {
-    DefaultArtifact rootArtifact = new DefaultArtifact(coordinate);
+  static ImmutableList<Path> coordinatesToClasspath(String coordinates) throws RepositoryException {
+    DefaultArtifact rootArtifact = new DefaultArtifact(coordinates);
     // dependencyGraph holds multiple versions for one artifact key (groupId:artifactId)
     DependencyGraph dependencyGraph =
         DependencyGraphBuilder.getStaticLinkageCheckDependencies(rootArtifact);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -64,7 +64,8 @@ class StaticLinkageChecker {
   private final ImmutableSet<Path> entryPoints;
 
   StaticLinkageChecker(
-      boolean reportOnlyReachable, List<Path> jarFilePaths, Iterable<Path> entryPoints) {
+      boolean reportOnlyReachable, List<Path> jarFilePaths, Iterable<Path> entryPoints)
+      throws IOException, ClassNotFoundException {
     Preconditions.checkArgument(
         !jarFilePaths.isEmpty(),
         "The linkage classpath is empty. Specify input to supply one or more jar files");

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -97,7 +97,6 @@ class StaticLinkageChecker {
     List<FullyQualifiedMethodSignature> unresolvedMethodReferences =
         staticLinkageChecker.findUnresolvedMethodReferences();
 
-    // TODO(suztomo): print the report
     StaticLinkageCheckReport report = staticLinkageChecker.findLinkageErrors();
 
     printStaticLinkageReport(report);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -144,12 +144,9 @@ class StaticLinkageChecker {
     ImmutableList.Builder<Path> jarFileBuilder = ImmutableList.builder();
 
     // TODO(suztomo): add logic to convert Maven BOM to list of Maven coordinates as per README.md
-    if (!linkageCheckOption.getJarFiles().isEmpty()) {
-      jarFileBuilder.addAll(linkageCheckOption.getJarFiles());
-    } else if (!linkageCheckOption.getArtifacts().isEmpty()) {
-      for (String mavenCoordinates : linkageCheckOption.getArtifacts()) {
-        jarFileBuilder.addAll(coordinatesToClasspath(mavenCoordinates));
-      }
+    jarFileBuilder.addAll(linkageCheckOption.getJarFiles());
+    for (String mavenCoordinates : linkageCheckOption.getArtifacts()) {
+      jarFileBuilder.addAll(coordinatesToClasspath(mavenCoordinates));
     }
     return jarFileBuilder.build();
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
@@ -25,7 +25,6 @@ package com.google.cloud.tools.opensource.classpath;
  *     Language Specification: 13.1. The Form of a Binary</a>
  */
 interface SymbolReference {
-
   /**
    * Returns fully-qualified class name of the source class of the reference.
    */

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
@@ -16,26 +16,11 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-import com.google.auto.value.AutoValue;
-
 /**
- * A symbolic reference to {@code targetClass} referenced from {@code sourceClass}.
+ * A reference to a symbol of {@code targetClass} from {@code sourceClass}.
  */
-@AutoValue
-abstract class ClassSymbolReference implements SymbolReference {
-  @Override
-  public abstract String getTargetClassName();
-  @Override
-  public abstract String getSourceClassName();
+interface SymbolReference {
+  String getSourceClassName();
 
-  static Builder builder() {
-    return new AutoValue_ClassSymbolReference.Builder();
-  }
-
-  @AutoValue.Builder
-  abstract static class Builder {
-    abstract Builder setTargetClassName(String className);
-    abstract Builder setSourceClassName(String className);
-    abstract ClassSymbolReference build();
-  }
+  String getTargetClassName();
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
@@ -27,12 +27,12 @@ package com.google.cloud.tools.opensource.classpath;
 interface SymbolReference {
 
   /**
-   * Fully-qualified class name of source of the reference
+   * Returns fully-qualified class name of the source class of the reference.
    */
   String getSourceClassName();
 
   /**
-   * Fully-qualified class name of target of the reference
+   * Returns fully-qualified class name of the target class of the reference.
    */
   String getTargetClassName();
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
@@ -18,8 +18,11 @@ package com.google.cloud.tools.opensource.classpath;
 
 /**
  * A reference to a symbol of {@code targetClass} from {@code sourceClass}. The values of the class
- * names are fully-qualified with '.' as separator and '$' for inner class. For example {@code
+ * names are fully-qualified form known as binary names. For example {@code
  * io.grpc.MethodDescriptor$MethodType}.
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.1">Java
+ *     Language Specification: 13.1. The Form of a Binary</a>
  */
 interface SymbolReference {
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
@@ -26,12 +26,12 @@ package com.google.cloud.tools.opensource.classpath;
  */
 interface SymbolReference {
   /**
-   * Returns fully-qualified class name of the source class of the reference.
+   * Returns the fully-qualified class name (binary name) of the source class of the reference.
    */
   String getSourceClassName();
 
   /**
-   * Returns fully-qualified class name of the target class of the reference.
+   * Returns the fully-qualified class name (binary name) of the target class of the reference.
    */
   String getTargetClassName();
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
@@ -17,10 +17,19 @@
 package com.google.cloud.tools.opensource.classpath;
 
 /**
- * A reference to a symbol of {@code targetClass} from {@code sourceClass}.
+ * A reference to a symbol of {@code targetClass} from {@code sourceClass}. The values of the class
+ * names are fully-qualified with '.' as separator and '$' for inner class. For example {@code
+ * io.grpc.MethodDescriptor$MethodType}.
  */
 interface SymbolReference {
+
+  /**
+   * Fully-qualified class name of source of the reference
+   */
   String getSourceClassName();
 
+  /**
+   * Fully-qualified class name of target of the reference
+   */
   String getTargetClassName();
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReferenceSet.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReferenceSet.java
@@ -58,7 +58,7 @@ abstract class SymbolReferenceSet {
 
     abstract SymbolReferenceSet build();
 
-    Builder merge(SymbolReferenceSet other) {
+    Builder addAll(SymbolReferenceSet other) {
       classReferencesBuilder().addAll(other.getClassReferences());
       methodReferencesBuilder().addAll(other.getMethodReferences());
       fieldReferencesBuilder().addAll(other.getFieldReferences());

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReferenceSet.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReferenceSet.java
@@ -20,7 +20,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 
 /**
- * A set of symbolic references in a file (jar file or class file). The references are from constant
+ * A set of symbol references in a file (jar file or class file). The references are from constant
  * pool of class file(s).
  *
  * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4">Java

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReferenceSet.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReferenceSet.java
@@ -32,10 +32,12 @@ abstract class SymbolReferenceSet {
    * Returns class references from the file.
    */
   abstract ImmutableSet<ClassSymbolReference> getClassReferences();
+
   /**
    * Returns method references from the file.
    */
   abstract ImmutableSet<MethodSymbolReference> getMethodReferences();
+
   /**
    * Returns field references from the file.
    */

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReferenceSet.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReferenceSet.java
@@ -20,14 +20,14 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 
 /**
- * Symbolic references in a file (jar file or class file). The references are from constant pool of
- * class file(s).
+ * A set of symbolic references in a file (jar file or class file). The references are from constant
+ * pool of class file(s).
  *
  * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4">Java
  *     Virtual Machine Specification: The Constant Pool</a>
  */
 @AutoValue
-abstract class SymbolsInFile {
+abstract class SymbolReferenceSet {
   /**
    * Returns class references from the file.
    */
@@ -40,8 +40,9 @@ abstract class SymbolsInFile {
    * Returns field references from the file.
    */
   abstract ImmutableSet<FieldSymbolReference> getFieldReferences();
+
   static Builder builder() {
-    return new AutoValue_SymbolsInFile.Builder();
+    return new AutoValue_SymbolReferenceSet.Builder();
   }
 
   @AutoValue.Builder
@@ -52,6 +53,14 @@ abstract class SymbolsInFile {
     abstract ImmutableSet.Builder<ClassSymbolReference> classReferencesBuilder();
     abstract ImmutableSet.Builder<MethodSymbolReference> methodReferencesBuilder();
     abstract ImmutableSet.Builder<FieldSymbolReference> fieldReferencesBuilder();
-    abstract SymbolsInFile build();
+
+    abstract SymbolReferenceSet build();
+
+    Builder merge(SymbolReferenceSet other) {
+      classReferencesBuilder().addAll(other.getClassReferences());
+      methodReferencesBuilder().addAll(other.getMethodReferences());
+      fieldReferencesBuilder().addAll(other.getFieldReferences());
+      return this;
+    }
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolTable.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolTable.java
@@ -20,7 +20,11 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 
 /**
- * A table of list of symbolic references and defined classes in a jar file or class file.
+ * A table of symbolic references and defined classes in a jar file or class file. The
+ * symbolic references are from constant pool of class files.
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4">Java
+ *     Virtual Machine Specification: The Constant Pool</a>
  */
 @AutoValue
 abstract class SymbolTable {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolTable.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolTable.java
@@ -20,7 +20,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 
 /**
- * A table of list symbolic references in a jar file.
+ * A table of list of symbolic references and defined classes in a jar file or class file.
  */
 @AutoValue
 abstract class SymbolTable {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolTable.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolTable.java
@@ -35,10 +35,10 @@ abstract class SymbolTable {
 
   @AutoValue.Builder
   abstract static class Builder {
-    abstract Builder setClassReferences(Iterable<ClassSymbolReference> value);
-    abstract Builder setFieldReferences(Iterable<FieldSymbolReference> value);
-    abstract Builder setMethodReferences(Iterable<MethodSymbolReference> value);
-    abstract Builder setDefinedClassNames(Iterable<String> value);
+    abstract Builder setClassReferences(Iterable<ClassSymbolReference> classReferences);
+    abstract Builder setFieldReferences(Iterable<FieldSymbolReference> fieldReferences);
+    abstract Builder setMethodReferences(Iterable<MethodSymbolReference> methodReferences);
+    abstract Builder setDefinedClassNames(Iterable<String> classNames);
     abstract ImmutableSet.Builder<ClassSymbolReference> classReferencesBuilder();
     abstract ImmutableSet.Builder<MethodSymbolReference> methodReferencesBuilder();
     abstract ImmutableSet.Builder<FieldSymbolReference> fieldReferencesBuilder();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolTable.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolTable.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.classpath;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * A table of list symbolic references in a jar file.
+ */
+@AutoValue
+abstract class SymbolTable {
+  abstract ImmutableSet<ClassSymbolReference> getClassReferences();
+  abstract ImmutableSet<FieldSymbolReference> getFieldReferences();
+  abstract ImmutableSet<MethodSymbolReference> getMethodReferences();
+  abstract ImmutableSet<String> getDefinedClassNames();
+
+  static Builder builder() {
+    return new AutoValue_SymbolTable.Builder();
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+    abstract Builder setClassReferences(Iterable<ClassSymbolReference> value);
+    abstract Builder setFieldReferences(Iterable<FieldSymbolReference> value);
+    abstract Builder setMethodReferences(Iterable<MethodSymbolReference> value);
+    abstract Builder setDefinedClassNames(Iterable<String> value);
+    abstract ImmutableSet.Builder<ClassSymbolReference> classReferencesBuilder();
+    abstract ImmutableSet.Builder<MethodSymbolReference> methodReferencesBuilder();
+    abstract ImmutableSet.Builder<FieldSymbolReference> fieldReferencesBuilder();
+    abstract ImmutableSet.Builder<String> definedClassNamesBuilder();
+    abstract SymbolTable build();
+  }
+}

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolsInFile.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolsInFile.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableSet;
 /**
  * Symbolic references and defined classes in a file (jar file or class file). The
  * symbolic references are from constant pool of class file(s). The defined class names are
- * from the class defined as top-level in a class file and inner classes in it.
+ * from the class defined as top-level in a class file and its inner classes.
  *
  * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4">Java
  *     Virtual Machine Specification: The Constant Pool</a>

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolsInFile.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolsInFile.java
@@ -20,21 +20,34 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 
 /**
- * A table of symbolic references and defined classes in a jar file or class file. The
- * symbolic references are from constant pool of class files.
+ * Symbolic references and defined classes in a file (jar file or class file). The
+ * symbolic references are from constant pool of class file(s). The defined class names are
+ * from the class defined as top-level in a class file and inner classes in it.
  *
  * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4">Java
  *     Virtual Machine Specification: The Constant Pool</a>
  */
 @AutoValue
-abstract class SymbolTable {
+abstract class SymbolsInFile {
+  /**
+   * Returns class references from the file.
+   */
   abstract ImmutableSet<ClassSymbolReference> getClassReferences();
-  abstract ImmutableSet<FieldSymbolReference> getFieldReferences();
+  /**
+   * Returns method references from the file.
+   */
   abstract ImmutableSet<MethodSymbolReference> getMethodReferences();
+  /**
+   * Returns field references from the file.
+   */
+  abstract ImmutableSet<FieldSymbolReference> getFieldReferences();
+  /**
+   * Returns class names defined in the file.
+   */
   abstract ImmutableSet<String> getDefinedClassNames();
 
   static Builder builder() {
-    return new AutoValue_SymbolTable.Builder();
+    return new AutoValue_SymbolsInFile.Builder();
   }
 
   @AutoValue.Builder
@@ -47,6 +60,6 @@ abstract class SymbolTable {
     abstract ImmutableSet.Builder<MethodSymbolReference> methodReferencesBuilder();
     abstract ImmutableSet.Builder<FieldSymbolReference> fieldReferencesBuilder();
     abstract ImmutableSet.Builder<String> definedClassNamesBuilder();
-    abstract SymbolTable build();
+    abstract SymbolsInFile build();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolsInFile.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolsInFile.java
@@ -20,9 +20,8 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 
 /**
- * Symbolic references and defined classes in a file (jar file or class file). The
- * symbolic references are from constant pool of class file(s). The defined class names are
- * from the class defined as top-level in a class file and its inner classes.
+ * Symbolic references in a file (jar file or class file). The references are from constant pool of
+ * class file(s).
  *
  * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4">Java
  *     Virtual Machine Specification: The Constant Pool</a>
@@ -41,11 +40,6 @@ abstract class SymbolsInFile {
    * Returns field references from the file.
    */
   abstract ImmutableSet<FieldSymbolReference> getFieldReferences();
-  /**
-   * Returns class names defined in the file.
-   */
-  abstract ImmutableSet<String> getDefinedClassNames();
-
   static Builder builder() {
     return new AutoValue_SymbolsInFile.Builder();
   }
@@ -55,11 +49,9 @@ abstract class SymbolsInFile {
     abstract Builder setClassReferences(Iterable<ClassSymbolReference> classReferences);
     abstract Builder setFieldReferences(Iterable<FieldSymbolReference> fieldReferences);
     abstract Builder setMethodReferences(Iterable<MethodSymbolReference> methodReferences);
-    abstract Builder setDefinedClassNames(Iterable<String> classNames);
     abstract ImmutableSet.Builder<ClassSymbolReference> classReferencesBuilder();
     abstract ImmutableSet.Builder<MethodSymbolReference> methodReferencesBuilder();
     abstract ImmutableSet.Builder<FieldSymbolReference> fieldReferencesBuilder();
-    abstract ImmutableSet.Builder<String> definedClassNamesBuilder();
     abstract SymbolsInFile build();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
@@ -51,7 +51,6 @@ public class DependencyTreeFormatter {
    * Prints dependencies for the coordinate of an artifact
    *
    * @param coordinate Maven coordinate of an artifact to print its dependencies
-   * @throws RepositoryException when dependencies cannot be collected or resolved
    */
   private static void printDependencyTree(String coordinate)
       throws DependencyCollectionException, DependencyResolutionException {

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -136,7 +136,8 @@ public class ClassDumperTest {
   }
 
   @Test
-  public void testScanSymbolTableFromJar() throws URISyntaxException {
+  public void testScanSymbolTableFromJar()
+      throws URISyntaxException, IOException, ClassNotFoundException {
     URL jarFileUrl = URLClassLoader.getSystemResource(EXAMPLE_JAR_FILE);
 
     SymbolReferenceSet symbolReferenceSet =

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -53,7 +53,7 @@ public class ClassDumperTest {
   }
 
   @Test
-  public void testMethodDescriptorToClass_byteArray() {
+  public void testMethodDescriptorToClass_byteArray() throws IOException, ClassNotFoundException {
     ClassDumper classDumper = ClassDumper.create(ImmutableList.of());
     Class[] byteArrayClass =
         classDumper.methodDescriptorToClass("([B)Ljava/lang/String;");
@@ -61,7 +61,8 @@ public class ClassDumperTest {
   }
 
   @Test
-  public void testMethodDescriptorToClass_primitiveTypes() {
+  public void testMethodDescriptorToClass_primitiveTypes()
+      throws IOException, ClassNotFoundException {
     ClassDumper classDumper = ClassDumper.create(ImmutableList.of());
     // List of primitive types that appear in descriptor:
     // https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3
@@ -82,7 +83,7 @@ public class ClassDumperTest {
   }
 
   @Test
-  public void testMethodDefinitionExists_arrayType() throws ClassNotFoundException {
+  public void testMethodDefinitionExists_arrayType() throws ClassNotFoundException, IOException {
     FullyQualifiedMethodSignature checkArgumentMethod =
         new FullyQualifiedMethodSignature(
             "com.google.common.base.Preconditions", "checkArgument", "(ZLjava/lang/Object;)V");
@@ -93,7 +94,7 @@ public class ClassDumperTest {
 
   @Test
   public void testMethodDefinitionExists_constructorInAbstractClass()
-      throws ClassNotFoundException {
+      throws ClassNotFoundException, IOException {
     ClassDumper classDumper = ClassDumper.create(ImmutableList.of());
     FullyQualifiedMethodSignature constructorInAbstract =
         new FullyQualifiedMethodSignature(
@@ -126,12 +127,12 @@ public class ClassDumperTest {
   }
 
   @Test
-  public void testCreationInvalidInput() {
+  public void testCreationInvalidInput() throws IOException {
     try {
       ClassDumper.create(ImmutableList.of(Paths.get("")));
-      Assert.fail("Empty path should generate RuntimeException");
-    } catch (RuntimeException ex) {
-      Assert.assertEquals("There was problem in loading classes in jar file", ex.getMessage());
+      Assert.fail("Empty path should generate ClassNotFoundException");
+    } catch (ClassNotFoundException ex) {
+      // pass
     }
   }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReferenceTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReferenceTest.java
@@ -16,22 +16,20 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-import com.google.auto.value.AutoValue;
+import org.junit.Assert;
 
-/**
- * A missing method linkage error.
- */
-@AutoValue
-abstract class LinkageErrorMissingMethod {
-  abstract MethodSymbolReference getReference();
+import org.junit.Test;
 
-  static Builder builder() {
-    return new AutoValue_LinkageErrorMissingMethod.Builder();
-  }
+public class ClassSymbolReferenceTest {
+  @Test
+  public void testCreation() {
+    ClassSymbolReference classSymbolReference =
+        ClassSymbolReference.builder()
+            .setTargetClassName("ClassA")
+            .setSourceClassName("ClassB")
+            .build();
 
-  @AutoValue.Builder
-  abstract static class Builder {
-    abstract Builder setReference(MethodSymbolReference value);
-    abstract LinkageErrorMissingMethod build();
+    Assert.assertEquals("ClassA", classSymbolReference.getTargetClassName());
+    Assert.assertEquals("ClassB", classSymbolReference.getSourceClassName());
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReferenceTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReferenceTest.java
@@ -16,22 +16,21 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-import com.google.auto.value.AutoValue;
+import org.junit.Assert;
+import org.junit.Test;
 
-/**
- * A missing method linkage error.
- */
-@AutoValue
-abstract class LinkageErrorMissingMethod {
-  abstract MethodSymbolReference getReference();
+public class FieldSymbolReferenceTest {
+  @Test
+  public void testCreation() {
+    FieldSymbolReference fieldSymbolReference =
+        FieldSymbolReference.builder()
+            .setTargetClassName("ClassC")
+            .setFieldName("fieldX")
+            .setSourceClassName("ClassD")
+            .build();
 
-  static Builder builder() {
-    return new AutoValue_LinkageErrorMissingMethod.Builder();
-  }
-
-  @AutoValue.Builder
-  abstract static class Builder {
-    abstract Builder setReference(MethodSymbolReference value);
-    abstract LinkageErrorMissingMethod build();
+    Assert.assertEquals("ClassC", fieldSymbolReference.getTargetClassName());
+    Assert.assertEquals("fieldX", fieldSymbolReference.getFieldName());
+    Assert.assertEquals("ClassD", fieldSymbolReference.getSourceClassName());
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
@@ -25,28 +25,43 @@ public class JarLinkageReportTest {
 
   @Test
   public void testCreation() {
+    ClassSymbolReference classSymbolReference =
+        ClassSymbolReference.builder()
+            .setTargetClassName("ClassA")
+            .setSourceClassName("ClassB")
+            .build();
+    LinkageErrorMissingClass linkageErrorMissingClass =
+        LinkageErrorMissingClass.builder().setReference(classSymbolReference).build();
+
     ImmutableList<LinkageErrorMissingClass> linkageErrorMissingClasses =
-        ImmutableList.of(
-            LinkageErrorMissingClass.builder()
-                .setSourceClassName("ClassA")
-                .setTargetClassName("ClassB")
-                .build());
-    LinkageErrorMissingMethod linkageErrorMissingMethod =
-        LinkageErrorMissingMethod.builder()
+        ImmutableList.of(linkageErrorMissingClass);
+
+    MethodSymbolReference methodSymbolReference =
+        MethodSymbolReference.builder()
             .setTargetClassName("ClassA")
             .setMethodName("methodX")
             .setDescriptor("java.lang.String")
             .setSourceClassName("ClassB")
             .build();
+    LinkageErrorMissingMethod linkageErrorMissingMethod =
+        LinkageErrorMissingMethod.builder()
+            .setReference(methodSymbolReference)
+            .build();
     ImmutableList<LinkageErrorMissingMethod> missingMethodErrors =
         ImmutableList.of(linkageErrorMissingMethod);
+
+    FieldSymbolReference fieldSymbolReference =
+        FieldSymbolReference.builder()
+            .setTargetClassName("ClassC")
+            .setFieldName("fieldX")
+            .setSourceClassName("ClassD")
+            .build();
+    LinkageErrorMissingField linkageErrorMissingField =
+        LinkageErrorMissingField.builder()
+            .setReference(fieldSymbolReference)
+            .build();
     ImmutableList<LinkageErrorMissingField> missingFieldErrors =
-        ImmutableList.of(
-            LinkageErrorMissingField.builder()
-                .setTargetClassName("ClassC")
-                .setFieldName("fieldX")
-                .setSourceClassName("ClassD")
-                .build());
+        ImmutableList.of(linkageErrorMissingField);
     JarLinkageReport jarLinkageReport =
         JarLinkageReport.builder()
             .setJarPath(Paths.get("a", "b", "c"))

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingClassTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingClassTest.java
@@ -22,13 +22,14 @@ import org.junit.Test;
 public class LinkageErrorMissingClassTest {
   @Test
   public void testCreation() {
-    LinkageErrorMissingClass linkageErrorMissingClass =
-        LinkageErrorMissingClass.builder()
+    ClassSymbolReference classSymbolReference =
+        ClassSymbolReference.builder()
             .setTargetClassName("ClassA")
             .setSourceClassName("ClassB")
             .build();
+    LinkageErrorMissingClass linkageErrorMissingClass =
+        LinkageErrorMissingClass.builder().setReference(classSymbolReference).build();
 
-    Assert.assertEquals("ClassA", linkageErrorMissingClass.getTargetClassName());
-    Assert.assertEquals("ClassB", linkageErrorMissingClass.getSourceClassName());
+    Assert.assertEquals(classSymbolReference, linkageErrorMissingClass.getReference());
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingFieldTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingFieldTest.java
@@ -22,15 +22,17 @@ import org.junit.Test;
 public class LinkageErrorMissingFieldTest {
   @Test
   public void testCreation() {
-    LinkageErrorMissingField linkageErrorMissingField =
-        LinkageErrorMissingField.builder()
+    FieldSymbolReference fieldSymbolReference =
+        FieldSymbolReference.builder()
             .setTargetClassName("ClassC")
             .setFieldName("fieldX")
             .setSourceClassName("ClassD")
             .build();
+    LinkageErrorMissingField linkageErrorMissingField =
+        LinkageErrorMissingField.builder()
+            .setReference(fieldSymbolReference)
+            .build();
 
-    Assert.assertEquals("ClassC", linkageErrorMissingField.getTargetClassName());
-    Assert.assertEquals("fieldX", linkageErrorMissingField.getFieldName());
-    Assert.assertEquals("ClassD", linkageErrorMissingField.getSourceClassName());
+    Assert.assertEquals(fieldSymbolReference, linkageErrorMissingField.getReference());
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReferenceTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReferenceTest.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.opensource.classpath;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class LinkageErrorMissingMethodTest {
+public class MethodSymbolReferenceTest {
   @Test
   public void testCreation() {
     MethodSymbolReference methodSymbolReference =
@@ -29,11 +29,10 @@ public class LinkageErrorMissingMethodTest {
             .setDescriptor("java.lang.String")
             .setSourceClassName("ClassB")
             .build();
-    LinkageErrorMissingMethod linkageErrorMissingMethod =
-        LinkageErrorMissingMethod.builder()
-            .setReference(methodSymbolReference)
-            .build();
 
-    Assert.assertEquals(methodSymbolReference, linkageErrorMissingMethod.getReference());
+    Assert.assertEquals("ClassA", methodSymbolReference.getTargetClassName());
+    Assert.assertEquals("methodX", methodSymbolReference.getMethodName());
+    Assert.assertEquals("java.lang.String", methodSymbolReference.getDescriptor());
+    Assert.assertEquals("ClassB", methodSymbolReference.getSourceClassName());
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
@@ -43,7 +43,7 @@ public class StaticLinkageCheckOptionTest {
     StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArguments(arguments);
 
     Assert.assertEquals(ImmutableList.of("abc.com:abc:1.1", "abc.com:abc-util:1.2"),
-        parsedOption.getMavenCoordinates());
+        parsedOption.getMavenCoordinatesList());
     Assert.assertTrue(parsedOption.isReportOnlyReachable());
   }
 
@@ -68,7 +68,7 @@ public class StaticLinkageCheckOptionTest {
 
     Assert.assertTrue(parsedOption.getJarFileList().isEmpty());
     Assert.assertNull(parsedOption.getBomCoordinates());
-    Assert.assertTrue(parsedOption.getMavenCoordinates().isEmpty());
+    Assert.assertTrue(parsedOption.getMavenCoordinatesList().isEmpty());
     Assert.assertFalse(parsedOption.isReportOnlyReachable());
   }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.opensource.classpath;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.truth.Truth;
 import org.apache.commons.cli.ParseException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -31,8 +32,8 @@ public class StaticLinkageCheckOptionTest {
     StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArguments(arguments);
 
     Assert.assertEquals("abc.com:dummy:1.2", parsedOption.getBom());
-    Assert.assertTrue(parsedOption.getArtifacts().isEmpty());
-    Assert.assertTrue(parsedOption.getJarFiles().isEmpty());
+    Truth.assertThat(parsedOption.getArtifacts()).isEmpty();
+    Truth.assertThat(parsedOption.getJarFiles()).isEmpty();
     Assert.assertTrue(parsedOption.isReportOnlyReachable());
   }
 
@@ -57,7 +58,7 @@ public class StaticLinkageCheckOptionTest {
         "--report-only-reachable"
     };
     try {
-      StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArguments(arguments);
+      StaticLinkageCheckOption.parseArguments(arguments);
       Assert.fail();
     } catch (IllegalArgumentException ex) {
       // pass

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.opensource.classpath;
 
 import com.google.common.collect.ImmutableList;
-import java.nio.file.Paths;
 import org.apache.commons.cli.ParseException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -31,7 +30,7 @@ public class StaticLinkageCheckOptionTest {
     };
     StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArguments(arguments);
 
-    Assert.assertEquals("abc.com:dummy:1.2", parsedOption.getBomCoordinate());
+    Assert.assertEquals("abc.com:dummy:1.2", parsedOption.getBomCoordinates());
     Assert.assertTrue(parsedOption.isReportOnlyReachable());
   }
 
@@ -68,7 +67,7 @@ public class StaticLinkageCheckOptionTest {
     StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArguments(new String[0]);
 
     Assert.assertTrue(parsedOption.getJarFileList().isEmpty());
-    Assert.assertNull(parsedOption.getBomCoordinate());
+    Assert.assertNull(parsedOption.getBomCoordinates());
     Assert.assertTrue(parsedOption.getMavenCoordinates().isEmpty());
     Assert.assertFalse(parsedOption.isReportOnlyReachable());
   }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
@@ -24,38 +24,25 @@ import org.junit.Test;
 
 public class StaticLinkageCheckOptionTest {
   @Test
-  public void parseCommandLineOptions_shortOptions() throws ParseException {
+  public void parseCommandLineOptions_shortOptions_bom() throws ParseException {
     String[] arguments = new String[] {
         "-b", "abc.com:dummy:1.2",
-        "-c", "abc.com:abc:1.1,abc.com:abc-util:1.2",
-        "-j", "foo.jar,dir/bar.jar",
         "-r"
     };
     StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArguments(arguments);
 
-    Assert.assertEquals(parsedOption.getJarFileList(),
-        ImmutableList.of(Paths.get("foo.jar").toAbsolutePath(),
-            Paths.get("dir/bar.jar").toAbsolutePath()));
     Assert.assertEquals("abc.com:dummy:1.2", parsedOption.getBomCoordinate());
-    Assert.assertEquals(ImmutableList.of("abc.com:abc:1.1", "abc.com:abc-util:1.2"),
-        parsedOption.getMavenCoordinates());
     Assert.assertTrue(parsedOption.isReportOnlyReachable());
   }
 
   @Test
   public void parseCommandLineOptions_longOptions() throws ParseException {
     String[] arguments = new String[] {
-        "--bom", "abc.com:dummy:1.2",
         "--coordinate", "abc.com:abc:1.1,abc.com:abc-util:1.2",
-        "--jars", "foo.jar,dir/bar.jar",
         "--report-only-reachable"
     };
     StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArguments(arguments);
 
-    Assert.assertEquals(parsedOption.getJarFileList(),
-        ImmutableList.of(Paths.get("foo.jar").toAbsolutePath(),
-            Paths.get("dir/bar.jar").toAbsolutePath()));
-    Assert.assertEquals("abc.com:dummy:1.2", parsedOption.getBomCoordinate());
     Assert.assertEquals(ImmutableList.of("abc.com:abc:1.1", "abc.com:abc-util:1.2"),
         parsedOption.getMavenCoordinates());
     Assert.assertTrue(parsedOption.isReportOnlyReachable());

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
@@ -49,6 +49,21 @@ public class StaticLinkageCheckOptionTest {
   }
 
   @Test
+  public void parseCommandLineOptions_duplicates() throws ParseException {
+    String[] arguments = new String[] {
+        "--coordinate", "abc.com:abc:1.1,abc.com:abc-util:1.2",
+        "-b", "abc.com:dummy:1.2",
+        "--report-only-reachable"
+    };
+    try {
+      StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArguments(arguments);
+      Assert.fail();
+    } catch (IllegalArgumentException ex) {
+      // pass
+    }
+  }
+
+  @Test
   public void parseCommandLineOptions_emptyOption() throws ParseException {
     StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArguments(new String[0]);
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
@@ -31,7 +31,7 @@ public class StaticLinkageCheckOptionTest {
         "-j", "foo.jar,dir/bar.jar",
         "-r"
     };
-    StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArgument(arguments);
+    StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArguments(arguments);
 
     Assert.assertEquals(parsedOption.getJarFileList(),
         ImmutableList.of(Paths.get("foo.jar").toAbsolutePath(),
@@ -50,7 +50,7 @@ public class StaticLinkageCheckOptionTest {
         "--jars", "foo.jar,dir/bar.jar",
         "--report-only-reachable"
     };
-    StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArgument(arguments);
+    StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArguments(arguments);
 
     Assert.assertEquals(parsedOption.getJarFileList(),
         ImmutableList.of(Paths.get("foo.jar").toAbsolutePath(),
@@ -63,7 +63,7 @@ public class StaticLinkageCheckOptionTest {
 
   @Test
   public void parseCommandLineOptions_emptyOption() throws ParseException {
-    StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArgument(new String[0]);
+    StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArguments(new String[0]);
 
     Assert.assertTrue(parsedOption.getJarFileList().isEmpty());
     Assert.assertNull(parsedOption.getBomCoordinate());
@@ -77,7 +77,7 @@ public class StaticLinkageCheckOptionTest {
         "-x" // No such option
     };
     try {
-      StaticLinkageCheckOption.parseArgument(arguments);
+      StaticLinkageCheckOption.parseArguments(arguments);
       Assert.fail();
     } catch (ParseException ex) {
       Assert.assertEquals("Unrecognized option: -x", ex.getMessage());

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
@@ -31,6 +31,8 @@ public class StaticLinkageCheckOptionTest {
     StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArguments(arguments);
 
     Assert.assertEquals("abc.com:dummy:1.2", parsedOption.getBom());
+    Assert.assertTrue(parsedOption.getArtifacts().isEmpty());
+    Assert.assertTrue(parsedOption.getJarFiles().isEmpty());
     Assert.assertTrue(parsedOption.isReportOnlyReachable());
   }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
@@ -30,27 +30,27 @@ public class StaticLinkageCheckOptionTest {
     };
     StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArguments(arguments);
 
-    Assert.assertEquals("abc.com:dummy:1.2", parsedOption.getBomCoordinates());
+    Assert.assertEquals("abc.com:dummy:1.2", parsedOption.getBom());
     Assert.assertTrue(parsedOption.isReportOnlyReachable());
   }
 
   @Test
   public void parseCommandLineOptions_longOptions() throws ParseException {
     String[] arguments = new String[] {
-        "--coordinate", "abc.com:abc:1.1,abc.com:abc-util:1.2",
+        "--artifacts", "abc.com:abc:1.1,abc.com:abc-util:1.2",
         "--report-only-reachable"
     };
     StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArguments(arguments);
 
     Assert.assertEquals(ImmutableList.of("abc.com:abc:1.1", "abc.com:abc-util:1.2"),
-        parsedOption.getMavenCoordinatesList());
+        parsedOption.getArtifacts());
     Assert.assertTrue(parsedOption.isReportOnlyReachable());
   }
 
   @Test
   public void parseCommandLineOptions_duplicates() throws ParseException {
     String[] arguments = new String[] {
-        "--coordinate", "abc.com:abc:1.1,abc.com:abc-util:1.2",
+        "--artifacts", "abc.com:abc:1.1,abc.com:abc-util:1.2",
         "-b", "abc.com:dummy:1.2",
         "--report-only-reachable"
     };
@@ -66,9 +66,9 @@ public class StaticLinkageCheckOptionTest {
   public void parseCommandLineOptions_emptyOption() throws ParseException {
     StaticLinkageCheckOption parsedOption = StaticLinkageCheckOption.parseArguments(new String[0]);
 
-    Assert.assertTrue(parsedOption.getJarFileList().isEmpty());
-    Assert.assertNull(parsedOption.getBomCoordinates());
-    Assert.assertTrue(parsedOption.getMavenCoordinatesList().isEmpty());
+    Assert.assertTrue(parsedOption.getJarFiles().isEmpty());
+    Assert.assertNull(parsedOption.getBom());
+    Assert.assertTrue(parsedOption.getArtifacts().isEmpty());
     Assert.assertFalse(parsedOption.isReportOnlyReachable());
   }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckReportTest.java
@@ -22,36 +22,59 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class StaticLinkageCheckReportTest {
+  private static JarLinkageReport createDummyJarLinkageReport() {
+    ClassSymbolReference classSymbolReference =
+        ClassSymbolReference.builder()
+            .setTargetClassName("ClassA")
+            .setSourceClassName("ClassB")
+            .build();
+    LinkageErrorMissingClass linkageErrorMissingClass =
+        LinkageErrorMissingClass.builder().setReference(classSymbolReference).build();
 
-  @Test
-  public void testCreation() {
+    ImmutableList<LinkageErrorMissingClass> linkageErrorMissingClasses =
+        ImmutableList.of(linkageErrorMissingClass);
+
+    MethodSymbolReference methodSymbolReference =
+        MethodSymbolReference.builder()
+            .setTargetClassName("ClassA")
+            .setMethodName("methodX")
+            .setDescriptor("java.lang.String")
+            .setSourceClassName("ClassB")
+            .build();
+    LinkageErrorMissingMethod linkageErrorMissingMethod =
+        LinkageErrorMissingMethod.builder()
+            .setReference(methodSymbolReference)
+            .build();
+    ImmutableList<LinkageErrorMissingMethod> missingMethodErrors =
+        ImmutableList.of(linkageErrorMissingMethod);
+
+    FieldSymbolReference fieldSymbolReference =
+        FieldSymbolReference.builder()
+            .setTargetClassName("ClassC")
+            .setFieldName("fieldX")
+            .setSourceClassName("ClassD")
+            .build();
+    LinkageErrorMissingField linkageErrorMissingField =
+        LinkageErrorMissingField.builder()
+            .setReference(fieldSymbolReference)
+            .build();
+    ImmutableList<LinkageErrorMissingField> missingFieldErrors =
+        ImmutableList.of(linkageErrorMissingField);
     JarLinkageReport jarLinkageReport =
         JarLinkageReport.builder()
             .setJarPath(Paths.get("a", "b", "c"))
-            .setMissingClassErrors(
-                ImmutableList.of(
-                    LinkageErrorMissingClass.builder()
-                        .setTargetClassName("ClassA")
-                        .setSourceClassName("ClassB")
-                        .build()))
-            .setMissingMethodErrors(
-                ImmutableList.of(
-                    LinkageErrorMissingMethod.builder()
-                        .setTargetClassName("ClassA")
-                        .setMethodName("methodX")
-                        .setDescriptor("java.lang.String")
-                        .setSourceClassName("ClassB")
-                        .build()))
-            .setMissingFieldErrors(
-                ImmutableList.of(
-                    LinkageErrorMissingField.builder()
-                        .setTargetClassName("ClassC")
-                        .setFieldName("fieldX")
-                        .setSourceClassName("ClassD")
-                        .build()))
+            .setMissingClassErrors(linkageErrorMissingClasses)
+            .setMissingMethodErrors(missingMethodErrors)
+            .setMissingFieldErrors(missingFieldErrors)
             .build();
+    return jarLinkageReport;
+  }
+
+  @Test
+  public void testCreation() {
+    JarLinkageReport jarLinkageReport = createDummyJarLinkageReport();
     StaticLinkageCheckReport staticLinkageCheckReport =
-        StaticLinkageCheckReport.create(ImmutableList.of(jarLinkageReport));
+        StaticLinkageCheckReport.create(ImmutableList.of(createDummyJarLinkageReport()));
 
     Assert.assertEquals(1, staticLinkageCheckReport.getJarLinkageReports().size());
     Assert.assertEquals(jarLinkageReport, staticLinkageCheckReport.getJarLinkageReports().get(0));
@@ -62,6 +85,7 @@ public class StaticLinkageCheckReportTest {
             .get(0)
             .getMissingClassErrors()
             .get(0)
+            .getReference()
             .getTargetClassName());
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -96,10 +96,11 @@ public class StaticLinkageCheckerTest {
       throws IOException, ClassNotFoundException, URISyntaxException {
     URL jarFileUrl = URLClassLoader.getSystemResource(EXAMPLE_JAR_FILE);
 
-    StaticLinkageChecker staticLinkageChecker = new StaticLinkageChecker(
-        true,
-        ImmutableList.of(Paths.get(EXAMPLE_JAR_FILE)),
-        ImmutableSet.of(Paths.get(EXAMPLE_JAR_FILE)));
+    StaticLinkageChecker staticLinkageChecker =
+        StaticLinkageChecker.create(
+            true,
+            ImmutableList.of(Paths.get(EXAMPLE_JAR_FILE)),
+            ImmutableSet.of(Paths.get(EXAMPLE_JAR_FILE)));
 
     List<FullyQualifiedMethodSignature> signatures =
         staticLinkageChecker.listExternalMethodReferences(
@@ -126,10 +127,8 @@ public class StaticLinkageCheckerTest {
         absolutePathOfResource(EXAMPLE_PROTO_JAR_FILE));
     pathsForJar.addAll(FIRESTORE_DEPENDENCIES);
 
-    StaticLinkageChecker staticLinkageChecker = new StaticLinkageChecker(
-        true,
-        pathsForJar,
-        ImmutableSet.copyOf(pathsForJar));
+    StaticLinkageChecker staticLinkageChecker =
+        StaticLinkageChecker.create(true, pathsForJar, ImmutableSet.copyOf(pathsForJar));
 
     FullyQualifiedMethodSignature internalMethodReference =
         new FullyQualifiedMethodSignature(
@@ -172,8 +171,8 @@ public class StaticLinkageCheckerTest {
     );
     pathsForJar.addAll(FIRESTORE_DEPENDENCIES);
 
-    StaticLinkageChecker staticLinkageChecker = new StaticLinkageChecker(true, pathsForJar,
-        ImmutableSet.of(pathsForJar.get(0)));
+    StaticLinkageChecker staticLinkageChecker =
+        StaticLinkageChecker.create(true, pathsForJar, ImmutableSet.of(pathsForJar.get(0)));
     List<FullyQualifiedMethodSignature> report =
         staticLinkageChecker.findUnresolvedMethodReferences();
     Truth.assertThat(report.toString()).doesNotContain("com.google.api.pathtemplate.PathTemplate");
@@ -200,7 +199,7 @@ public class StaticLinkageCheckerTest {
             absolutePathOfResource("testdata/google-cloud-firestore-0.65.0-beta.jar"),
             absolutePathOfResource("testdata/google-cloud-firestore-0.66.0-beta.jar"));
     pathsForJarWithVersion65First.addAll(firestoreDependencies);
-    StaticLinkageChecker staticLinkageChecker65First = new StaticLinkageChecker(
+    StaticLinkageChecker staticLinkageChecker65First = StaticLinkageChecker.create(
         true,
         pathsForJarWithVersion65First,
         ImmutableSet.copyOf(pathsForJarWithVersion65First));
@@ -210,10 +209,11 @@ public class StaticLinkageCheckerTest {
             absolutePathOfResource("testdata/google-cloud-firestore-0.66.0-beta.jar"),
             absolutePathOfResource("testdata/google-cloud-firestore-0.65.0-beta.jar"));
     pathsForJarWithVersion66First.addAll(firestoreDependencies);
-    StaticLinkageChecker staticLinkageChecker66First = new StaticLinkageChecker(
-        true,
-        pathsForJarWithVersion66First,
-        ImmutableSet.copyOf(pathsForJarWithVersion66First));
+    StaticLinkageChecker staticLinkageChecker66First =
+        StaticLinkageChecker.create(
+            true,
+            pathsForJarWithVersion66First,
+            ImmutableSet.copyOf(pathsForJarWithVersion66First));
 
     FullyQualifiedMethodSignature methodAddedInVersion66 =
         new FullyQualifiedMethodSignature(
@@ -238,9 +238,8 @@ public class StaticLinkageCheckerTest {
   public void testFindUnresolvedReferences_packagePrivateInnerClass()
       throws RepositoryException, IOException, ClassNotFoundException {
     List<Path> paths = StaticLinkageChecker.coordinateToClasspath("io.grpc:grpc-auth:1.15.1");
-    StaticLinkageChecker staticLinkageChecker = new StaticLinkageChecker(
-        true,
-        paths, ImmutableSet.copyOf(paths));
+    StaticLinkageChecker staticLinkageChecker =
+        StaticLinkageChecker.create(true, paths, ImmutableSet.copyOf(paths));
 
     FullyQualifiedMethodSignature constructorOfPrivateInnerClass =
         new FullyQualifiedMethodSignature(
@@ -258,9 +257,9 @@ public class StaticLinkageCheckerTest {
   public void testNonExistentJarFileInput() throws ClassNotFoundException {
     try {
       Path nonExistentJar = Paths.get("nosuchfile.jar");
-      StaticLinkageChecker staticLinkageChecker = new StaticLinkageChecker(true,
-          ImmutableList.of(nonExistentJar),
-          ImmutableSet.of(nonExistentJar));
+      StaticLinkageChecker staticLinkageChecker =
+          StaticLinkageChecker.create(
+              true, ImmutableList.of(nonExistentJar), ImmutableSet.of(nonExistentJar));
       staticLinkageChecker.findUnresolvedMethodReferences();
       Assert.fail("findUnresolvedMethodReferences should raise IOException");
     } catch (IOException ex) {
@@ -326,10 +325,8 @@ public class StaticLinkageCheckerTest {
     List<Path> pathsForJar =
         Arrays.asList(
             Paths.get(URLClassLoader.getSystemResource("testdata/guava-26.0-jre.jar").toURI()));
-    StaticLinkageChecker staticLinkageChecker = new StaticLinkageChecker(
-        true,
-        pathsForJar,
-        ImmutableSet.copyOf(pathsForJar));
+    StaticLinkageChecker staticLinkageChecker =
+        StaticLinkageChecker.create(true, pathsForJar, ImmutableSet.copyOf(pathsForJar));
 
     List<FullyQualifiedMethodSignature> methodsNotFound =
         staticLinkageChecker.findUnresolvedReferences(
@@ -345,8 +342,8 @@ public class StaticLinkageCheckerTest {
     Truth.assertThat(paths).isNotEmpty();
 
     // Prior to class usage graph traversal, there was linkage error for lzma-java classes.
-    StaticLinkageChecker staticLinkageChecker = new StaticLinkageChecker(true, paths,
-        ImmutableSet.of(paths.get(0)));
+    StaticLinkageChecker staticLinkageChecker =
+        StaticLinkageChecker.create(true, paths, ImmutableSet.of(paths.get(0)));
     List<FullyQualifiedMethodSignature> unresolvedMethodReferences =
         staticLinkageChecker.findUnresolvedMethodReferences();
 
@@ -366,8 +363,8 @@ public class StaticLinkageCheckerTest {
     // grpc-netty-shaded pom.xml does not have dependency to lzma-java even though netty-codec
     // refers lzma.sdk.lzma.Encoder. StaticLinkageChecker should be able to detect it.
     boolean reportOnlyReachable = false;
-    StaticLinkageChecker staticLinkageChecker = new StaticLinkageChecker(reportOnlyReachable,
-        paths, ImmutableSet.copyOf(paths));
+    StaticLinkageChecker staticLinkageChecker =
+        StaticLinkageChecker.create(reportOnlyReachable, paths, ImmutableSet.copyOf(paths));
     List<FullyQualifiedMethodSignature> unresolvedMethodReferences =
         staticLinkageChecker.findUnresolvedMethodReferences();
 
@@ -386,8 +383,8 @@ public class StaticLinkageCheckerTest {
 
     // Prior to 'provided' scope inclusion, there was linkage error for classes in
     // com.google.appengine.api.urlfetch package.
-    StaticLinkageChecker staticLinkageChecker = new StaticLinkageChecker(true,
-        paths, ImmutableSet.of(paths.get(0)));
+    StaticLinkageChecker staticLinkageChecker =
+        StaticLinkageChecker.create(true, paths, ImmutableSet.of(paths.get(0)));
     List<FullyQualifiedMethodSignature> unresolvedMethodReferences =
         staticLinkageChecker.findUnresolvedMethodReferences();
 
@@ -405,10 +402,8 @@ public class StaticLinkageCheckerTest {
     List<Path> pathsForJar =
         Arrays.asList(
             Paths.get(URLClassLoader.getSystemResource("testdata/guava-26.0-jre.jar").toURI()));
-    StaticLinkageChecker staticLinkageChecker = new StaticLinkageChecker(
-        true,
-        pathsForJar,
-        ImmutableSet.copyOf(pathsForJar));
+    StaticLinkageChecker staticLinkageChecker =
+        StaticLinkageChecker.create(true, pathsForJar, ImmutableSet.copyOf(pathsForJar));
 
     List<FullyQualifiedMethodSignature> methodsNotFound =
         staticLinkageChecker.findUnresolvedReferences(

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -120,12 +120,11 @@ public class StaticLinkageCheckerTest {
   }
 
   @Test
-  public void testScanSymbolTableFromJar()
-      throws IOException, ClassNotFoundException, URISyntaxException {
+  public void testScanSymbolTableFromJar() throws URISyntaxException {
     URL jarFileUrl = URLClassLoader.getSystemResource(EXAMPLE_JAR_FILE);
 
     SymbolsInFile symbolsInFile =
-        StaticLinkageChecker.scanExternalSymbolTable(
+        StaticLinkageChecker.scanSymbolReferences(
             Paths.get(jarFileUrl.toURI()));
 
     Set<FieldSymbolReference> actualFieldReferences = symbolsInFile.getFieldReferences();
@@ -144,18 +143,6 @@ public class StaticLinkageCheckerTest {
             .setDescriptor("(Lcom/google/protobuf/Message;)Lio/grpc/MethodDescriptor$Marshaller;")
             .build();
     Truth.assertThat(actualMethodReferences).contains(expectedMethodReference);
-
-    Truth.assertWithMessage(
-        "scanExternalSymbolTable should not give references pointing to classes in the jar")
-        .that(actualMethodReferences)
-        .comparingElementsUsing(TARGET_CLASS_NAMES)
-        .containsNoneOf("com.google.firestore.v1beta1.FirestoreGrpc",
-            "com.google.firestore.v1beta1.FirestoreGrpc$FirestoreStub");
-
-    Set<String> classesDefinedInJar = symbolsInFile.getDefinedClassNames();
-    Truth.assertThat(classesDefinedInJar).contains("com.google.firestore.v1beta1.FirestoreGrpc");
-    Truth.assertThat(classesDefinedInJar)
-        .contains("com.google.firestore.v1beta1.FirestoreGrpc$FirestoreStub");
   }
 
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -420,7 +420,7 @@ public class StaticLinkageCheckerTest {
     StaticLinkageCheckOption parsedOption =
         StaticLinkageCheckOption.parseArguments(
             new String[] {
-              "--coordinate", mavenCoordinates
+              "--artifacts", mavenCoordinates
             });
 
     List<Path> inputClasspath =

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -124,18 +124,18 @@ public class StaticLinkageCheckerTest {
       throws IOException, ClassNotFoundException, URISyntaxException {
     URL jarFileUrl = URLClassLoader.getSystemResource(EXAMPLE_JAR_FILE);
 
-    SymbolTable symbolTable =
+    SymbolsInFile symbolsInFile =
         StaticLinkageChecker.scanExternalSymbolTable(
             Paths.get(jarFileUrl.toURI()));
 
-    Set<FieldSymbolReference> actualFieldReferences = symbolTable.getFieldReferences();
+    Set<FieldSymbolReference> actualFieldReferences = symbolsInFile.getFieldReferences();
     FieldSymbolReference expectedFieldReference =
         FieldSymbolReference.builder().setFieldName("BIDI_STREAMING")
         .setSourceClassName("com.google.firestore.v1beta1.FirestoreGrpc")
         .setTargetClassName("io.grpc.MethodDescriptor$MethodType").build();
     Truth.assertThat(actualFieldReferences).contains(expectedFieldReference);
 
-    Set<MethodSymbolReference> actualMethodReferences = symbolTable.getMethodReferences();
+    Set<MethodSymbolReference> actualMethodReferences = symbolsInFile.getMethodReferences();
     MethodSymbolReference expectedMethodReference =
         MethodSymbolReference.builder()
             .setTargetClassName("io.grpc.protobuf.ProtoUtils")
@@ -152,7 +152,7 @@ public class StaticLinkageCheckerTest {
         .containsNoneOf("com.google.firestore.v1beta1.FirestoreGrpc",
             "com.google.firestore.v1beta1.FirestoreGrpc$FirestoreStub");
 
-    Set<String> classesDefinedInJar = symbolTable.getDefinedClassNames();
+    Set<String> classesDefinedInJar = symbolsInFile.getDefinedClassNames();
     Truth.assertThat(classesDefinedInJar).contains("com.google.firestore.v1beta1.FirestoreGrpc");
     Truth.assertThat(classesDefinedInJar)
         .contains("com.google.firestore.v1beta1.FirestoreGrpc$FirestoreStub");

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -237,7 +237,7 @@ public class StaticLinkageCheckerTest {
   @Test
   public void testFindUnresolvedReferences_packagePrivateInnerClass()
       throws RepositoryException, IOException, ClassNotFoundException {
-    List<Path> paths = StaticLinkageChecker.coordinateToClasspath("io.grpc:grpc-auth:1.15.1");
+    List<Path> paths = StaticLinkageChecker.coordinatesToClasspath("io.grpc:grpc-auth:1.15.1");
     StaticLinkageChecker staticLinkageChecker =
         StaticLinkageChecker.create(true, paths, ImmutableSet.copyOf(paths));
 
@@ -269,7 +269,7 @@ public class StaticLinkageCheckerTest {
 
   @Test
   public void testCoordinateToClasspath_validCoordinate() throws RepositoryException {
-    List<Path> paths = StaticLinkageChecker.coordinateToClasspath("io.grpc:grpc-auth:1.15.1");
+    List<Path> paths = StaticLinkageChecker.coordinatesToClasspath("io.grpc:grpc-auth:1.15.1");
     Truth.assertThat(paths).hasSize(12);
 
     String pathsString = paths.toString();
@@ -289,7 +289,7 @@ public class StaticLinkageCheckerTest {
   @Test
   public void testCoordinateToClasspath_optionalDependency() throws RepositoryException {
     List<Path> paths =
-        StaticLinkageChecker.coordinateToClasspath(
+        StaticLinkageChecker.coordinatesToClasspath(
             "com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha");
 
     // The tree from google-cloud-bigtable to log4j:
@@ -306,7 +306,7 @@ public class StaticLinkageCheckerTest {
   @Test
   public void testCoordinateToClasspath_invalidCoordinate() {
     try {
-      StaticLinkageChecker.coordinateToClasspath("io.grpc:nosuchartifact:1.2.3");
+      StaticLinkageChecker.coordinatesToClasspath("io.grpc:nosuchartifact:1.2.3");
       Assert.fail("Invalid Maven coodinate should raise RepositoryException");
     } catch (RepositoryException ex) {
       Truth.assertThat(ex.getMessage())
@@ -337,8 +337,8 @@ public class StaticLinkageCheckerTest {
   @Test
   public void testFindUnresolvedReferences_unusedLzmaClassByGrpc()
       throws RepositoryException, IOException, ClassNotFoundException {
-    String bigTableCoordinate = "com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha";
-    List<Path> paths = StaticLinkageChecker.coordinateToClasspath(bigTableCoordinate);
+    String bigTableCoordinates = "com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha";
+    List<Path> paths = StaticLinkageChecker.coordinatesToClasspath(bigTableCoordinates);
     Truth.assertThat(paths).isNotEmpty();
 
     // Prior to class usage graph traversal, there was linkage error for lzma-java classes.
@@ -357,8 +357,8 @@ public class StaticLinkageCheckerTest {
   @Test
   public void testFindUnresolvedReferences_checkAllOption()
       throws RepositoryException, IOException, ClassNotFoundException {
-    String bigTableCoordinate = "com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha";
-    List<Path> paths = StaticLinkageChecker.coordinateToClasspath(bigTableCoordinate);
+    String bigTableCoordinates = "com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha";
+    List<Path> paths = StaticLinkageChecker.coordinatesToClasspath(bigTableCoordinates);
 
     // grpc-netty-shaded pom.xml does not have dependency to lzma-java even though netty-codec
     // refers lzma.sdk.lzma.Encoder. StaticLinkageChecker should be able to detect it.
@@ -378,8 +378,8 @@ public class StaticLinkageCheckerTest {
   @Test
   public void testFindUnresolvedReferences_appengineSdkWithProvidedScope()
       throws RepositoryException, IOException, ClassNotFoundException {
-    String bigTableCoordinate = "com.google.cloud:google-cloud-compute:jar:0.67.0-alpha";
-    List<Path> paths = StaticLinkageChecker.coordinateToClasspath(bigTableCoordinate);
+    String bigTableCoordinates = "com.google.cloud:google-cloud-compute:jar:0.67.0-alpha";
+    List<Path> paths = StaticLinkageChecker.coordinatesToClasspath(bigTableCoordinates);
 
     // Prior to 'provided' scope inclusion, there was linkage error for classes in
     // com.google.appengine.api.urlfetch package.

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -124,11 +124,6 @@ public class StaticLinkageCheckerTest {
       throws IOException, ClassNotFoundException, URISyntaxException {
     URL jarFileUrl = URLClassLoader.getSystemResource(EXAMPLE_JAR_FILE);
 
-    StaticLinkageChecker staticLinkageChecker = new StaticLinkageChecker(
-        true,
-        ImmutableList.of(Paths.get(EXAMPLE_JAR_FILE)),
-        ImmutableSet.of(Paths.get(EXAMPLE_JAR_FILE)));
-
     SymbolTable symbolTable =
         StaticLinkageChecker.scanExternalSymbolTable(
             Paths.get(jarFileUrl.toURI()));
@@ -161,8 +156,6 @@ public class StaticLinkageCheckerTest {
     Truth.assertThat(classesDefinedInJar).contains("com.google.firestore.v1beta1.FirestoreGrpc");
     Truth.assertThat(classesDefinedInJar)
         .contains("com.google.firestore.v1beta1.FirestoreGrpc$FirestoreStub");
-
-
   }
 
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -123,18 +123,18 @@ public class StaticLinkageCheckerTest {
   public void testScanSymbolTableFromJar() throws URISyntaxException {
     URL jarFileUrl = URLClassLoader.getSystemResource(EXAMPLE_JAR_FILE);
 
-    SymbolsInFile symbolsInFile =
-        StaticLinkageChecker.scanSymbolReferences(
+    SymbolReferenceSet symbolReferenceSet =
+        StaticLinkageChecker.scanSymbolReferencesInJar(
             Paths.get(jarFileUrl.toURI()));
 
-    Set<FieldSymbolReference> actualFieldReferences = symbolsInFile.getFieldReferences();
+    Set<FieldSymbolReference> actualFieldReferences = symbolReferenceSet.getFieldReferences();
     FieldSymbolReference expectedFieldReference =
         FieldSymbolReference.builder().setFieldName("BIDI_STREAMING")
         .setSourceClassName("com.google.firestore.v1beta1.FirestoreGrpc")
         .setTargetClassName("io.grpc.MethodDescriptor$MethodType").build();
     Truth.assertThat(actualFieldReferences).contains(expectedFieldReference);
 
-    Set<MethodSymbolReference> actualMethodReferences = symbolsInFile.getMethodReferences();
+    Set<MethodSymbolReference> actualMethodReferences = symbolReferenceSet.getMethodReferences();
     MethodSymbolReference expectedMethodReference =
         MethodSymbolReference.builder()
             .setTargetClassName("io.grpc.protobuf.ProtoUtils")

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -120,7 +120,7 @@ public class StaticLinkageCheckerTest {
   }
 
   @Test
-  public void testResolvedMethodReferences() {
+  public void testResolvedMethodReferences() throws IOException, ClassNotFoundException {
     List<Path> pathsForJar = Lists.newArrayList(
         absolutePathOfResource(EXAMPLE_JAR_FILE),
         absolutePathOfResource(EXAMPLE_PROTO_JAR_FILE));
@@ -186,7 +186,7 @@ public class StaticLinkageCheckerTest {
   }
 
   @Test
-  public void testJarPathOrderInResolvingReferences() {
+  public void testJarPathOrderInResolvingReferences() throws IOException, ClassNotFoundException  {
     // listDocuments method on CollectionReference class is added at version 0.66.0-beta
     // https://github.com/googleapis/google-cloud-java/releases/tag/v0.66.0
     List<Path> firestoreDependencies = Lists.newArrayList(
@@ -236,7 +236,7 @@ public class StaticLinkageCheckerTest {
 
   @Test
   public void testFindUnresolvedReferences_packagePrivateInnerClass()
-      throws RepositoryException {
+      throws RepositoryException, IOException, ClassNotFoundException {
     List<Path> paths = StaticLinkageChecker.coordinateToClasspath("io.grpc:grpc-auth:1.15.1");
     StaticLinkageChecker staticLinkageChecker = new StaticLinkageChecker(
         true,
@@ -316,7 +316,8 @@ public class StaticLinkageCheckerTest {
   }
 
   @Test
-  public void testInheritanceWithGuavaCollectionInheritance() throws URISyntaxException {
+  public void testInheritanceWithGuavaCollectionInheritance()
+      throws URISyntaxException, IOException, ClassNotFoundException {
     FullyQualifiedMethodSignature guavaCollectionPut =
         new FullyQualifiedMethodSignature(
             "com.google.common.collect.ArrayListMultimapGwtSerializationDependencies",
@@ -397,7 +398,7 @@ public class StaticLinkageCheckerTest {
   }
 
   @Test
-  public void testArrayCloneMethod() throws URISyntaxException {
+  public void testArrayCloneMethod() throws URISyntaxException, IOException, ClassNotFoundException {
     FullyQualifiedMethodSignature arrayCloneMethod =
         new FullyQualifiedMethodSignature(
             "[Lio.grpc.InternalKnownTransport;", "clone", "()Ljava/lang/Object");

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -120,33 +120,6 @@ public class StaticLinkageCheckerTest {
   }
 
   @Test
-  public void testScanSymbolTableFromJar() throws URISyntaxException {
-    URL jarFileUrl = URLClassLoader.getSystemResource(EXAMPLE_JAR_FILE);
-
-    SymbolReferenceSet symbolReferenceSet =
-        StaticLinkageChecker.scanSymbolReferencesInJar(
-            Paths.get(jarFileUrl.toURI()));
-
-    Set<FieldSymbolReference> actualFieldReferences = symbolReferenceSet.getFieldReferences();
-    FieldSymbolReference expectedFieldReference =
-        FieldSymbolReference.builder().setFieldName("BIDI_STREAMING")
-        .setSourceClassName("com.google.firestore.v1beta1.FirestoreGrpc")
-        .setTargetClassName("io.grpc.MethodDescriptor$MethodType").build();
-    Truth.assertThat(actualFieldReferences).contains(expectedFieldReference);
-
-    Set<MethodSymbolReference> actualMethodReferences = symbolReferenceSet.getMethodReferences();
-    MethodSymbolReference expectedMethodReference =
-        MethodSymbolReference.builder()
-            .setTargetClassName("io.grpc.protobuf.ProtoUtils")
-            .setMethodName("marshaller")
-            .setSourceClassName("com.google.firestore.v1beta1.FirestoreGrpc")
-            .setDescriptor("(Lcom/google/protobuf/Message;)Lio/grpc/MethodDescriptor$Marshaller;")
-            .build();
-    Truth.assertThat(actualMethodReferences).contains(expectedMethodReference);
-  }
-
-
-  @Test
   public void testResolvedMethodReferences() {
     List<Path> pathsForJar = Lists.newArrayList(
         absolutePathOfResource(EXAMPLE_JAR_FILE),

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolReferenceSetTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolReferenceSetTest.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class SymbolsInFileTest {
+public class SymbolReferenceSetTest {
   @Test
   public void testCreation() {
     ClassSymbolReference classSymbolReference =
@@ -42,15 +42,15 @@ public class SymbolsInFileTest {
             .setSourceClassName("ClassD")
             .build();
 
-    SymbolsInFile symbolsInFile = SymbolsInFile.builder().setClassReferences(
+    SymbolReferenceSet symbolReferenceSet = SymbolReferenceSet.builder().setClassReferences(
         ImmutableSet.of(classSymbolReference))
         .setFieldReferences(ImmutableSet.of(fieldSymbolReference))
         .setMethodReferences(ImmutableSet.of(methodSymbolReference))
         .build();
 
-    Assert.assertEquals(classSymbolReference, symbolsInFile.getClassReferences().iterator().next());
-    Assert.assertEquals(methodSymbolReference, symbolsInFile.getMethodReferences().iterator().next());
-    Assert.assertEquals(fieldSymbolReference, symbolsInFile.getFieldReferences().iterator().next());
+    Assert.assertEquals(classSymbolReference, symbolReferenceSet.getClassReferences().iterator().next());
+    Assert.assertEquals(methodSymbolReference, symbolReferenceSet.getMethodReferences().iterator().next());
+    Assert.assertEquals(fieldSymbolReference, symbolReferenceSet.getFieldReferences().iterator().next());
   }
 
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolTableTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolTableTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.classpath;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SymbolTableTest {
+  @Test
+  public void testCreation() {
+    ClassSymbolReference classSymbolReference =
+        ClassSymbolReference.builder()
+            .setTargetClassName("ClassA")
+            .setSourceClassName("ClassB")
+            .build();
+    MethodSymbolReference methodSymbolReference =
+        MethodSymbolReference.builder()
+            .setTargetClassName("ClassA")
+            .setMethodName("methodX")
+            .setDescriptor("java.lang.String")
+            .setSourceClassName("ClassB")
+            .build();
+    FieldSymbolReference fieldSymbolReference =
+        FieldSymbolReference.builder()
+            .setTargetClassName("ClassC")
+            .setFieldName("fieldX")
+            .setSourceClassName("ClassD")
+            .build();
+
+    SymbolTable symbolTable = SymbolTable.builder().setClassReferences(
+        ImmutableSet.of(classSymbolReference))
+        .setFieldReferences(ImmutableSet.of(fieldSymbolReference))
+        .setMethodReferences(ImmutableSet.of(methodSymbolReference))
+        .setDefinedClassNames(ImmutableSet.of(SymbolTableTest.class.getName()))
+        .build();
+
+    Assert.assertEquals(classSymbolReference, symbolTable.getClassReferences().iterator().next());
+    Assert.assertEquals(methodSymbolReference, symbolTable.getMethodReferences().iterator().next());
+    Assert.assertEquals(fieldSymbolReference, symbolTable.getFieldReferences().iterator().next());
+  }
+
+}

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolsInFileTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolsInFileTest.java
@@ -46,7 +46,6 @@ public class SymbolsInFileTest {
         ImmutableSet.of(classSymbolReference))
         .setFieldReferences(ImmutableSet.of(fieldSymbolReference))
         .setMethodReferences(ImmutableSet.of(methodSymbolReference))
-        .setDefinedClassNames(ImmutableSet.of(SymbolsInFileTest.class.getName()))
         .build();
 
     Assert.assertEquals(classSymbolReference, symbolsInFile.getClassReferences().iterator().next());

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolsInFileTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolsInFileTest.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class SymbolTableTest {
+public class SymbolsInFileTest {
   @Test
   public void testCreation() {
     ClassSymbolReference classSymbolReference =
@@ -42,16 +42,16 @@ public class SymbolTableTest {
             .setSourceClassName("ClassD")
             .build();
 
-    SymbolTable symbolTable = SymbolTable.builder().setClassReferences(
+    SymbolsInFile symbolsInFile = SymbolsInFile.builder().setClassReferences(
         ImmutableSet.of(classSymbolReference))
         .setFieldReferences(ImmutableSet.of(fieldSymbolReference))
         .setMethodReferences(ImmutableSet.of(methodSymbolReference))
-        .setDefinedClassNames(ImmutableSet.of(SymbolTableTest.class.getName()))
+        .setDefinedClassNames(ImmutableSet.of(SymbolsInFileTest.class.getName()))
         .build();
 
-    Assert.assertEquals(classSymbolReference, symbolTable.getClassReferences().iterator().next());
-    Assert.assertEquals(methodSymbolReference, symbolTable.getMethodReferences().iterator().next());
-    Assert.assertEquals(fieldSymbolReference, symbolTable.getFieldReferences().iterator().next());
+    Assert.assertEquals(classSymbolReference, symbolsInFile.getClassReferences().iterator().next());
+    Assert.assertEquals(methodSymbolReference, symbolsInFile.getMethodReferences().iterator().next());
+    Assert.assertEquals(fieldSymbolReference, symbolsInFile.getFieldReferences().iterator().next());
   }
 
 }


### PR DESCRIPTION
* Classes to represent symbolic references: `ClassSymbolReference`, `MethodSymbolReference`, `FieldSymbolReference` with AutoValue.

* The error classes (e.g., `LinkageErrorMissingField`) now have pointers to the references above.

* To represent a scan result of a jar, `SymbolTable` class is introduced to hold the set of these references above. StaticLinkageChecker.scanExternalSymbolTable generates a SymbolTable per jar file.

* new function `findLinkageErrors` is to start separating the logic of data extraction and validation. (previously, the validation was happening while data extraction progresses)

* `FullyQualifiedMethodReference` and `MethodSignature` classes are to be replaced with `MethodSymbolReference` class (not in this PR). So no need to review logics around FullyQualifiedMethodReference.

