### PR TITLE
keep dependency path in static linkage check

### DIFF
--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -91,11 +91,14 @@ public class DashboardMain {
     ArtifactCache cache = loadArtifactInfo(managedDependencies);
     
     ImmutableList<Path> classpath = StaticLinkageChecker.artifactsToClasspath(managedDependencies);
-    ListMultimap<Path, DependencyPath> paths = StaticLinkageChecker.artifactsToPaths(managedDependencies);
+    LinkedListMultimap<Path, DependencyPath> paths =
+        StaticLinkageChecker.artifactsToPaths(managedDependencies);
     
     // TODO(suztomo): choose entry point classes for reachability
     ImmutableSet<Path> entryPoints = ImmutableSet.of(classpath.get(0));
 
+    
+    
     boolean onlyReachable = false;
     StaticLinkageChecker staticLinkageChecker =
         StaticLinkageChecker.create(onlyReachable, paths, entryPoints);

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -91,12 +91,15 @@ public class DashboardMain {
     ArtifactCache cache = loadArtifactInfo(managedDependencies);
     
     ImmutableList<Path> classpath = StaticLinkageChecker.artifactsToClasspath(managedDependencies);
+    ListMultimap<Path, DependencyPath> paths = StaticLinkageChecker.artifactsToPaths(managedDependencies);
+    
     // TODO(suztomo): choose entry point classes for reachability
     ImmutableSet<Path> entryPoints = ImmutableSet.of(classpath.get(0));
 
     boolean onlyReachable = false;
     StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(onlyReachable, classpath, entryPoints);
+        StaticLinkageChecker.create(onlyReachable, paths, entryPoints);
+    
     StaticLinkageCheckReport report = staticLinkageChecker.findLinkageErrors();
     List<ArtifactResults> table = generateReports(configuration, output, cache);
     generateDashboard(configuration, output, table, cache.getGlobalDependencies(), report);

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -21,7 +21,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -66,8 +66,7 @@ class ClassDumper {
   }
 
   static ClassDumper create(List<Path> jarFilePaths) throws IOException, ClassNotFoundException {
-    // Creates classpath in the same order as inputClasspath for BCEL API
-        
+    // Creates classpath in the same order as inputClasspath for BCEL API        
     String pathAsString =
         jarFilePaths.stream().map(Path::toString).collect(Collectors.joining(File.pathSeparator));
     ClassPath classPath = new ClassPath(pathAsString);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -66,7 +66,7 @@ class ClassDumper {
   }
 
   static ClassDumper create(List<Path> jarFilePaths) throws IOException, ClassNotFoundException {
-    // Creates classpath in the same order as inputClasspath for BCEL API        
+    // Creates classpath in the same order as inputClasspath for BCEL API
     String pathAsString =
         jarFilePaths.stream().map(Path::toString).collect(Collectors.joining(File.pathSeparator));
     ClassPath classPath = new ClassPath(pathAsString);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -19,12 +19,10 @@ package com.google.cloud.tools.opensource.classpath;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.SetMultimap;
-import com.google.common.collect.Sets;
 import com.google.common.reflect.ClassPath.ClassInfo;
 import java.io.File;
 import java.io.IOException;
@@ -69,9 +67,7 @@ class ClassDumper {
 
   static ClassDumper create(List<Path> jarFilePaths) throws IOException, ClassNotFoundException {
     // Creates classpath in the same order as inputClasspath for BCEL API
-    
-    Preconditions.checkArgument(jarFilePaths.size() == Sets.newHashSet(jarFilePaths).size());
-    
+        
     String pathAsString =
         jarFilePaths.stream().map(Path::toString).collect(Collectors.joining(File.pathSeparator));
     ClassPath classPath = new ClassPath(pathAsString);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -19,10 +19,12 @@ package com.google.cloud.tools.opensource.classpath;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
 import com.google.common.reflect.ClassPath.ClassInfo;
 import java.io.File;
 import java.io.IOException;
@@ -67,6 +69,9 @@ class ClassDumper {
 
   static ClassDumper create(List<Path> jarFilePaths) throws IOException, ClassNotFoundException {
     // Creates classpath in the same order as inputClasspath for BCEL API
+    
+    Preconditions.checkArgument(jarFilePaths.size() == Sets.newHashSet(jarFilePaths).size());
+    
     String pathAsString =
         jarFilePaths.stream().map(Path::toString).collect(Collectors.joining(File.pathSeparator));
     ClassPath classPath = new ClassPath(pathAsString);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.opensource.classpath;
 
 import com.google.auto.value.AutoValue;
+import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.collect.ImmutableList;
 import java.nio.file.Path;
 
@@ -28,19 +29,25 @@ public abstract class JarLinkageReport {
   /**
    * Returns the absolute path of the jar file containing source classes of linkage errors
    */
-  public abstract Path getJarPath();
+  abstract Path getJarPath();
+  
+  /**
+   * @return the paths to this artifact
+   */
+  abstract ImmutableList<DependencyPath> getDependencyPaths();
 
-  public abstract ImmutableList<LinkageErrorMissingClass> getMissingClassErrors();
-  public abstract ImmutableList<LinkageErrorMissingMethod> getMissingMethodErrors();
-  public abstract ImmutableList<LinkageErrorMissingField> getMissingFieldErrors();
+  abstract ImmutableList<LinkageErrorMissingClass> getMissingClassErrors();
+  abstract ImmutableList<LinkageErrorMissingMethod> getMissingMethodErrors();
+  abstract ImmutableList<LinkageErrorMissingField> getMissingFieldErrors();
 
   static Builder builder() {
-    return new AutoValue_JarLinkageReport.Builder();
+    return new AutoValue_JarLinkageReport.Builder().setDependencyPaths(ImmutableList.of());
   }
 
   @AutoValue.Builder
   abstract static class Builder {
     abstract Builder setJarPath(Path value);
+    abstract Builder setDependencyPaths(Iterable<DependencyPath> paths);
     abstract Builder setMissingClassErrors(Iterable<LinkageErrorMissingClass> value);
     abstract Builder setMissingMethodErrors(Iterable<LinkageErrorMissingMethod> value);
     abstract Builder setMissingFieldErrors(Iterable<LinkageErrorMissingField> value);
@@ -49,10 +56,15 @@ public abstract class JarLinkageReport {
   
   @Override
   public String toString() {
+    String indent = "  ";
     StringBuilder builder = new StringBuilder();
     int totalErrors = getTotalErrorCount();
+
     builder.append(getJarPath().getFileName() + " (" + totalErrors + " errors):\n");
-    String indent = "  ";
+    for (DependencyPath path : getDependencyPaths()) {
+      builder.append(indent + "Linked from: " + path);
+      builder.append("\n");
+    }    
     for (LinkageErrorMissingClass missingClass : getMissingClassErrors()) {
       builder.append(indent + missingClass.getReference());
       builder.append("\n");

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
@@ -32,7 +32,7 @@ public abstract class JarLinkageReport {
   abstract Path getJarPath();
   
   /**
-   * @return the paths to this artifact
+   * Returns the dependency path(s) to this artifact.
    */
   abstract ImmutableList<DependencyPath> getDependencyPaths();
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import java.io.IOException;
@@ -42,6 +41,7 @@ import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraphBuilder;
 import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -56,7 +56,6 @@ public class StaticLinkageChecker {
 
   private static final Logger logger = Logger.getLogger(StaticLinkageChecker.class.getName());
 
-  @Deprecated
   static StaticLinkageChecker create(
       boolean onlyReachable, List<Path> jarFilePaths, Iterable<Path> entryPoints)
       throws IOException, ClassNotFoundException {
@@ -91,7 +90,7 @@ public class StaticLinkageChecker {
     this.reportOnlyReachable = reportOnlyReachable;
     this.classDumper = classDumper;
     this.entryPoints = ImmutableSet.copyOf(entryPoints);
-    this.paths = null;
+    this.paths = ArrayListMultimap.create();
   }
   
   StaticLinkageChecker(boolean reportOnlyReachable, ClassDumper classDumper,
@@ -117,7 +116,7 @@ public class StaticLinkageChecker {
     
     CommandLine commandLine = StaticLinkageCheckOption.readCommandLine(arguments);
     ImmutableList<Path> inputClasspath = StaticLinkageCheckOption.generateInputClasspath(commandLine);
-    // TODO(suztomo): to take command-line option to choose entry point classes for reachability
+    // TODO(suztomo): take command-line option to choose entry point classes for reachability
     ImmutableSet<Path> entryPoints = ImmutableSet.of(inputClasspath.get(0));
 
     boolean onlyReachable = commandLine.hasOption("r");

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -69,8 +69,7 @@ public class StaticLinkageChecker {
   public static StaticLinkageChecker create(boolean onlyReachable,
       LinkedListMultimap<Path, DependencyPath> paths, ImmutableSet<Path> entryPoints) 
           throws ClassNotFoundException, IOException {
-    List<Path> jarFilePaths = new ArrayList<>();
-    jarFilePaths.addAll(paths.keySet());
+    List<Path> jarFilePaths = new ArrayList<>(paths.keySet());
     ClassDumper dumper = ClassDumper.create(jarFilePaths);
     return new StaticLinkageChecker(onlyReachable, dumper, entryPoints, paths);
   }
@@ -96,7 +95,7 @@ public class StaticLinkageChecker {
       Iterable<Path> entryPoints, ListMultimap<Path, DependencyPath> paths) {
     this.reportOnlyReachable = reportOnlyReachable;
     this.classDumper = Preconditions.checkNotNull(classDumper);
-    this.entryPoints = ImmutableSet.copyOf(Preconditions.checkNotNull(entryPoints));
+    this.entryPoints = ImmutableSet.copyOf(entryPoints);
     this.paths = Preconditions.checkNotNull(paths);
   }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
@@ -95,5 +95,14 @@ public class JarLinkageReportTest {
   public void testGetTotalErrorCount() {
     Assert.assertEquals(3, jarLinkageReport.getTotalErrorCount());
   }
+  
+  @Test
+  public void testToString() {
+    Assert.assertEquals("c (3 errors):\n" + 
+        "  ClassSymbolReference{sourceClassName=ClassB, targetClassName=ClassA}\n" + 
+        "  MethodSymbolReference{sourceClassName=ClassB, targetClassName=ClassA, methodName=methodX, descriptor=java.lang.String}\n" + 
+        "  FieldSymbolReference{sourceClassName=ClassD, targetClassName=ClassC, fieldName=fieldX}\n" + 
+        "", jarLinkageReport.toString());
+  }
 
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -28,6 +28,7 @@ import java.net.URISyntaxException;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -69,10 +70,7 @@ public class StaticLinkageCheckerTest {
     
     Truth.assertThat(paths)
         .comparingElementsUsing(PATH_FILE_NAMES)
-        .contains("grpc-auth-1.15.1.jar");
-    Truth.assertThat(paths)
-        .comparingElementsUsing(PATH_FILE_NAMES)
-        .contains("google-auth-library-credentials-0.9.0.jar");
+        .containsAllOf("grpc-auth-1.15.1.jar", "google-auth-library-credentials-0.9.0.jar");
     paths.forEach(
         path ->
             Truth.assertWithMessage("Every returned path should be an absolute path")
@@ -147,8 +145,8 @@ public class StaticLinkageCheckerTest {
     // https://github.com/apache/httpcomponents-client/blob/e2cf733c60f910d17dc5cfc0a77797054a2e322e/httpclient/src/main/java/org/apache/http/conn/ssl/AbstractVerifier.java#L153
     SymbolReferenceSet symbolReferenceSet = ClassDumper.scanSymbolReferencesInJar(httpClientJar);
 
-    JarLinkageReport jarLinkageReport =
-        staticLinkageChecker.generateLinkageReport(httpClientJar, symbolReferenceSet, null);
+    JarLinkageReport jarLinkageReport = staticLinkageChecker.generateLinkageReport(httpClientJar,
+        symbolReferenceSet, Collections.emptyList());
 
     Truth.assertWithMessage("Method references within the same jar file should not be reported")
         .that(jarLinkageReport.getMissingMethodErrors())
@@ -182,7 +180,8 @@ public class StaticLinkageCheckerTest {
             .build();
 
     JarLinkageReport jarLinkageReport =
-        staticLinkageChecker.generateLinkageReport(paths.get(0), symbolReferenceSet, null);
+        staticLinkageChecker.generateLinkageReport(paths.get(0), symbolReferenceSet, 
+            Collections.emptyList());
 
     Truth.assertThat(jarLinkageReport.getMissingMethodErrors()).hasSize(1);
     Assert.assertEquals(
@@ -208,8 +207,8 @@ public class StaticLinkageCheckerTest {
     SymbolReferenceSet symbolReferenceSet =
         SymbolReferenceSet.builder().setMethodReferences(methodReferences).build();
 
-    JarLinkageReport jarLinkageReport =
-        staticLinkageChecker.generateLinkageReport(paths.get(0), symbolReferenceSet, null);
+    JarLinkageReport jarLinkageReport = staticLinkageChecker.generateLinkageReport(paths.get(0),
+        symbolReferenceSet, Collections.emptyList());
 
     Truth.assertThat(jarLinkageReport.getMissingMethodErrors()).isEmpty();
   }
@@ -365,14 +364,14 @@ public class StaticLinkageCheckerTest {
 
     JarLinkageReport reportWith65First =
         staticLinkageChecker65First.generateLinkageReport(
-            firestoreDependencies.get(0), symbolReferenceSet, null);
+            firestoreDependencies.get(0), symbolReferenceSet, Collections.emptyList());
     Truth.assertWithMessage("Firestore version 65 does not have CollectionReference.listDocuments")
         .that(reportWith65First.getMissingMethodErrors())
         .hasSize(1);
 
     JarLinkageReport reportWith66First =
         staticLinkageChecker66First.generateLinkageReport(
-            firestoreDependencies.get(0), symbolReferenceSet, null);
+            firestoreDependencies.get(0), symbolReferenceSet, Collections.emptyList());
     Truth.assertWithMessage("Firestore version 66 has CollectionReference.listDocuments")
         .that(reportWith66First.getMissingMethodErrors())
         .isEmpty();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -148,7 +148,7 @@ public class StaticLinkageCheckerTest {
     SymbolReferenceSet symbolReferenceSet = ClassDumper.scanSymbolReferencesInJar(httpClientJar);
 
     JarLinkageReport jarLinkageReport =
-        staticLinkageChecker.generateLinkageReport(httpClientJar, symbolReferenceSet);
+        staticLinkageChecker.generateLinkageReport(httpClientJar, symbolReferenceSet, null);
 
     Truth.assertWithMessage("Method references within the same jar file should not be reported")
         .that(jarLinkageReport.getMissingMethodErrors())
@@ -182,7 +182,7 @@ public class StaticLinkageCheckerTest {
             .build();
 
     JarLinkageReport jarLinkageReport =
-        staticLinkageChecker.generateLinkageReport(paths.get(0), symbolReferenceSet);
+        staticLinkageChecker.generateLinkageReport(paths.get(0), symbolReferenceSet, null);
 
     Truth.assertThat(jarLinkageReport.getMissingMethodErrors()).hasSize(1);
     Assert.assertEquals(
@@ -209,7 +209,7 @@ public class StaticLinkageCheckerTest {
         SymbolReferenceSet.builder().setMethodReferences(methodReferences).build();
 
     JarLinkageReport jarLinkageReport =
-        staticLinkageChecker.generateLinkageReport(paths.get(0), symbolReferenceSet);
+        staticLinkageChecker.generateLinkageReport(paths.get(0), symbolReferenceSet, null);
 
     Truth.assertThat(jarLinkageReport.getMissingMethodErrors()).isEmpty();
   }
@@ -365,14 +365,14 @@ public class StaticLinkageCheckerTest {
 
     JarLinkageReport reportWith65First =
         staticLinkageChecker65First.generateLinkageReport(
-            firestoreDependencies.get(0), symbolReferenceSet);
+            firestoreDependencies.get(0), symbolReferenceSet, null);
     Truth.assertWithMessage("Firestore version 65 does not have CollectionReference.listDocuments")
         .that(reportWith65First.getMissingMethodErrors())
         .hasSize(1);
 
     JarLinkageReport reportWith66First =
         staticLinkageChecker66First.generateLinkageReport(
-            firestoreDependencies.get(0), symbolReferenceSet);
+            firestoreDependencies.get(0), symbolReferenceSet, null);
     Truth.assertWithMessage("Firestore version 66 has CollectionReference.listDocuments")
         .that(reportWith66First.getMissingMethodErrors())
         .isEmpty();


### PR DESCRIPTION
@suztomo @netdpb This shows us the paths by which we reached a jar that has static linkage errors. 