### PR TITLE
Maven-exec-plugin exec -> executable

### DIFF
--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -78,7 +78,7 @@
         <artifactId>exec-maven-plugin</artifactId>
         <configuration>
           <skip>false</skip>
-          <exec>java</exec>
+          <executable>java</executable>
           <mainClass>com.google.cloud.tools.opensource.dashboard.DashboardMain</mainClass>
         </configuration>
       </plugin>

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -78,7 +78,6 @@
         <artifactId>exec-maven-plugin</artifactId>
         <configuration>
           <skip>false</skip>
-          <executable>java</executable>
           <mainClass>com.google.cloud.tools.opensource.dashboard.DashboardMain</mainClass>
         </configuration>
       </plugin>


### PR DESCRIPTION
Fixes #316 

As per documentation ([link](https://www.mojohaus.org/exec-maven-plugin/examples/example-exec-for-java-programs.html)), `<executable>` is correct.