### PR TITLE
To validate class reference modifier

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -403,11 +403,17 @@ class ClassDumper {
     return javaClasses.build();
   }
 
+  /**
+   * Returns true if two class names (binary name JLS 13.1) have the same package.
+   */
   static boolean classesInSamePackage(String classNameA, String classNameB) {
-    Preconditions.checkArgument(classNameA.contains("."),
-        "Class name A does not have package");
-    Preconditions.checkArgument(classNameB.contains("."),
-        "Class name B does not have package");
+    if (classNameA.contains(".") != classNameB.contains(".")) {
+      return false;
+    }
+    if (classNameA.lastIndexOf('.') < 0 && classNameB.lastIndexOf('.') < 0) {
+      return true;
+    }
+    // The conditions above ensure that lastIndexOf returns non-negative number
     String packageNameA = classNameA.substring(0, classNameA.lastIndexOf('.'));
     String packageNameB = classNameB.substring(0, classNameB.lastIndexOf('.'));
     return packageNameA.equals(packageNameB);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
@@ -67,6 +67,7 @@ public abstract class JarLinkageReport {
     }    
     for (LinkageErrorMissingClass missingClass : getMissingClassErrors()) {
       builder.append(indent + missingClass.getReference());
+      builder.append(" reason:" + missingClass.getReason());
       builder.append("\n");
     }
     for (LinkageErrorMissingMethod missingMethod : getMissingMethodErrors()) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingClass.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingClass.java
@@ -17,15 +17,23 @@
 package com.google.cloud.tools.opensource.classpath;
 
 import com.google.auto.value.AutoValue;
+import java.net.URL;
 
 /**
  * A missing class linkage error.
  */
 @AutoValue
-public abstract class LinkageErrorMissingClass {
+public abstract class LinkageErrorMissingClass implements LinkageErrorWithReason {
+
   public abstract ClassSymbolReference getReference();
 
   public static LinkageErrorMissingClass errorAt(ClassSymbolReference reference) {
-    return new AutoValue_LinkageErrorMissingClass(reference);
+    return new AutoValue_LinkageErrorMissingClass(null, Reason.TARGET_CLASS_NOT_FOUND, reference);
+  }
+
+  public static LinkageErrorMissingClass errorWithModifierAt(URL targetClassLocation,
+      ClassSymbolReference reference) {
+    return new AutoValue_LinkageErrorMissingClass(targetClassLocation,
+        Reason.INVALID_ACCESS_MODIFIER, reference);
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingClass.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingClass.java
@@ -27,13 +27,29 @@ public abstract class LinkageErrorMissingClass implements LinkageErrorWithReason
 
   public abstract ClassSymbolReference getReference();
 
-  public static LinkageErrorMissingClass errorAt(ClassSymbolReference reference) {
-    return new AutoValue_LinkageErrorMissingClass(null, Reason.TARGET_CLASS_NOT_FOUND, reference);
+  public static LinkageErrorMissingClass errorMissingTargetClass(ClassSymbolReference reference) {
+    return builder().setReference(reference).setReason(Reason.TARGET_CLASS_NOT_FOUND).build();
   }
 
-  public static LinkageErrorMissingClass errorWithModifierAt(URL targetClassLocation,
+  public static LinkageErrorMissingClass errorInvalidModifier(URL targetClassLocation,
       ClassSymbolReference reference) {
-    return new AutoValue_LinkageErrorMissingClass(targetClassLocation,
-        Reason.INVALID_ACCESS_MODIFIER, reference);
+    return builder().setReference(reference).setReason(Reason.INVALID_ACCESS_MODIFIER)
+        .setTargetClassLocation(targetClassLocation).build();
+  }
+
+  private static Builder builder() {
+    return new AutoValue_LinkageErrorMissingClass.Builder();
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+
+    abstract LinkageErrorMissingClass.Builder setTargetClassLocation(URL targetClassLocation);
+
+    abstract LinkageErrorMissingClass.Builder setReason(Reason reason);
+
+    abstract LinkageErrorMissingClass.Builder setReference(ClassSymbolReference reference);
+
+    abstract LinkageErrorMissingClass build();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingField.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingField.java
@@ -24,25 +24,26 @@ import javax.annotation.Nullable;
  * A missing field linkage error.
  */
 @AutoValue
-abstract class LinkageErrorMissingField {
+abstract class LinkageErrorMissingField implements LinkageErrorWithReason {
   abstract FieldSymbolReference getReference();
 
-  /**
-   * Returns the location of the target class in the field reference; null if the target class is
-   * not found in the class path.
-   */
-  @Nullable
-  abstract URL getTargetClassLocation();
+  static LinkageErrorMissingField errorMissingTargetClass(
+      FieldSymbolReference reference) {
+    return new AutoValue_LinkageErrorMissingField(null,
+        Reason.TARGET_CLASS_NOT_FOUND, reference);
+  }
 
-  static LinkageErrorMissingField errorAt(
-      FieldSymbolReference reference, @Nullable URL targetClassLocation) {
-    return new AutoValue_LinkageErrorMissingField(reference, targetClassLocation);
+  static LinkageErrorMissingField errorMissingField(
+      FieldSymbolReference reference, URL targetClassLocation) {
+    return new AutoValue_LinkageErrorMissingField(targetClassLocation, Reason.MISSING_MEMBER,
+        reference);
   }
 
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
     builder.append(getReference());
+    builder.append(", reason: " + getReason());
     if (getTargetClassLocation() != null) {
       builder.append(", target class from " + getTargetClassLocation());
     } else {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingField.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingField.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.opensource.classpath;
 
 import com.google.auto.value.AutoValue;
 import java.net.URL;
-import javax.annotation.Nullable;
 
 /**
  * A missing field linkage error.
@@ -29,14 +28,29 @@ abstract class LinkageErrorMissingField implements LinkageErrorWithReason {
 
   static LinkageErrorMissingField errorMissingTargetClass(
       FieldSymbolReference reference) {
-    return new AutoValue_LinkageErrorMissingField(null,
-        Reason.TARGET_CLASS_NOT_FOUND, reference);
+    return builder().setReference(reference).setReason(Reason.TARGET_CLASS_NOT_FOUND).build();
   }
 
   static LinkageErrorMissingField errorMissingField(
       FieldSymbolReference reference, URL targetClassLocation) {
-    return new AutoValue_LinkageErrorMissingField(targetClassLocation, Reason.MISSING_MEMBER,
-        reference);
+    return builder().setReference(reference).setReason(Reason.MISSING_MEMBER)
+        .setTargetClassLocation(targetClassLocation).build();
+  }
+
+  private static LinkageErrorMissingField.Builder builder() {
+    return new AutoValue_LinkageErrorMissingField.Builder();
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+
+    abstract LinkageErrorMissingField.Builder setTargetClassLocation(URL targetClassLocation);
+
+    abstract LinkageErrorMissingField.Builder setReason(Reason reason);
+
+    abstract LinkageErrorMissingField.Builder setReference(FieldSymbolReference reference);
+
+    abstract LinkageErrorMissingField build();
   }
 
   @Override

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingMethod.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingMethod.java
@@ -28,4 +28,6 @@ abstract class LinkageErrorMissingMethod {
   static LinkageErrorMissingMethod errorAt(MethodSymbolReference reference) {
     return new AutoValue_LinkageErrorMissingMethod(reference);
   }
+
+  // TODO(#293): Add reason and target class location
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorWithReason.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorWithReason.java
@@ -4,26 +4,41 @@ import java.net.URL;
 import javax.annotation.Nullable;
 
 /**
- * Interface to provide common fields for the different types of static linkage errors.
+ * Interface to provide common fields for different types of static linkage errors.
  */
 interface LinkageErrorWithReason {
 
   /**
-   * Returns the location of the target class in the field reference; null if the target class is
-   * not found in the class path.
+   * Returns the location of the target class in a symbol reference; null if the target class is
+   * not found in the class path or the source location is unavailable.
    */
   @Nullable
   URL getTargetClassLocation();
 
   /**
-   * Returns the reason why a symbol reference is detected as a linkage error.
+   * Returns the reason why a symbol reference is marked as a linkage error.
    */
   Reason getReason();
 
   /**
-   * Reason to distinguish the cause of a static linkage error
+   * Reason to distinguish the cause of a static linkage error against a symbol reference.
    */
   enum Reason {
-    TARGET_CLASS_NOT_FOUND, INVALID_ACCESS_MODIFIER, MISSING_MEMBER
+    /**
+     * The target class of the symbol reference is not found in the class path.
+     */
+    TARGET_CLASS_NOT_FOUND,
+
+    /**
+     * The access modifier (e.g., public or protected) does not allow the source of the symbol
+     * reference to use the target symbol.
+     */
+    INVALID_ACCESS_MODIFIER,
+
+    /**
+     * For a method or field reference, the member is not found in the target class in the class
+     * path.
+     */
+    MISSING_MEMBER
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorWithReason.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorWithReason.java
@@ -9,8 +9,8 @@ import javax.annotation.Nullable;
 interface LinkageErrorWithReason {
 
   /**
-   * Returns the location of the target class in a symbol reference; null if the target class is
-   * not found in the class path or the source location is unavailable.
+   * Returns the location of the target class in a symbol reference; null if the target class is not
+   * found in the class path or the source location is unavailable.
    */
   @Nullable
   URL getTargetClassLocation();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorWithReason.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorWithReason.java
@@ -1,0 +1,29 @@
+package com.google.cloud.tools.opensource.classpath;
+
+import java.net.URL;
+import javax.annotation.Nullable;
+
+/**
+ * Interface to provide common fields for the different types of static linkage errors.
+ */
+interface LinkageErrorWithReason {
+
+  /**
+   * Returns the location of the target class in the field reference; null if the target class is
+   * not found in the class path.
+   */
+  @Nullable
+  URL getTargetClassLocation();
+
+  /**
+   * Returns the reason why a symbol reference is detected as a linkage error.
+   */
+  Reason getReason();
+
+  /**
+   * Reason to distinguish the cause of a static linkage error
+   */
+  enum Reason {
+    TARGET_CLASS_NOT_FOUND, INVALID_ACCESS_MODIFIER, MISSING_MEMBER
+  }
+}

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -181,4 +181,11 @@ public class ClassDumperTest {
         .comparingElementsUsing(SYMBOL_REFERENCE_TARGET_CLASS_NAME)
         .doesNotContain("[Ljava.lang.Object;");
   }
+
+  @Test
+  public void testClassesInSamePackage() {
+    Truth.assertThat(ClassDumper.classesInSamePackage("foo.Abc", "bar.Abc")).isFalse();
+    Truth.assertThat(ClassDumper.classesInSamePackage("foo.bar.Abc", "foo.bar.Cde")).isTrue();
+    Truth.assertThat(ClassDumper.classesInSamePackage("foo.bar.Abc$XYZ", "foo.bar.Cde")).isTrue();
+  }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -187,5 +187,6 @@ public class ClassDumperTest {
     Truth.assertThat(ClassDumper.classesInSamePackage("foo.Abc", "bar.Abc")).isFalse();
     Truth.assertThat(ClassDumper.classesInSamePackage("foo.bar.Abc", "foo.bar.Cde")).isTrue();
     Truth.assertThat(ClassDumper.classesInSamePackage("foo.bar.Abc$XYZ", "foo.bar.Cde")).isTrue();
+    Truth.assertThat(ClassDumper.classesInSamePackage("Abc", "Cde")).isTrue();
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
@@ -60,7 +60,7 @@ public class JarLinkageReportTest {
             .setSourceClassName("ClassD")
             .build();
     LinkageErrorMissingField linkageErrorMissingField =
-        LinkageErrorMissingField.errorAt(fieldSymbolReference, null);
+        LinkageErrorMissingField.errorMissingTargetClass(fieldSymbolReference);
     missingFieldErrors = ImmutableList.of(linkageErrorMissingField);
     jarLinkageReport =
         JarLinkageReport.builder()
@@ -99,9 +99,9 @@ public class JarLinkageReportTest {
   @Test
   public void testToString() {
     Assert.assertEquals("c (3 errors):\n" + 
-        "  ClassSymbolReference{sourceClassName=ClassB, targetClassName=ClassA}\n" + 
+        "  ClassSymbolReference{sourceClassName=ClassB, targetClassName=ClassA} reason:TARGET_CLASS_NOT_FOUND\n" +
         "  MethodSymbolReference{sourceClassName=ClassB, targetClassName=ClassA, methodName=methodX, descriptor=java.lang.String}\n" + 
-        "  FieldSymbolReference{sourceClassName=ClassD, targetClassName=ClassC, fieldName=fieldX}, target class location not found\n" +
+        "  FieldSymbolReference{sourceClassName=ClassD, targetClassName=ClassC, fieldName=fieldX}, reason: TARGET_CLASS_NOT_FOUND, target class location not found\n" +
         "", jarLinkageReport.toString());
   }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
@@ -39,7 +39,7 @@ public class JarLinkageReportTest {
             .build();
     
     LinkageErrorMissingClass linkageErrorMissingClass =
-        LinkageErrorMissingClass.errorAt(classSymbolReference);
+        LinkageErrorMissingClass.errorMissingTargetClass(classSymbolReference);
     missingClassErrors = ImmutableList.of(linkageErrorMissingClass);
 
     MethodSymbolReference methodSymbolReference =

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingClassTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingClassTest.java
@@ -28,7 +28,7 @@ public class LinkageErrorMissingClassTest {
             .setSourceClassName("ClassB")
             .build();
     LinkageErrorMissingClass linkageErrorMissingClass =
-        LinkageErrorMissingClass.errorAt(classSymbolReference);
+        LinkageErrorMissingClass.errorMissingTargetClass(classSymbolReference);
 
     Assert.assertEquals(classSymbolReference, linkageErrorMissingClass.getReference());
   }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingFieldTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageErrorMissingFieldTest.java
@@ -32,7 +32,7 @@ public class LinkageErrorMissingFieldTest{
             .build();
     URL targetClassLocation = new URL("file://foo/bar");
     LinkageErrorMissingField linkageErrorMissingField =
-        LinkageErrorMissingField.errorAt(fieldSymbolReference, targetClassLocation);
+        LinkageErrorMissingField.errorMissingField(fieldSymbolReference, targetClassLocation);
 
     Assert.assertEquals(fieldSymbolReference, linkageErrorMissingField.getReference());
     Assert.assertEquals(targetClassLocation, linkageErrorMissingField.getTargetClassLocation());

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckReportTest.java
@@ -40,7 +40,7 @@ public class StaticLinkageCheckReportTest {
             .setSourceClassName("ClassB")
             .build();
     LinkageErrorMissingClass linkageErrorMissingClass =
-        LinkageErrorMissingClass.errorAt(classSymbolReference);
+        LinkageErrorMissingClass.errorMissingTargetClass(classSymbolReference);
 
     ImmutableList<LinkageErrorMissingClass> linkageErrorMissingClasses =
         ImmutableList.of(linkageErrorMissingClass);

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckReportTest.java
@@ -64,7 +64,7 @@ public class StaticLinkageCheckReportTest {
             .setSourceClassName("ClassD")
             .build();
     LinkageErrorMissingField linkageErrorMissingField =
-        LinkageErrorMissingField.errorAt(fieldSymbolReference, null);
+        LinkageErrorMissingField.errorMissingTargetClass(fieldSymbolReference);
     ImmutableList<LinkageErrorMissingField> missingFieldErrors =
         ImmutableList.of(linkageErrorMissingField);
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -304,7 +304,6 @@ public class StaticLinkageCheckerTest {
     Truth.assertThat(
         jarLinkageReport.getMissingClassErrors().get(0).getReason())
         .isEqualTo(Reason.TARGET_CLASS_NOT_FOUND);
-
   }
 
   @Test

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
+import com.google.cloud.tools.opensource.classpath.LinkageErrorWithReason.Reason;
 import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -300,6 +301,10 @@ public class StaticLinkageCheckerTest {
     Truth.assertThat(
             jarLinkageReport.getMissingClassErrors().get(0).getReference().getTargetClassName())
         .isEqualTo(nonExistentClassName);
+    Truth.assertThat(
+        jarLinkageReport.getMissingClassErrors().get(0).getReason())
+        .isEqualTo(Reason.TARGET_CLASS_NOT_FOUND);
+
   }
 
   @Test
@@ -310,14 +315,42 @@ public class StaticLinkageCheckerTest {
     StaticLinkageChecker staticLinkageChecker =
         StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
-    ClassSymbolReference invalidClassReference =
+    ClassSymbolReference publicClassReference =
+        ClassSymbolReference.builder()
+            .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
+            // This inner class is defined as public in firestore-v1beta1-0.28.0.jar
+            .setTargetClassName(
+                "com.google.firestore.v1beta1.FirestoreGrpc$FirestoreStub")
+            .build();
+    ImmutableList<ClassSymbolReference> classReferences = ImmutableList.of(publicClassReference);
+    SymbolReferenceSet symbolReferenceSet =
+        SymbolReferenceSet.builder().setClassReferences(classReferences).build();
+
+    JarLinkageReport jarLinkageReport =
+        staticLinkageChecker.generateLinkageReport(
+            absolutePathOfResource("testdata/gax-1.32.0.jar"),
+            symbolReferenceSet,
+            Collections.emptyList());
+
+    Truth.assertThat(jarLinkageReport.getMissingClassErrors()).isEmpty();
+  }
+
+  @Test
+  public void testFindClassReferences_privateClass() throws IOException, URISyntaxException {
+    List<Path> paths =
+        ImmutableList.of(
+            absolutePathOfResource("testdata/api-common-1.7.0.jar"));
+    StaticLinkageChecker staticLinkageChecker =
+        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+
+    ClassSymbolReference referenceToPrivateClass =
         ClassSymbolReference.builder()
             .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
             // This inner class is defined in firestore-v1beta1-0.28.0.jar
             .setTargetClassName(
-                "com.google.firestore.v1beta1.FirestoreGrpc$FirestoreMethodDescriptorSupplier")
+                "com.google.api.core.AbstractApiService$InnerService")
             .build();
-    ImmutableList<ClassSymbolReference> fieldReferences = ImmutableList.of(invalidClassReference);
+    ImmutableList<ClassSymbolReference> fieldReferences = ImmutableList.of(referenceToPrivateClass);
     SymbolReferenceSet symbolReferenceSet =
         SymbolReferenceSet.builder().setClassReferences(fieldReferences).build();
 
@@ -327,7 +360,9 @@ public class StaticLinkageCheckerTest {
             symbolReferenceSet,
             Collections.emptyList());
 
-    Truth.assertThat(jarLinkageReport.getMissingClassErrors()).isEmpty();
+    Truth.assertThat(jarLinkageReport.getMissingClassErrors()).hasSize(1);
+    Truth.assertThat(jarLinkageReport.getMissingClassErrors().get(0).getReason()).isEqualTo(
+        Reason.INVALID_ACCESS_MODIFIER);
   }
 
   @Test


### PR DESCRIPTION
To validate class reference modifier.

Fixes #253 

- `StaticLinkageChecker.checkLinkageErrorMissingClassAt` validates modifiers of target class.
- New interface `LinkageErrorWithReason` provides common fields for linkage errors: `reason` and `targetClassLocation`.
  The two field will help us when we diagnose why we get linkage errors
- The reason is represented as enum `LinkageErrorWithReason.Reason`
- LinkageErrorMissingField and LinkageErrorMissingClass implement the interface. Method reference is to follow the same (#293).

