### PR TITLE
Filter duplicate artifacts of different versions by groupId:artifactId

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -148,12 +148,12 @@ public class StaticLinkageChecker {
   /**
    * Finds jar file paths and dependency paths for Maven artifacts and their transitive
    * dependencies. When there are multiple versions of an artifact, the closest to the root ({@code
-   * artifacts}) is picked up into the key of the return value. This 'pick closest' strategy follows
-   * Maven's dependency mediation.
+   * artifacts}) is picked up. This 'pick closest' strategy follows Maven's dependency mediation.
+   * The values of the returned map for a key (jar file) represent the different Maven dependency
+   * paths from {@code artifacts} to the Maven artifact of the jar file.
    *
    * @param artifacts Maven artifacts to check
-   * @return map absolute paths of jar files to one or more Maven dependency path(s) from ({@code
-   *     artifacts}) to the Maven artifacts of the jar files
+   * @return map absolute paths of jar files to one or more Maven dependency paths
    * @throws RepositoryException when there is a problem in retrieving jar files
    * @see <a
    *     href="https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Transitive_Dependencies">Maven:

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -144,7 +144,6 @@ public class StaticLinkageChecker {
     return ImmutableList.copyOf(multimap.keySet());
   }
 
-  // Multimap is a pain, maybe just use LinkedHashMap<Path, List<DependencyPath>>
   /**
    * Finds jar file paths and dependency paths for Maven artifacts and their transitive
    * dependencies. When there are multiple versions of an artifact, the closest to the root ({@code
@@ -161,6 +160,8 @@ public class StaticLinkageChecker {
    */
   public static LinkedListMultimap<Path, DependencyPath> artifactsToPaths(List<Artifact> artifacts)
       throws RepositoryException {
+    // TODO(#315): Consider using LinkedHashMap<Path, List<DependencyPath>> over Multimap
+    // Multimap has many variation with different behaviors.
 
     LinkedListMultimap<Path, DependencyPath> multimap = LinkedListMultimap.create();
     if (artifacts.isEmpty()) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -189,8 +189,8 @@ public class StaticLinkageChecker {
         continue;
       }
       keyToFirstArtifactVersion.put(dependencyMediationKey, artifact.getVersion());
-      // When finding key first time, or additional dependency path to the artifact with same
-      // version is encountered, adds the dependency path to `multimap`,
+      // When finding the key (groupId:artifactId) first time, or additional dependency path to
+      // the artifact of the same version is encountered, adds the dependency path to `multimap`.
 
       Path jarAbsolutePath = artifact.getFile().toPath().toAbsolutePath();
       if (!jarAbsolutePath.toString().endsWith(".jar")) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -136,6 +136,9 @@ public class StaticLinkageChecker {
    * @param artifacts Maven artifacts to check
    * @return list of absolute paths to jar files
    * @throws RepositoryException when there is a problem in retrieving jar files
+   * @see <a
+   *     href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/classpath.html#sthref15">Setting
+   *     the Class Path: Specification Order</a>
    */
   public static ImmutableList<Path> artifactsToClasspath(List<Artifact> artifacts)
       throws RepositoryException {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -171,16 +171,16 @@ public class StaticLinkageChecker {
     List<DependencyPath> dependencyPaths = dependencyGraph.list();
 
     // To remove duplicates on (groupId:artifactId) for dependency mediation
-    Map<String, Artifact> keyToFirstArtifact = Maps.newHashMap();
+    Map<String, String> keyToFirstArtifactVersion = Maps.newHashMap();
 
     for (DependencyPath dependencyPath : dependencyPaths) {
       Artifact artifact = dependencyPath.getLeaf();
       String artifactVersion = artifact.getVersion();
       // groupId:artifactId
       String dependencyMediationKey = Artifacts.makeKey(artifact);
-      Artifact firstArtifactForKey = keyToFirstArtifact.get(dependencyMediationKey);
-      if (firstArtifactForKey != null
-          && !artifactVersion.equals(firstArtifactForKey.getVersion())) {
+      String firstArtifactVersionForKey = keyToFirstArtifactVersion.get(dependencyMediationKey);
+      if (firstArtifactVersionForKey != null
+          && !artifactVersion.equals(firstArtifactVersionForKey)) {
         // Not adding this artifact if different version of the artifact (<groupId>:<artifactId> as
         // key) is already in `multimap`.
         // As `dependencyPaths` elements are in level order (breadth-first), this first-wins
@@ -188,9 +188,9 @@ public class StaticLinkageChecker {
         // TODO(#309): add Gradle's dependency mediation
         continue;
       }
-      keyToFirstArtifact.put(dependencyMediationKey, artifact);
+      keyToFirstArtifactVersion.put(dependencyMediationKey, artifact.getVersion());
       // When finding key first time, or additional dependency path to the artifact with same
-      // version is encountered, add the dependency path to `multimap`
+      // version is encountered, adds the dependency path to `multimap`,
 
       Path jarAbsolutePath = artifact.getFile().toPath().toAbsolutePath();
       if (!jarAbsolutePath.toString().endsWith(".jar")) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -153,7 +153,7 @@ public class DependencyGraphBuilder {
    * @throws DependencyCollectionException when there is a problem in collecting dependency
    * @throws DependencyResolutionException when there is a problem in resolving dependency
    */
-  public static DependencyGraph getStaticLinkageCheckDependencies(List<Artifact> artifacts)
+  public static DependencyGraph getStaticLinkageCheckDependencyGraph(List<Artifact> artifacts)
       throws DependencyCollectionException, DependencyResolutionException {
     DependencyNode node = resolveCompileTimeDependencies(artifacts, true);
     DependencyGraph graph = new DependencyGraph();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -78,6 +78,19 @@ public class StaticLinkageCheckerTest {
   }
 
   @Test
+  public void testArtifactsToPaths_removingDuplicates() throws RepositoryException {
+    Artifact grpcArtifact = new DefaultArtifact("io.grpc:grpc-auth:1.15.1");
+    ListMultimap<Path, DependencyPath> multimap =
+        StaticLinkageChecker.artifactsToPaths(ImmutableList.of(grpcArtifact));
+
+    Set<Path> paths = multimap.keySet();
+    long jsr305Count = paths.stream().filter(path -> path.toString().contains("jsr305-")).count();
+    Truth.assertWithMessage("There should not be duplicated versions for jsr305")
+        .that(jsr305Count)
+        .isEqualTo(1);
+  }
+
+  @Test
   public void testCoordinateToClasspath_validCoordinate() throws RepositoryException {
     Artifact grpcArtifact = new DefaultArtifact("io.grpc:grpc-auth:1.15.1");
     List<Path> paths = StaticLinkageChecker.artifactsToClasspath(ImmutableList.of(grpcArtifact));

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -88,6 +88,14 @@ public class StaticLinkageCheckerTest {
     Truth.assertWithMessage("There should not be duplicated versions for jsr305")
         .that(jsr305Count)
         .isEqualTo(1);
+
+    Optional<Path> opencensusApiPathFound =
+        paths.stream().filter(path -> path.toString().contains("opencensus-api-")).findFirst();
+    Truth8.assertThat(opencensusApiPathFound).isPresent();
+    Path opencensusApiPath = opencensusApiPathFound.get();
+    Truth.assertWithMessage("Opencensus API should have multiple dependency paths")
+        .that(multimap.get(opencensusApiPath).size())
+        .isGreaterThan(1);
   }
 
   @Test

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -90,7 +90,7 @@ public class DependencyGraphBuilderTest {
   }
 
   @Test
-  public void testGetStaticLinkageCheckDependencies_multipleArtifacts()
+  public void testGetStaticLinkageCheckDependencyGraph_multipleArtifacts()
       throws DependencyCollectionException, DependencyResolutionException {
     DependencyGraph graph =
         DependencyGraphBuilder.getStaticLinkageCheckDependencyGraph(

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -93,7 +93,8 @@ public class DependencyGraphBuilderTest {
   public void testGetStaticLinkageCheckDependencies_multipleArtifacts()
       throws DependencyCollectionException, DependencyResolutionException {
     DependencyGraph graph =
-        DependencyGraphBuilder.getStaticLinkageCheckDependencies(Arrays.asList(datastore, guava));
+        DependencyGraphBuilder.getStaticLinkageCheckDependencyGraph(
+            Arrays.asList(datastore, guava));
 
     List<DependencyPath> list = graph.list();
     Assert.assertTrue(list.size() > 10);


### PR DESCRIPTION
Fixes #307 (on the option 2 in the issue)
Fixes #306, by ensuring there should not be duplicated jar files containing `TypeSafeMatcher`
