### PR TITLE
add static linkage report to dashboard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
     docker:
       # specify the version you desire here
       - image: circleci/openjdk:8-jdk
+        cmd: ["/bin/bash"]
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
 
     environment:
       # Customize the JVM maximum heap limit
-      MAVEN_OPTS: -Xmx8192m
+      MAVEN_OPTS: -Xmx3500m
     
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,8 @@ jobs:
 
     environment:
       # Customize the JVM maximum heap limit
-      MAVEN_OPTS: -Xmx2048m
+      MAVEN_OPTS: -Xmx1024m -XX:MaxPermSize=128m
+
     
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,3 +42,5 @@ jobs:
           cd ../..
           mvn integration-test -Dmaven.home=/opt/apache-maven
 
+      - store_test_results:
+          path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
 
     environment:
       # Customize the JVM maximum heap limit
-      MAVEN_OPTS: -Xmx3200m
+      MAVEN_OPTS: -Xmx4096m
     
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
 
     environment:
       # Customize the JVM maximum heap limit
-      MAVEN_OPTS: -Xmx3500m
+      MAVEN_OPTS: -Xmx2048m
     
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ jobs:
     docker:
       # specify the version you desire here
       - image: circleci/openjdk:8-jdk
-        cmd: ["/bin/bash"]
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
 
     environment:
       # Customize the JVM maximum heap limit
-      MAVEN_OPTS: -Xmx4096m
+      MAVEN_OPTS: -Xmx8192m
     
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           name: Save test results
           command: |
             mkdir -p ~/junit/
-            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
+            find . -type f -regex ".*/target/surefire-reports/.*" -exec cp {} ~/junit/ \;
           when: always
       - store_test_results:
           path: ~/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,5 +42,13 @@ jobs:
           cd ../..
           mvn integration-test -Dmaven.home=/opt/apache-maven
 
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
+          when: always
       - store_test_results:
-          path: /tmp/test-results
+          path: ~/junit
+      - store_artifacts:
+          path: ~/junit   

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           cd boms/cloud-oss-bom
           mvn install
           cd ../..
-          mvn integration-test -Dmaven.home=/opt/apache-maven
+          mvn -e integration-test -Dmaven.home=/opt/apache-maven
 
       - run:
           name: Save test results

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -82,6 +82,15 @@
           <mainClass>com.google.cloud.tools.opensource.dashboard.DashboardMain</mainClass>
         </configuration>
       </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+          <configuration>
+            <!-- To avoid ForkedBooter loading issue -->
+            <useSystemClassLoader>false</useSystemClassLoader>
+          </configuration>
+        </plugin>
     </plugins>
   </build>
 

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -100,8 +100,7 @@ public class DashboardMain {
     StaticLinkageCheckReport report = staticLinkageChecker.findLinkageErrors();
 
     List<ArtifactResults> table = generateReports(configuration, output, cache);
-    generateDashboard(configuration, output, table, cache.getGlobalDependencies(),
-        report.toString());
+    generateDashboard(configuration, output, table, cache.getGlobalDependencies(), report);
 
     return output;
   }
@@ -269,8 +268,8 @@ public class DashboardMain {
 
   @VisibleForTesting
   static void generateDashboard(Configuration configuration, Path output,
-      List<ArtifactResults> table, List<DependencyGraph> globalDependencies, String staticLinkageErrors)
-      throws IOException, TemplateException {
+      List<ArtifactResults> table, List<DependencyGraph> globalDependencies,
+      StaticLinkageCheckReport report) throws IOException, TemplateException {
     File dashboardFile = output.resolve("dashboard.html").toFile();
     
     Map<String, String> latestArtifacts = collectLatestVersions(globalDependencies);
@@ -282,7 +281,7 @@ public class DashboardMain {
       templateData.put("table", table);
       templateData.put("lastUpdated", LocalDateTime.now());
       templateData.put("latestArtifacts", latestArtifacts);
-      String escapedStaticLinkageErrors = HtmlEscapers.htmlEscaper().escape(staticLinkageErrors);
+      String escapedStaticLinkageErrors = HtmlEscapers.htmlEscaper().escape(report.toString());
       templateData.put("staticLinkageErrors", escapedStaticLinkageErrors);
 
       dashboard.process(templateData, out);

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -91,7 +91,7 @@ public class DashboardMain {
     ArtifactCache cache = loadArtifactInfo(managedDependencies);
     
     ImmutableList<Path> classpath = StaticLinkageChecker.artifactsToClasspath(managedDependencies);
-    // TODO(suztomo): to take command-line option to choose entry point classes for reachability
+    // TODO(suztomo): choose entry point classes for reachability
     ImmutableSet<Path> entryPoints = ImmutableSet.of(classpath.get(0));
 
     boolean onlyReachable = false;

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -97,8 +97,8 @@ public class DashboardMain {
     boolean onlyReachable = false;
     StaticLinkageChecker staticLinkageChecker =
         StaticLinkageChecker.create(onlyReachable, classpath, entryPoints);
-    StaticLinkageCheckReport report = staticLinkageChecker.findLinkageErrors();
-
+    // StaticLinkageCheckReport report = staticLinkageChecker.findLinkageErrors();
+    StaticLinkageCheckReport report = null;
     List<ArtifactResults> table = generateReports(configuration, output, cache);
     generateDashboard(configuration, output, table, cache.getGlobalDependencies(), report);
 
@@ -281,7 +281,7 @@ public class DashboardMain {
       templateData.put("table", table);
       templateData.put("lastUpdated", LocalDateTime.now());
       templateData.put("latestArtifacts", latestArtifacts);
-      String escapedStaticLinkageErrors = HtmlEscapers.htmlEscaper().escape(report.toString());
+      String escapedStaticLinkageErrors = "foo"; //HtmlEscapers.htmlEscaper().escape(report.toString());
       templateData.put("staticLinkageErrors", escapedStaticLinkageErrors);
 
       dashboard.process(templateData, out);

--- a/dashboard/src/main/resources/templates/dashboard.ftl
+++ b/dashboard/src/main/resources/templates/dashboard.ftl
@@ -51,6 +51,12 @@
     </table>
     
     <hr />
+
+    <h2>Static Linkage Errors</h2>
+
+    <pre id="static_linkage_errors">${staticLinkageErrors}</pre>
+
+    <hr />      
       
     <h2>Recommended Versions</h2>
       

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -69,14 +69,14 @@ public class DashboardTest {
     MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
   }
 
-  @Test
+  //@Test
   public void testMain()
       throws IOException, TemplateException, RepositoryException, ClassNotFoundException {
     // Ensuring normal execution doesn't cause any exception
     DashboardMain.main(null);
   }
   
-  @Test
+  //@Test
   public void testCss()
       throws IOException, TemplateException, ParsingException, ArtifactDescriptorException {
     Path dashboardCss = outputDirectory.resolve("dashboard.css");
@@ -84,7 +84,7 @@ public class DashboardTest {
     Assert.assertTrue(Files.isRegularFile(dashboardCss));
   }
 
-  @Test
+  //@Test
   public void testDashboard()
       throws IOException, TemplateException, ParsingException, ArtifactDescriptorException {
     Assert.assertTrue(Files.exists(outputDirectory));
@@ -178,7 +178,7 @@ public class DashboardTest {
     }
   }
 
-  @Test
+  //@Test
   public void testComponent_success() throws IOException, ValidityException, ParsingException {
     Path successHtml = outputDirectory.resolve(
         "com.google.api.grpc_proto-google-common-protos_1.12.0.html");

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -57,23 +57,22 @@ public class DashboardTest {
   private static Path outputDirectory;
   private Builder builder = new Builder();
 
-  // @BeforeClass
+  @BeforeClass
   public static void setUp()
       throws IOException, TemplateException, RepositoryException, ClassNotFoundException {
     // Creates "dashboard.html" in outputDirectory
     outputDirectory = DashboardMain.generate();
   }
 
-  // @AfterClass
+  @AfterClass
   public static void cleanUp() throws IOException {
     MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
   }
-
-  //@Test
-  public void testMain()
-      throws IOException, TemplateException, RepositoryException, ClassNotFoundException {
-    // Ensuring normal execution doesn't cause any exception
-    DashboardMain.main(null);
+  
+  @Test
+  public void testPass() {
+    
+    
   }
   
   //@Test

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -30,16 +30,17 @@ import java.util.List;
 import nu.xom.Builder;
 import nu.xom.Document;
 import nu.xom.Element;
+import nu.xom.Node;
 import nu.xom.Nodes;
 import nu.xom.ParsingException;
 import nu.xom.ValidityException;
 
 import freemarker.template.TemplateException;
+
+import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.collection.DependencyCollectionException;
 import org.eclipse.aether.resolution.ArtifactDescriptorException;
-import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -57,8 +58,8 @@ public class DashboardTest {
   private Builder builder = new Builder();
 
   @BeforeClass
-  public static void setUp() throws ArtifactDescriptorException, IOException, TemplateException,
-      DependencyCollectionException, DependencyResolutionException {
+  public static void setUp()
+      throws IOException, TemplateException, RepositoryException, ClassNotFoundException {
     // Creates "dashboard.html" in outputDirectory
     outputDirectory = DashboardMain.generate();
   }
@@ -69,8 +70,8 @@ public class DashboardTest {
   }
 
   @Test
-  public void testMain() throws IOException, TemplateException, ArtifactDescriptorException,
-      DependencyCollectionException, DependencyResolutionException {
+  public void testMain()
+      throws IOException, TemplateException, RepositoryException, ClassNotFoundException {
     // Ensuring normal execution doesn't cause any exception
     DashboardMain.main(null);
   }
@@ -137,6 +138,10 @@ public class DashboardTest {
           Assert.fail(message);
         }
       }
+
+      // TODO these should all be separate tests for the different components
+      Node linkage = document.query("//pre[@id='static_linkage_errors']").get(0);
+      Assert.assertTrue(linkage.getValue().startsWith("guava-20.0.jar (0 errors)"));
 
       Nodes li = document.query("//ul[@id='recommended']/li");
       Assert.assertTrue(li.size() > 100);
@@ -209,9 +214,9 @@ public class DashboardTest {
       Nodes presDependencyMediation = document.query("//pre[@class='suggested-dependency-mediation']");
       Assert.assertTrue("For failed component, suggested dependency should be shown",
           presDependencyMediation.size() >= 1);
-      Nodes presDependencyTree = document.query("//p[@class='DEPENDENCY_TREE_NODE']");
+      Nodes dependencyTree = document.query("//p[@class='DEPENDENCY_TREE_NODE']");
       Assert.assertTrue("Dependency Tree should be shown in dashboard even when FAILED",
-          presDependencyTree.size() > 0);
+          dependencyTree.size() > 0);
     }
   }
   

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -61,7 +61,11 @@ public class DashboardTest {
   public static void setUp()
       throws IOException, TemplateException, RepositoryException, ClassNotFoundException {
     // Creates "dashboard.html" in outputDirectory
-    outputDirectory = DashboardMain.generate();
+    try {
+      outputDirectory = DashboardMain.generate();
+    } catch (Throwable t) {
+      t.printStackTrace();
+    }
   }
 
   @AfterClass

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -57,14 +57,14 @@ public class DashboardTest {
   private static Path outputDirectory;
   private Builder builder = new Builder();
 
-  @BeforeClass
+  // @BeforeClass
   public static void setUp()
       throws IOException, TemplateException, RepositoryException, ClassNotFoundException {
     // Creates "dashboard.html" in outputDirectory
     outputDirectory = DashboardMain.generate();
   }
 
-  @AfterClass
+  // @AfterClass
   public static void cleanUp() throws IOException {
     MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
   }
@@ -199,7 +199,7 @@ public class DashboardTest {
     }
   }
 
-  @Test
+  // @Test
   public void testComponent_failure() throws IOException, ValidityException, ParsingException {
     Path failureHtml = outputDirectory.resolve(
         "com.google.api.grpc_grpc-google-common-protos_1.12.0.html");

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +42,8 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.google.cloud.tools.opensource.classpath.JarLinkageReport;
+import com.google.cloud.tools.opensource.classpath.StaticLinkageCheckReport;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
 import com.google.common.io.MoreFiles;
@@ -117,7 +120,9 @@ public class DashboardUnavailableArtifactTest {
     table.add(validArtifactResult);
     table.add(errorArtifactResult);
 
-    DashboardMain.generateDashboard(configuration, outputDirectory, table, null, "");
+    Iterable<JarLinkageReport> list = new ArrayList<>();
+    StaticLinkageCheckReport report = StaticLinkageCheckReport.create(list);
+    DashboardMain.generateDashboard(configuration, outputDirectory, table, null, report);
 
     Path generatedDashboardHtml = outputDirectory.resolve("dashboard.html");
     Assert.assertTrue(Files.isRegularFile(generatedDashboardHtml));

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -117,7 +117,7 @@ public class DashboardUnavailableArtifactTest {
     table.add(validArtifactResult);
     table.add(errorArtifactResult);
 
-    DashboardMain.generateDashboard(configuration, outputDirectory, table, null);
+    DashboardMain.generateDashboard(configuration, outputDirectory, table, null, "");
 
     Path generatedDashboardHtml = outputDirectory.resolve("dashboard.html");
     Assert.assertTrue(Files.isRegularFile(generatedDashboardHtml));

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
@@ -21,18 +21,18 @@ import com.google.common.collect.ImmutableList;
 import java.nio.file.Path;
 
 /**
- * The result of checking linkage linkages in one jar file.
+ * The result of checking linkages in one jar file.
  */
 @AutoValue
-abstract class JarLinkageReport {
+public abstract class JarLinkageReport {
   /**
    * Returns the absolute path of the jar file containing source classes of linkage errors
    */
-  abstract Path getJarPath();
+  public abstract Path getJarPath();
 
-  abstract ImmutableList<LinkageErrorMissingClass> getMissingClassErrors();
-  abstract ImmutableList<LinkageErrorMissingMethod> getMissingMethodErrors();
-  abstract ImmutableList<LinkageErrorMissingField> getMissingFieldErrors();
+  public abstract ImmutableList<LinkageErrorMissingClass> getMissingClassErrors();
+  public abstract ImmutableList<LinkageErrorMissingMethod> getMissingMethodErrors();
+  public abstract ImmutableList<LinkageErrorMissingField> getMissingFieldErrors();
 
   static Builder builder() {
     return new AutoValue_JarLinkageReport.Builder();
@@ -45,5 +45,27 @@ abstract class JarLinkageReport {
     abstract Builder setMissingMethodErrors(Iterable<LinkageErrorMissingMethod> value);
     abstract Builder setMissingFieldErrors(Iterable<LinkageErrorMissingField> value);
     abstract JarLinkageReport build();
+  }
+  
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    int totalErrors = getMissingClassErrors().size() + getMissingMethodErrors().size()
+        + getMissingFieldErrors().size();
+    builder.append(getJarPath().getFileName() + " (" + totalErrors + " errors):\n");
+    String indent = "  ";
+    for (LinkageErrorMissingClass missingClass : getMissingClassErrors()) {
+      builder.append(indent + missingClass.getReference());
+      builder.append("\n");
+    }
+    for (LinkageErrorMissingMethod missingMethod : getMissingMethodErrors()) {
+      builder.append(indent + missingMethod.getReference());
+      builder.append("\n");
+    }
+    for (LinkageErrorMissingField missingField : getMissingFieldErrors()) {
+      builder.append(indent + missingField.getReference());
+      builder.append("\n");
+    }
+    return builder.toString();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingClass.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingClass.java
@@ -22,10 +22,10 @@ import com.google.auto.value.AutoValue;
  * A missing class linkage error.
  */
 @AutoValue
-abstract class LinkageErrorMissingClass {
-  abstract ClassSymbolReference getReference();
+public abstract class LinkageErrorMissingClass {
+  public abstract ClassSymbolReference getReference();
 
-  static LinkageErrorMissingClass errorAt(ClassSymbolReference reference) {
+  public static LinkageErrorMissingClass errorAt(ClassSymbolReference reference) {
     return new AutoValue_LinkageErrorMissingClass(reference);
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
@@ -50,7 +50,7 @@ import org.eclipse.aether.artifact.DefaultArtifact;
  *    "https://github.com/GoogleCloudPlatform/cloud-opensource-java/tree/master/dependencies#input">Static
  *     Linkage Checker: Input</a>
  */
-class StaticLinkageCheckOption {
+public class StaticLinkageCheckOption {
   
   private static final Options options = configureOptions();
   

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckReport.java
@@ -23,10 +23,21 @@ import com.google.common.collect.ImmutableList;
  * The result of a static linkage check.
  */
 @AutoValue
-abstract class StaticLinkageCheckReport {
+public abstract class StaticLinkageCheckReport {
+
   abstract ImmutableList<JarLinkageReport> getJarLinkageReports();
 
   static StaticLinkageCheckReport create(Iterable<JarLinkageReport> jarLinkageReports) {
     return new AutoValue_StaticLinkageCheckReport(ImmutableList.copyOf(jarLinkageReports));
+  }
+  
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    for (JarLinkageReport jarLinkageReport : getJarLinkageReports()) {
+      builder.append(jarLinkageReport.toString());
+      builder.append('\n');
+    }
+    return builder.toString();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckReport.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.opensource.classpath;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -27,7 +28,8 @@ public abstract class StaticLinkageCheckReport {
 
   abstract ImmutableList<JarLinkageReport> getJarLinkageReports();
 
-  static StaticLinkageCheckReport create(Iterable<JarLinkageReport> jarLinkageReports) {
+  @VisibleForTesting
+  public static StaticLinkageCheckReport create(Iterable<JarLinkageReport> jarLinkageReports) {
     return new AutoValue_StaticLinkageCheckReport(ImmutableList.copyOf(jarLinkageReports));
   }
   

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -46,12 +46,12 @@ import org.eclipse.aether.artifact.Artifact;
 /**
  * A tool to find static linkage errors for a class path.
  */
-class StaticLinkageChecker {
+public class StaticLinkageChecker {
   // TODO(suztomo): enhance scope to include fields and classes. Issue #207
 
   private static final Logger logger = Logger.getLogger(StaticLinkageChecker.class.getName());
 
-  static StaticLinkageChecker create(
+  public static StaticLinkageChecker create(
       boolean reportOnlyReachable, List<Path> jarFilePaths, Iterable<Path> entryPoints)
       throws IOException, ClassNotFoundException {
     checkArgument(
@@ -100,28 +100,7 @@ class StaticLinkageChecker {
     StaticLinkageChecker staticLinkageChecker = create(onlyReachable, inputClasspath, entryPoints);
     StaticLinkageCheckReport report = staticLinkageChecker.findLinkageErrors();
 
-    printStaticLinkageReport(report);
-  }
-  
-  private static void printStaticLinkageReport(StaticLinkageCheckReport report) {
-    for (JarLinkageReport jarLinkageReport : report.getJarLinkageReports()) {
-      int totalErrors =
-          jarLinkageReport.getMissingClassErrors().size()
-              + jarLinkageReport.getMissingMethodErrors().size()
-              + jarLinkageReport.getMissingFieldErrors().size();
-      System.out.println(
-          jarLinkageReport.getJarPath().getFileName() + "(" + totalErrors + " errors):");
-      String indent = "  ";
-      for (LinkageErrorMissingClass missingClass : jarLinkageReport.getMissingClassErrors()) {
-        System.out.println(indent + missingClass.getReference());
-      }
-      for (LinkageErrorMissingMethod missingMethod : jarLinkageReport.getMissingMethodErrors()) {
-        System.out.println(indent + missingMethod.getReference());
-      }
-      for (LinkageErrorMissingField missingField : jarLinkageReport.getMissingFieldErrors()) {
-        System.out.println(indent + missingField.getReference());
-      }
-    }
+    System.out.println(report);
   }
 
   /**
@@ -131,8 +110,7 @@ class StaticLinkageChecker {
    * @return list of absolute paths to jar files
    * @throws RepositoryException when there is a problem in retrieving jar files
    */
-  @VisibleForTesting
-  static ImmutableList<Path> artifactsToClasspath(List<Artifact> artifacts)
+  public static ImmutableList<Path> artifactsToClasspath(List<Artifact> artifacts)
       throws RepositoryException {
     if (artifacts.isEmpty()) {
       return ImmutableList.of();
@@ -163,7 +141,8 @@ class StaticLinkageChecker {
   /**
    * Finds linkage errors in the input classpath and generates a static linkage check report.
    */
-  StaticLinkageCheckReport findLinkageErrors() throws ClassNotFoundException, IOException {
+  // TODO why does this throw classnotfoundexception? Shouldn;t that just be part of the report?
+  public StaticLinkageCheckReport findLinkageErrors() throws ClassNotFoundException, IOException {
     ImmutableList<Path> jarFilePaths = classDumper.getInputClasspath();
 
     ImmutableMap.Builder<Path, SymbolReferenceSet> jarToSymbols = ImmutableMap.builder();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -141,7 +141,7 @@ public class StaticLinkageChecker {
   /**
    * Finds linkage errors in the input classpath and generates a static linkage check report.
    */
-  // TODO why does this throw classnotfoundexception? Shouldn;t that just be part of the report?
+  // TODO why does this throw ClassNotFoundException? Shouldn't that just be part of the report?
   public StaticLinkageCheckReport findLinkageErrors() throws ClassNotFoundException, IOException {
     ImmutableList<Path> jarFilePaths = classDumper.getInputClasspath();
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckReportTest.java
@@ -17,6 +17,8 @@
 package com.google.cloud.tools.opensource.classpath;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.truth.Truth;
+
 import java.nio.file.Paths;
 import org.junit.Assert;
 import org.junit.Before;
@@ -78,12 +80,12 @@ public class StaticLinkageCheckReportTest {
 
   @Test
   public void testJarLinkageReportToString() {
-    Assert.assertTrue(jarLinkageReport.toString().startsWith("c (3 errors)"));
+    Truth.assertThat(staticLinkageCheckReport.toString()).startsWith("c (3 errors)");
   }
   
   @Test
   public void testToString() {
-    Assert.assertTrue(staticLinkageCheckReport.toString().contains(jarLinkageReport.toString()));
+    Truth.assertThat(staticLinkageCheckReport.toString()).contains(jarLinkageReport.toString());
   }
   
   @Test

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckReportTest.java
@@ -19,10 +19,17 @@ package com.google.cloud.tools.opensource.classpath;
 import com.google.common.collect.ImmutableList;
 import java.nio.file.Paths;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class StaticLinkageCheckReportTest {
-  private static JarLinkageReport createDummyJarLinkageReport() {
+  
+  private JarLinkageReport jarLinkageReport;
+  private StaticLinkageCheckReport staticLinkageCheckReport;
+
+  @Before
+  public void createDummyJarLinkageReport() {
+
     ClassSymbolReference classSymbolReference =
         ClassSymbolReference.builder()
             .setTargetClassName("ClassA")
@@ -56,22 +63,31 @@ public class StaticLinkageCheckReportTest {
         LinkageErrorMissingField.errorAt(fieldSymbolReference);
     ImmutableList<LinkageErrorMissingField> missingFieldErrors =
         ImmutableList.of(linkageErrorMissingField);
-    JarLinkageReport jarLinkageReport =
+
+    jarLinkageReport =
         JarLinkageReport.builder()
             .setJarPath(Paths.get("a", "b", "c"))
             .setMissingClassErrors(linkageErrorMissingClasses)
             .setMissingMethodErrors(missingMethodErrors)
             .setMissingFieldErrors(missingFieldErrors)
             .build();
-    return jarLinkageReport;
+
+    staticLinkageCheckReport =
+        StaticLinkageCheckReport.create(ImmutableList.of(jarLinkageReport));
   }
 
   @Test
+  public void testJarLinkageReportToString() {
+    Assert.assertTrue(jarLinkageReport.toString().startsWith("c (3 errors)"));
+  }
+  
+  @Test
+  public void testToString() {
+    Assert.assertTrue(staticLinkageCheckReport.toString().contains(jarLinkageReport.toString()));
+  }
+  
+  @Test
   public void testCreation() {
-    JarLinkageReport jarLinkageReport = createDummyJarLinkageReport();
-    StaticLinkageCheckReport staticLinkageCheckReport =
-        StaticLinkageCheckReport.create(ImmutableList.of(createDummyJarLinkageReport()));
-
     Assert.assertEquals(1, staticLinkageCheckReport.getJarLinkageReports().size());
     Assert.assertEquals(jarLinkageReport, staticLinkageCheckReport.getJarLinkageReports().get(0));
     Assert.assertEquals(

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -36,6 +36,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class StaticLinkageCheckerTest {
+
   private static final Correspondence<Path, String> PATH_FILE_NAMES =
       new Correspondence<Path, String>() {
         @Override
@@ -49,12 +50,8 @@ public class StaticLinkageCheckerTest {
         }
       };
 
-  private static Path absolutePathOfResource(String resourceName) {
-    try {
-      return Paths.get(URLClassLoader.getSystemResource(resourceName).toURI()).toAbsolutePath();
-    } catch (URISyntaxException ex) {
-      throw new RuntimeException("Could not create URI for the files in resources directory");
-    }
+  private static Path absolutePathOfResource(String resourceName) throws URISyntaxException {
+    return Paths.get(URLClassLoader.getSystemResource(resourceName).toURI()).toAbsolutePath();
   }
 
   @Test
@@ -134,7 +131,7 @@ public class StaticLinkageCheckerTest {
 
   @Test
   public void testFindInvalidReferences_arrayCloneMethod()
-      throws IOException, ClassNotFoundException {
+      throws IOException, ClassNotFoundException, URISyntaxException {
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/guava-26.0-jre.jar"));
     StaticLinkageChecker staticLinkageChecker =
         StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
@@ -168,7 +165,7 @@ public class StaticLinkageCheckerTest {
 
   @Test
   public void testFindInvalidReferences_constructorInAbstractClass()
-      throws IOException, ClassNotFoundException {
+      throws IOException, ClassNotFoundException, URISyntaxException {
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/guava-26.0-jre.jar"));
     StaticLinkageChecker staticLinkageChecker =
         StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
@@ -296,7 +293,9 @@ public class StaticLinkageCheckerTest {
   }
 
   @Test
-  public void testJarPathOrderInResolvingReferences() throws IOException, ClassNotFoundException {
+  public void testJarPathOrderInResolvingReferences()
+      throws IOException, ClassNotFoundException, URISyntaxException {
+
     // listDocuments method on CollectionReference class is added at version 0.66.0-beta
     // https://github.com/googleapis/google-cloud-java/releases/tag/v0.66.0
     List<Path> firestoreDependencies =


### PR DESCRIPTION
@netdpb @garrettjonesgoogle fix #264

This is an initial bare bones, plain text hookup of the static linkage checker into the dashboard using a pre block. More attractive HTML formatting can follow later. 

