### PR TITLE
StaticLinkageChecker to support BOM

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.stream.Stream;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -32,6 +33,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.eclipse.aether.RepositoryException;
+import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 
 /**
@@ -98,9 +100,10 @@ class StaticLinkageCheckOption {
     Splitter commaSplitter = Splitter.on(",");
 
     if (commandLine.hasOption("b")) {
-      String bomCoordinatesOption = commandLine.getOptionValue("b");
-      DefaultArtifact bomArtifact = new DefaultArtifact(bomCoordinatesOption);
-      return StaticLinkageChecker.artifactsToClasspath(RepositoryUtility.readBom(bomArtifact));
+      String bomCoordinates = commandLine.getOptionValue("b");
+      DefaultArtifact bomArtifact = new DefaultArtifact(bomCoordinates);
+      List<Artifact> artifactsInBom = RepositoryUtility.readBom(bomArtifact);
+      return StaticLinkageChecker.artifactsToClasspath(artifactsInBom);
     } else if (commandLine.hasOption("a")) {
       String mavenCoordinatesOption = commandLine.getOptionValue("a");
       return StaticLinkageChecker.artifactsToClasspath(

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
@@ -106,12 +106,13 @@ class StaticLinkageCheckOption {
       return StaticLinkageChecker.artifactsToClasspath(artifactsInBom);
     } else if (commandLine.hasOption("a")) {
       String mavenCoordinatesOption = commandLine.getOptionValue("a");
-      return StaticLinkageChecker.artifactsToClasspath(
+      ImmutableList<Artifact> artifacts =
           commaSplitter
               .splitToList(mavenCoordinatesOption)
               .stream()
               .map(DefaultArtifact::new)
-              .collect(toImmutableList()));
+              .collect(toImmutableList());
+      return StaticLinkageChecker.artifactsToClasspath(artifacts);
     } else if (commandLine.hasOption("j")) {
       String jarFiles = commandLine.getOptionValue("j");
       ImmutableList<Path> jarFilesInArguments =

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -28,11 +28,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.nio.file.Path;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -158,27 +158,30 @@ class StaticLinkageChecker {
   }
 
   /**
-   * Finds jar file paths for the dependencies of the Maven artifacts.
+   * Finds jar file paths for Maven artifacts and their the dependencies.
    *
-   * @param artifacts Maven artifacts to check its dependencies
+   * @param artifacts Maven artifacts to check
    * @return list of absolute paths to jar files
    * @throws RepositoryException when there is a problem in retrieving jar files
    */
   @VisibleForTesting
   static ImmutableList<Path> artifactsToClasspath(List<Artifact> artifacts)
       throws RepositoryException {
+    if (artifacts.isEmpty()) {
+      return ImmutableList.of();
+    }
     // dependencyGraph holds multiple versions for one artifact key (groupId:artifactId)
     DependencyGraph dependencyGraph =
         DependencyGraphBuilder.getStaticLinkageCheckDependencies(artifacts);
     List<DependencyPath> dependencyPaths = dependencyGraph.list();
 
     // Removes duplicates on (groupId:artifactId)
-    Set<String> artifactInPaths = new HashSet<>();
+    Set<String> artifactsInPaths = Sets.newHashSet();
 
     return dependencyPaths
         .stream()
         .map(DependencyPath::getLeaf)
-        .filter(artifact -> artifactInPaths.add(Artifacts.makeKey(artifact)))
+        .filter(artifact -> artifactsInPaths.add(Artifacts.makeKey(artifact)))
         .map(Artifact::getFile)
         .map(File::toPath)
         .map(Path::toAbsolutePath)

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -243,7 +243,8 @@ public class DependencyGraphBuilder {
         // set to null
         forPath.add(dependencyNode.getArtifact());
 
-        // Because DefaultDependencyNode does not override equals(), using Artifact::equals instead
+        // Because DependencyNode (or DefaultDependencyNode) does not override equals(),
+        // using Artifact::equals instead to check recursive dependency
         boolean artifactPresentInParent =
             parentNodes
                 .stream()

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -67,6 +67,7 @@ public class DependencyGraphBuilder {
     }
   }
 
+  // caching cuts time by about a factor of 4.
   private static final Map<String, DependencyNode> cacheWithProvidedScope = new HashMap<>();
   private static final Map<String, DependencyNode> cacheWithoutProvidedScope = new HashMap<>();
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -107,7 +107,7 @@ public class DependencyGraphBuilder {
 
     CollectRequest collectRequest = new CollectRequest();
     if (dependencyArtifacts.size() == 1) {
-      // With setRoot, Dependencies with `optional:true` or `provided` are fetched
+      // With setRoot, the result includes dependencies with `optional:true` or `provided`
       collectRequest.setRoot(dependencyList.get(0));
     } else {
       collectRequest.setDependencies(dependencyList);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -44,7 +44,7 @@ import org.eclipse.aether.resolution.DependencyResolutionException;
  * Based on the <a href="https://maven.apache.org/resolver/index.html">Apache Maven Artifact
  * Resolver</a> (formerly known as Eclipse Aether).
  */
-public class  DependencyGraphBuilder {
+public class DependencyGraphBuilder {
 
   private static final Logger logger = Logger.getLogger(DependencyGraphBuilder.class.getName());
   
@@ -107,7 +107,7 @@ public class  DependencyGraphBuilder {
 
     CollectRequest collectRequest = new CollectRequest();
     if (dependencyArtifacts.size() == 1) {
-      // Dependencies with `optional:true` or `provided` are fetched when requested from root
+      // With setRoot, Dependencies with `optional:true` or `provided` are fetched
       collectRequest.setRoot(dependencyList.get(0));
     } else {
       collectRequest.setDependencies(dependencyList);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -86,6 +86,8 @@ public class DependencyGraphBuilder {
       List<Artifact> dependencyArtifacts, boolean includeProvidedScope)
       throws DependencyCollectionException, DependencyResolutionException {
 
+    // Because this function is called only once with dependencyArtifacts.size() >= 2 (when running
+    // StaticLinkageChecker), no need to cache the result for such input
     boolean useCache = dependencyArtifacts.size() == 1;
     String cacheKey = Artifacts.toCoordinates(dependencyArtifacts.get(0));
     Map<String, DependencyNode> cache =
@@ -244,6 +246,7 @@ public class DependencyGraphBuilder {
   private static void levelOrder(
       DependencyNode firstNode, DependencyGraph graph, GraphTraversalOption graphTraversalOption)
       throws DependencyCollectionException, DependencyResolutionException {
+
     boolean resolveFullDependency = graphTraversalOption.resolveFullDependencies();
     Queue<LevelOrderQueueItem> queue = new ArrayDeque<>();
     queue.add(new LevelOrderQueueItem(firstNode, new Stack<>()));

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Stack;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import com.google.common.collect.ImmutableList;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.RepositorySystem;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -250,6 +250,7 @@ public class DependencyGraphBuilder {
     boolean resolveFullDependency = graphTraversalOption.resolveFullDependencies();
     Queue<LevelOrderQueueItem> queue = new ArrayDeque<>();
     queue.add(new LevelOrderQueueItem(firstNode, new Stack<>()));
+
     while (!queue.isEmpty()) {
       LevelOrderQueueItem item = queue.poll();
       DependencyNode dependencyNode = item.dependencyNode;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -86,11 +86,11 @@ public class DependencyGraphBuilder {
   private static DependencyNode resolveCompileTimeDependencies(
       List<Artifact> dependencyArtifacts, boolean includeProvidedScope)
       throws DependencyCollectionException, DependencyResolutionException {
+    // This cache is only used when dependencyArtifacts has 1 element
     Map<String, DependencyNode> cache =
         includeProvidedScope ? cacheWithProvidedScope : cacheWithoutProvidedScope;
-    String cacheKey =
-        dependencyArtifacts.stream().map(Artifacts::toCoordinates).collect(Collectors.joining(","));
-    if (cache.containsKey(cacheKey)) {
+    String cacheKey = Artifacts.toCoordinates(dependencyArtifacts.get(0));
+    if (dependencyArtifacts.size() == 1 && cache.containsKey(cacheKey)) {
       return cache.get(cacheKey);
     }
 
@@ -123,7 +123,9 @@ public class DependencyGraphBuilder {
     // This might be able to speed up by using collectDependencies here instead
     system.resolveDependencies(session, dependencyRequest);
 
-    cache.put(cacheKey, node);
+    if (dependencyArtifacts.size() == 0) {
+      cache.put(cacheKey, node);
+    }
     return node;
   }
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -190,15 +190,6 @@ public class DependencyGraphBuilder {
     return graph;
   }
 
-  static DependencyGraph getTransitiveDependencies(List<Artifact> artifacts)
-      throws DependencyCollectionException, DependencyResolutionException {
-    // root node artifact is null and the node has dependencies as children
-    DependencyNode node = resolveCompileTimeDependencies(artifacts, false);
-    DependencyGraph graph = new DependencyGraph();
-    levelOrder(node, graph);
-    return graph;
-  }
-
   private static final class LevelOrderQueueItem {
     final DependencyNode dependencyNode;
     final Stack<DependencyNode> parentNodes;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -274,19 +274,19 @@ public class DependencyGraphBuilder {
                 resolveCompileTimeDependencies(dependencyNode.getArtifact(), includeProvidedScope);
           } catch (DependencyResolutionException ex) {
             // A dependency may be unavailable any more. For example:
-            // com.google.guava:guava-gwt:jar:20.0 (compile) has transitive dependency to
+            // com.google.guava:guava-gwt:jar:20.0 (compile) has a transitive dependency to
             // org.eclipse.jdt.core.compiler:ecj:jar:4.4RC4 (not found in Maven central)
             logger.warning(
                 "Could not resolve "
                     + dependencyNode
                     + " under "
-                    + parentNodes
+                    + parentNodes // This shows "(compile?)" if optional:true
                     + " Exception: "
                     + ex.getMessage());
             boolean optionalParentCount =
                 parentNodes.stream().filter(node -> node.getDependency().isOptional()).count() > 0;
             if (!optionalParentCount) {
-              // When such unavailable dependency is not under `optional:true`, throw the exception
+              // When unavailable dependency is not under `optional:true`, rethrow the exception
               throw ex;
             }
           }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOptionTest.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class StaticLinkageCheckOptionTest {
+
   @Test
   public void parseCommandLineOptions_shortOptions_bom() throws ParseException {
     String[] arguments = {"-b", "abc.com:dummy:1.2", "-r"};

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -97,6 +97,12 @@ public class StaticLinkageCheckerTest {
   }
 
   @Test
+  public void testCoordinateToClasspath_emptyInput() throws RepositoryException {
+      List<Path> jars = StaticLinkageChecker.artifactsToClasspath(ImmutableList.of());
+      Truth.assertThat(jars).isEmpty();
+  }
+
+  @Test
   public void testFindInvalidReferences_selfReferenceFromAbstractClassToInterface()
       throws RepositoryException, IOException, ClassNotFoundException {
     String bigTableCoordinates = "com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha";

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -71,8 +71,8 @@ public class StaticLinkageCheckerTest {
     paths.forEach(
         path ->
             Truth.assertWithMessage("Every returned path should be an absolute path")
-                .that(path.toString())
-                .startsWith("/"));
+                .that(path.isAbsolute())
+                .isTrue());
   }
 
   @Test
@@ -194,7 +194,6 @@ public class StaticLinkageCheckerTest {
   @Test
   public void testGenerateInputClasspathFromLinkageCheckOption_mavenBom()
       throws RepositoryException, ParseException {
-    // This bom is installed locally by cloud-tools-opensource-boms module
     String bomCoordinates = "com.google.cloud:cloud-oss-bom:pom:1.0.0-SNAPSHOT";
     CommandLine parsedOption =
         StaticLinkageCheckOption.readCommandLine(new String[] {"-b", bomCoordinates});

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -29,6 +29,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import org.apache.commons.cli.ParseException;
 import org.eclipse.aether.RepositoryException;
+import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -56,35 +57,38 @@ public class StaticLinkageCheckerTest {
 
   @Test
   public void testCoordinateToClasspath_validCoordinate() throws RepositoryException {
-    List<Path> paths = StaticLinkageChecker.coordinatesToClasspath("io.grpc:grpc-auth:1.15.1");
-    Truth.assertThat(paths).hasSize(12);
+    List<Path> paths =
+        StaticLinkageChecker.artifactsToClasspath(
+            ImmutableList.of(new DefaultArtifact("io.grpc:grpc-auth:1.15.1")));
 
-    String pathsString = paths.toString();
-
-    Truth.assertThat(pathsString).contains("io/grpc/grpc-auth/1.15.1/grpc-auth-1.15.1.jar");
-    Truth.assertThat(pathsString)
-        .contains(
-            "com/google/auth/google-auth-library-credentials/0.9.0/google-auth-library-credentials-0.9.0.jar");
+    Truth.assertThat(paths).isNotEmpty();
+    Truth.assertThat(paths)
+        .comparingElementsUsing(PATH_FILE_NAMES)
+        .contains("grpc-auth-1.15.1.jar");
+    Truth.assertThat(paths)
+        .comparingElementsUsing(PATH_FILE_NAMES)
+        .contains("google-auth-library-credentials-0.9.0.jar");
     paths.forEach(
-        path -> {
-          Truth.assertWithMessage("Every returned path should be an absolute path")
-              .that(path.toString())
-              .startsWith("/");
-        });
+        path ->
+            Truth.assertWithMessage("Every returned path should be an absolute path")
+                .that(path.toString())
+                .startsWith("/"));
   }
 
   @Test
   public void testCoordinateToClasspath_optionalDependency() throws RepositoryException {
     List<Path> paths =
-        StaticLinkageChecker.coordinatesToClasspath(
-            "com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha");
+        StaticLinkageChecker.artifactsToClasspath(
+            ImmutableList.of(
+                new DefaultArtifact("com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha")));
     Truth.assertThat(paths).comparingElementsUsing(PATH_FILE_NAMES).contains("log4j-1.2.12.jar");
   }
 
   @Test
   public void testCoordinateToClasspath_invalidCoordinate() {
     try {
-      StaticLinkageChecker.coordinatesToClasspath("io.grpc:nosuchartifact:1.2.3");
+      StaticLinkageChecker.artifactsToClasspath(
+          ImmutableList.of(new DefaultArtifact("io.grpc:nosuchartifact:1.2.3")));
       Assert.fail("Invalid Maven coodinate should raise RepositoryException");
     } catch (RepositoryException ex) {
       Truth.assertThat(ex.getMessage())
@@ -96,7 +100,9 @@ public class StaticLinkageCheckerTest {
   public void testFindInvalidReferences_selfReferenceFromAbstractClassToInterface()
       throws RepositoryException, IOException, ClassNotFoundException {
     String bigTableCoordinates = "com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha";
-    List<Path> paths = StaticLinkageChecker.coordinatesToClasspath(bigTableCoordinates);
+    List<Path> paths =
+        StaticLinkageChecker.artifactsToClasspath(
+            ImmutableList.of(new DefaultArtifact(bigTableCoordinates)));
     Path httpClientJar =
         paths
             .stream()
@@ -181,7 +187,28 @@ public class StaticLinkageCheckerTest {
   }
 
   @Test
-  public void testGenerateInputClasspathFromArgument_mavenCoordinates()
+  public void testGenerateInputClasspathFromLinkageCheckOption_mavenBom()
+      throws RepositoryException, ParseException {
+    // This bom is installed locally by cloud-tools-opensource-boms module
+    String bomCoordinates = "com.google.cloud:cloud-oss-bom:pom:1.0.0-SNAPSHOT";
+    StaticLinkageCheckOption parsedOption =
+        StaticLinkageCheckOption.parseArguments(new String[] {"-b", bomCoordinates});
+    ImmutableList<Path> inputClasspath =
+        StaticLinkageChecker.generateInputClasspathFromLinkageCheckOption(parsedOption);
+    Truth.assertThat(inputClasspath).isNotEmpty();
+    Truth.assertWithMessage("The files should match the elements in the BOM")
+        .that(inputClasspath.subList(0, 3))
+        .comparingElementsUsing(PATH_FILE_NAMES)
+        .containsExactly("guava-20.0.jar", "guava-gwt-20.0.jar", "guava-testlib-20.0.jar");
+
+    Truth.assertWithMessage("Import dependency in BOM should be resolved")
+        .that(inputClasspath)
+        .comparingElementsUsing(PATH_FILE_NAMES)
+        .contains("google-cloud-firestore-0.69.0-beta.jar");
+  }
+
+  @Test
+  public void testGenerateInputClasspathFromLinkageCheckOption_mavenCoordinates()
       throws RepositoryException, ParseException {
     String mavenCoordinates =
         "com.google.cloud:google-cloud-compute:jar:0.67.0-alpha,"
@@ -189,17 +216,65 @@ public class StaticLinkageCheckerTest {
     StaticLinkageCheckOption parsedOption =
         StaticLinkageCheckOption.parseArguments(new String[] {"--artifacts", mavenCoordinates});
 
-    List<Path> inputClasspath =
+    ImmutableList<Path> inputClasspath =
+        StaticLinkageChecker.generateInputClasspathFromLinkageCheckOption(parsedOption);
+
+    Truth.assertWithMessage(
+            "The first 2 items in the classpath should be the 2 artifacts in the input")
+        .that(inputClasspath.subList(0, 2))
+        .comparingElementsUsing(PATH_FILE_NAMES)
+        .containsExactly(
+            "google-cloud-compute-0.67.0-alpha.jar", "google-cloud-bigtable-0.66.0-alpha.jar")
+        .inOrder();
+    Truth.assertWithMessage("The dependencies of the 2 artifacts should also be included")
+        .that(inputClasspath.subList(2, inputClasspath.size()))
+        .isNotEmpty();
+  }
+
+  @Test
+  public void testGenerateInputClasspathFromLinkageCheckOption_mavenCoordinates_missingDependency()
+      throws RepositoryException, ParseException {
+    // apache-jsp has missing transitive optional dependency:
+    //   org.mortbay.jasper:apache-jsp:jar:8.0.9.M3
+    //     org.apache.tomcat:tomcat-jasper:jar:8.0.9 (compile, optional:true)
+    //       org.eclipse.jdt.core.compiler:ecj:jar:4.4RC4 (not found in Maven central)
+
+    // Because such case is possible, StaticLinkageChecker should not abort execution when such
+    // dependency is under `optional:true`.
+    StaticLinkageCheckOption parsedOption =
+        StaticLinkageCheckOption.parseArguments(
+            new String[] {"--artifacts", "org.mortbay.jasper:apache-jsp:jar:8.0.9.M3"});
+
+    ImmutableList<Path> inputClasspath =
         StaticLinkageChecker.generateInputClasspathFromLinkageCheckOption(parsedOption);
 
     Truth.assertThat(inputClasspath)
         .comparingElementsUsing(PATH_FILE_NAMES)
-        .containsAllOf(
-            "google-cloud-compute-0.67.0-alpha.jar", "google-cloud-bigtable-0.66.0-alpha.jar");
+        .contains("apache-jsp-8.0.9.M3.jar");
   }
 
   @Test
-  public void testGenerateInputClasspathFromArgument_jarFileList()
+  public void testGenerateInputClasspathFromLinkageCheckOption_failOnMissingDependency()
+      throws ParseException {
+    // tomcat-jasper has missing dependency (not optional):
+    //   org.apache.tomcat:tomcat-jasper:jar:8.0.9
+    //     org.eclipse.jdt.core.compiler:ecj:jar:4.4RC4 (not found in Maven central)
+    StaticLinkageCheckOption parsedOption =
+        StaticLinkageCheckOption.parseArguments(
+            new String[] {"--artifacts", "org.apache.tomcat:tomcat-jasper:8.0.9"});
+
+    try {
+      StaticLinkageChecker.generateInputClasspathFromLinkageCheckOption(parsedOption);
+      Assert.fail();
+    } catch (RepositoryException ex) {
+      Truth.assertThat(ex.getMessage())
+          .startsWith(
+              "Could not find artifact org.eclipse.jdt.core.compiler:ecj:jar:4.4RC4 in central");
+    }
+  }
+
+  @Test
+  public void testGenerateInputClasspathFromLinkageCheckOption_jarFileList()
       throws RepositoryException, ParseException {
     StaticLinkageCheckOption parsedOption =
         StaticLinkageCheckOption.parseArguments(

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -195,6 +195,7 @@ public class StaticLinkageCheckerTest {
   public void testGenerateInputClasspathFromLinkageCheckOption_mavenBom()
       throws RepositoryException, ParseException {
     String bomCoordinates = "com.google.cloud:cloud-oss-bom:pom:1.0.0-SNAPSHOT";
+
     CommandLine parsedOption =
         StaticLinkageCheckOption.readCommandLine(new String[] {"-b", bomCoordinates});
     ImmutableList<Path> inputClasspath =
@@ -220,6 +221,7 @@ public class StaticLinkageCheckerTest {
         "com.google.cloud:google-cloud-compute:jar:0.67.0-alpha,"
             + "com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha";
     String[] arguments = {"--artifacts", mavenCoordinates};
+
     CommandLine parsedOption = StaticLinkageCheckOption.readCommandLine(arguments);
     List<Path> inputClasspath = StaticLinkageCheckOption.generateInputClasspath(parsedOption);
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -240,16 +240,18 @@ public class StaticLinkageCheckerTest {
   @Test
   public void testGenerateInputClasspathFromLinkageCheckOption_mavenCoordinates_missingDependency()
       throws RepositoryException, ParseException {
-    // apache-jsp has missing transitive optional dependency:
-    //   org.mortbay.jasper:apache-jsp:jar:8.0.9.M3
-    //     org.apache.tomcat:tomcat-jasper:jar:8.0.9 (compile, optional:true)
-    //       org.eclipse.jdt.core.compiler:ecj:jar:4.4RC4 (not found in Maven central)
-
+    // guava-gwt has missing transitive dependency:
+    //   com.google.guava:guava-gwt:jar:20.0
+    //     com.google.gwt:gwt-dev:jar:2.8.0 (provided)
+    //       org.eclipse.jetty:apache-jsp:jar:9.2.14.v20151106 (compile)
+    //         org.mortbay.jasper:apache-jsp:jar:8.0.9.M3 (compile)
+    //           org.apache.tomcat:tomcat-jasper:jar:8.0.9 (compile, optional:true)
+    //             org.eclipse.jdt.core.compiler:ecj:jar:4.4RC4 (not found in Maven central)
     // Because such case is possible, StaticLinkageChecker should not abort execution when
-    // the unavailable dependency is under `optional:true`
+    // the unavailable dependency is under certain condition
     StaticLinkageCheckOption parsedOption =
         StaticLinkageCheckOption.parseArguments(
-            new String[] {"--artifacts", "org.mortbay.jasper:apache-jsp:jar:8.0.9.M3"});
+            new String[] {"--artifacts", "com.google.guava:guava-gwt:20.0"});
 
     ImmutableList<Path> inputClasspath =
         StaticLinkageChecker.generateInputClasspathFromLinkageCheckOption(parsedOption);

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -245,8 +245,8 @@ public class StaticLinkageCheckerTest {
     //     org.apache.tomcat:tomcat-jasper:jar:8.0.9 (compile, optional:true)
     //       org.eclipse.jdt.core.compiler:ecj:jar:4.4RC4 (not found in Maven central)
 
-    // Because such case is possible, StaticLinkageChecker should not abort execution when such
-    // dependency is under `optional:true`.
+    // Because such case is possible, StaticLinkageChecker should not abort execution when
+    // the unavailable dependency is under `optional:true`
     StaticLinkageCheckOption parsedOption =
         StaticLinkageCheckOption.parseArguments(
             new String[] {"--artifacts", "org.mortbay.jasper:apache-jsp:jar:8.0.9.M3"});
@@ -271,7 +271,8 @@ public class StaticLinkageCheckerTest {
 
     try {
       StaticLinkageChecker.generateInputClasspathFromLinkageCheckOption(parsedOption);
-      Assert.fail();
+      Assert.fail(
+          "Because the unavailable dependency is not optional, it should throw an exception");
     } catch (RepositoryException ex) {
       Truth.assertThat(ex.getMessage())
           .startsWith(

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -62,7 +62,6 @@ public class StaticLinkageCheckerTest {
         StaticLinkageChecker.artifactsToClasspath(
             ImmutableList.of(new DefaultArtifact("io.grpc:grpc-auth:1.15.1")));
 
-    Truth.assertThat(paths).isNotEmpty();
     Truth.assertThat(paths)
         .comparingElementsUsing(PATH_FILE_NAMES)
         .contains("grpc-auth-1.15.1.jar");
@@ -202,11 +201,13 @@ public class StaticLinkageCheckerTest {
     ImmutableList<Path> inputClasspath =
         StaticLinkageCheckOption.generateInputClasspath(parsedOption);
     Truth.assertThat(inputClasspath).isNotEmpty();
+    // These 3 files are the first 3 artifacts in the BOM
     Truth.assertWithMessage("The files should match the elements in the BOM")
         .that(inputClasspath.subList(0, 3))
         .comparingElementsUsing(PATH_FILE_NAMES)
         .containsExactly("guava-20.0.jar", "guava-gwt-20.0.jar", "guava-testlib-20.0.jar");
 
+    // google-cloud-bom, containing google-cloud-firestore, is in the BOM with scope:import
     Truth.assertWithMessage("Import dependency in BOM should be resolved")
         .that(inputClasspath)
         .comparingElementsUsing(PATH_FILE_NAMES)

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -90,18 +90,22 @@ public class DependencyGraphBuilderTest {
   }
 
   @Test
-  public void testGetTransitiveDependenciesWithMultipleArtifacts()
+  public void testGetStaticLinkageCheckDependencies_multipleArtifacts()
       throws DependencyCollectionException, DependencyResolutionException {
     DependencyGraph graph =
-        DependencyGraphBuilder.getTransitiveDependencies(Arrays.asList(datastore, guava));
+        DependencyGraphBuilder.getStaticLinkageCheckDependencies(Arrays.asList(datastore, guava));
 
     List<DependencyPath> list = graph.list();
     Assert.assertTrue(list.size() > 10);
     DependencyPath firstElement = list.get(0);
-    Assert.assertEquals("BFS should pick up datastore as first element in the list",
-        "google-cloud-datastore", firstElement.getLeaf().getArtifactId());
+    Assert.assertEquals(
+        "Level-order should pick up datastore as first element in the list",
+        "google-cloud-datastore",
+        firstElement.getLeaf().getArtifactId());
     DependencyPath secondElement = list.get(1);
-    Assert.assertEquals("BFS should pick up guava before dependencies from datastore",
-        "guava", secondElement.getLeaf().getArtifactId());
+    Assert.assertEquals(
+        "BFS should pick up guava before dependencies from datastore",
+        "guava",
+        secondElement.getLeaf().getArtifactId());
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -104,7 +104,7 @@ public class DependencyGraphBuilderTest {
         firstElement.getLeaf().getArtifactId());
     DependencyPath secondElement = list.get(1);
     Assert.assertEquals(
-        "BFS should pick up guava before dependencies from datastore",
+        "Level-order should pick up guava before the dependencies of the two",
         "guava",
         secondElement.getLeaf().getArtifactId());
   }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
@@ -104,7 +104,7 @@ public class DependencyGraphIntegrationTest {
     Truth.assertThat(updates).hasSize(5);
     
     List<DependencyPath> conflicts = graph.findConflicts();
-    Truth.assertThat(conflicts).hasSize(34);
+    Truth.assertThat(conflicts).hasSize(33);
     
     Map<String, String> versions = graph.getHighestVersionMap();
     Assert.assertEquals("2.6.2", versions.get("xerces:xercesImpl"));

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
@@ -104,7 +104,7 @@ public class DependencyGraphIntegrationTest {
     Truth.assertThat(updates).hasSize(5);
     
     List<DependencyPath> conflicts = graph.findConflicts();
-    Truth.assertThat(conflicts).hasSize(33);
+    Truth.assertThat(conflicts).hasSize(34);
     
     Map<String, String> versions = graph.getHighestVersionMap();
     Assert.assertEquals("2.6.2", versions.get("xerces:xercesImpl"));


### PR DESCRIPTION
Fixes #221.

-  `generateInputClasspathFromLinkageCheckOption` leverages `RepositoryUtility.readBom` to get  artifacts from a BOM
- `StaticLinkageChecker.artifactsToClasspath` to handle artifacts to classpath (jar list) conversion
- `DependencyGraphBuilder.resolveCompileTimeDependencies` had two (similar) overloaded implementations for 1 item and multiple items. They are now merged.
- Added test to confirm BOM to classpath conversion works fine.


