### PR TITLE
Class path builder

### DIFF
--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -78,7 +78,6 @@
         <artifactId>exec-maven-plugin</artifactId>
         <configuration>
           <skip>false</skip>
-          <exec>java</exec>
           <mainClass>com.google.cloud.tools.opensource.dashboard.DashboardMain</mainClass>
         </configuration>
       </plugin>

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -46,6 +46,7 @@ import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 
+import com.google.cloud.tools.opensource.classpath.ClassPathBuilder;
 import com.google.cloud.tools.opensource.classpath.JarLinkageReport;
 import com.google.cloud.tools.opensource.classpath.StaticLinkageCheckReport;
 import com.google.cloud.tools.opensource.classpath.StaticLinkageChecker;
@@ -95,9 +96,9 @@ public class DashboardMain {
 
     ArtifactCache cache = loadArtifactInfo(managedDependencies);
     
-    ImmutableList<Path> classpath = StaticLinkageChecker.artifactsToClasspath(managedDependencies);
+    ImmutableList<Path> classpath = ClassPathBuilder.artifactsToClasspath(managedDependencies);
     LinkedListMultimap<Path, DependencyPath> paths =
-        StaticLinkageChecker.artifactsToPaths(managedDependencies);
+        ClassPathBuilder.artifactsToPaths(managedDependencies);
     
     // TODO(suztomo): choose entry point classes for reachability
     ImmutableSet<Path> entryPoints = ImmutableSet.of(classpath.get(0));

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -252,7 +252,7 @@ public class DashboardMain {
 
       List<DependencyPath> dependencyPaths = completeDependencies.list();
 
-      // Filter relevant static linkage report
+      // Filter only relevant static linkage report to this artifact and its dependencies
       ImmutableSet<JarLinkageReport> staticLinkageCheckReports =
           dependencyPaths.stream()
               .map(dependencyPath -> dependencyPath.getLeaf().getFile().toPath())

--- a/dashboard/src/main/resources/css/dashboard.css
+++ b/dashboard/src/main/resources/css/dashboard.css
@@ -15,7 +15,15 @@
    margin-top: 0;
    margin-bottom: 0;
  }
- 
+
+ .static-linkage-check-dependency-paths {
+   margin-left: 15pt;
+ }
+
+ li.linked-from-artifact-true {
+   font-weight: bold;
+ }
+
  body {
    font-family: "Poppins", sans-serif;
    font-weight: 400;
@@ -50,5 +58,5 @@
  }
  
  pre {
-  line-height: normal;
+   line-height: normal;
  }

--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -115,14 +115,21 @@
     <p id="static-linkage-check">${totalLinkageErrorCount} static linkage error(s)</p>
     <#list jarLinkageReports as jarLinkageReport>
       <#if jarLinkageReport.getTotalErrorCount() gt 0>
-        <#assign jarPath = jarLinkageReport.getJarPath() />
-        <pre class="jar-linkage-report">${jarLinkageReport?html}</pre>
-        <#list jarToDependencyPaths.get(jarPath) as dependencyPath >
-          <#assign dependencyPathRoot = dependencyPath.get(0) />
-          <#assign linkedFromArtifact = dependencyPathRoot.getGroupId() == groupId
-              && dependencyPathRoot.getArtifactId() == artifactId>
-          <p class="linked-from-artifact-${linkedFromArtifact?c}">Linked from ${dependencyPath}</p>
-        </#list>
+        <pre>${jarLinkageReport?html}</pre>
+
+        <p class="static-linkage-check-dependency-paths">
+          Following paths to the jar file from BOM are found in the dependency tree.
+        </p>
+        <ul class="static-linkage-check-dependency-paths">
+          <#list jarToDependencyPaths.get(jarLinkageReport.getJarPath()) as dependencyPath >
+            <#assign dependencyPathRoot = dependencyPath.get(0) />
+            <#assign linkedFromArtifact = dependencyPathRoot.getGroupId() == groupId
+                && dependencyPathRoot.getArtifactId() == artifactId>
+            <li class="linked-from-artifact-${linkedFromArtifact?c}">${dependencyPath}
+            </li>
+          </#list>
+        </ul>
+
       </#if>
     </#list>
 

--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -115,7 +115,14 @@
     <p id="static-linkage-check">${totalLinkageErrorCount} static linkage error(s)</p>
     <#list jarLinkageReports as jarLinkageReport>
       <#if jarLinkageReport.getTotalErrorCount() gt 0>
+        <#assign jarPath = jarLinkageReport.getJarPath() />
         <pre class="jar-linkage-report">${jarLinkageReport?html}</pre>
+        <#list jarToDependencyPaths.get(jarPath) as dependencyPath >
+          <#assign dependencyPathRoot = dependencyPath.get(0) />
+          <#assign linkedFromArtifact = dependencyPathRoot.getGroupId() == groupId
+              && dependencyPathRoot.getArtifactId() == artifactId>
+          <p class="linked-from-artifact-${linkedFromArtifact?c}">Linked from ${dependencyPath}</p>
+        </#list>
       </#if>
     </#list>
 

--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -115,7 +115,7 @@
     <p id="static-linkage-check">${totalLinkageErrorCount} static linkage error(s)</p>
     <#list jarLinkageReports as jarLinkageReport>
       <#if jarLinkageReport.getTotalErrorCount() gt 0>
-        <pre>${jarLinkageReport?html}</pre>
+        <pre class="jar-linkage-report">${jarLinkageReport?html}</pre>
 
         <p class="static-linkage-check-dependency-paths">
           Following paths to the jar file from BOM are found in the dependency tree.

--- a/dashboard/src/main/resources/templates/dashboard.ftl
+++ b/dashboard/src/main/resources/templates/dashboard.ftl
@@ -58,7 +58,21 @@
 
     <h2>Static Linkage Errors</h2>
 
-    <pre id="static_linkage_errors">${staticLinkageErrors}</pre>
+    <#list jarLinkageReports as jarLinkageReport>
+      <#if jarLinkageReport.getTotalErrorCount() gt 0>
+        <pre id="static_linkage_errors">${jarLinkageReport?html}</pre>
+
+        <p class="static-linkage-check-dependency-paths">
+          Following paths to the jar file from BOM are found in the dependency tree.
+        </p>
+        <ul class="static-linkage-check-dependency-paths">
+          <#list jarToDependencyPaths.get(jarLinkageReport.getJarPath()) as dependencyPath >
+            <li>${dependencyPath}</li>
+          </#list>
+        </ul>
+
+      </#if>
+    </#list>
 
     <hr />      
       

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
-import com.google.common.collect.LinkedListMultimap;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -47,6 +46,7 @@ import com.google.cloud.tools.opensource.classpath.StaticLinkageCheckReport;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.LinkedListMultimap;
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
 import com.google.common.truth.Truth;
@@ -127,7 +127,8 @@ public class DashboardUnavailableArtifactTest {
 
     Iterable<JarLinkageReport> list = new ArrayList<>();
     StaticLinkageCheckReport report = StaticLinkageCheckReport.create(list);
-    DashboardMain.generateDashboard(configuration, outputDirectory, table, null, report);
+    DashboardMain.generateDashboard(
+        configuration, outputDirectory, table, null, report, LinkedListMultimap.create());
 
     Path generatedDashboardHtml = outputDirectory.resolve("dashboard.html");
     Assert.assertTrue(Files.isRegularFile(generatedDashboardHtml));

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
+import com.google.common.collect.LinkedListMultimap;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -84,7 +85,8 @@ public class DashboardUnavailableArtifactTest {
         StaticLinkageCheckReport.create(ImmutableList.of());
     List<ArtifactResults> artifactResults =
         DashboardMain.generateReports(
-            configuration, outputDirectory, cache, staticLinkageCheckReport);
+            configuration, outputDirectory, cache, staticLinkageCheckReport,
+            LinkedListMultimap.create());
 
     Assert.assertEquals(
         "The length of the ArtifactResults should match the length of artifacts",

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
@@ -59,9 +59,9 @@ public class ClassPathBuilder {
 
   /**
    * Finds jar file paths and dependency paths for Maven artifacts and their transitive
-   * dependencies. When there are multiple versions of an artifact, the closest to the root ({@code
-   * artifacts}) in breadth-first order is picked up. This 'pick closest' strategy follows Maven's
-   * dependency mediation.
+   * dependencies. When there are multiple versions of an artifact in the dependency tree, the
+   * closest to the root in breadth-first order is picked up. This 'pick closest' strategy follows
+   * Maven's dependency mediation.
    *
    * <p>The keys of the returned map represent jar files of {@code artifacts} and their transitive
    * dependencies. The return value of {@link LinkedListMultimap#keySet()} preserves key iteration
@@ -70,7 +70,7 @@ public class ClassPathBuilder {
    * <p>The values of the returned map for a key (jar file) represent the different Maven dependency
    * paths from {@code artifacts} to the Maven artifact of the jar file.
    *
-   * @param artifacts Maven artifacts to check
+   * @param artifacts Maven artifacts to check. They are treated as the root of the dependency tree.
    * @return an ordered map of absolute paths of jar files to one or more Maven dependency paths
    * @throws RepositoryException when there is a problem in retrieving jar files
    */

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
@@ -30,20 +30,20 @@ import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 
 /**
- * Utility to build a class path (a list of jar files) to be used as input for {@link
- * StaticLinkageChecker}. The order of the list affects the result of static linkage check as the
- * linkage checker picks a class file first found in the class path in the same manner as Java
- * virtual machine.
+ * Utility to build a class path (a list of jar files) through a dependency tree of Maven artifacts.
  *
  * @see <a
- *     href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/classpath.html#sthref15">Setting
- *     the Class Path: Specification Order</a>
+ *     href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/classpath.html#sthref15">
+ *     Setting the Class Path: Specification Order</a>
+ * @see <a
+ *     href="https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Transitive_Dependencies">
+ *     Maven: Introduction to the Dependency Mechanism</a>
  */
 public class ClassPathBuilder {
 
   /**
-   * Finds jar file paths for Maven artifacts and their transitive dependencies. The returned list
-   * can be used as input class path for {@link StaticLinkageChecker}.
+   * Finds jar file paths for Maven artifacts and their transitive dependencies, using Maven's
+   * dependency mediation strategy.
    *
    * @param artifacts Maven artifacts to check
    * @return list of absolute paths to jar files
@@ -60,11 +60,12 @@ public class ClassPathBuilder {
   /**
    * Finds jar file paths and dependency paths for Maven artifacts and their transitive
    * dependencies. When there are multiple versions of an artifact, the closest to the root ({@code
-   * artifacts}) is picked up. This 'pick closest' strategy follows Maven's dependency mediation.
+   * artifacts}) in breadth-first order is picked up. This 'pick closest' strategy follows Maven's
+   * dependency mediation.
    *
    * <p>The keys of the returned map represent jar files of {@code artifacts} and their transitive
-   * dependencies. The return value of {@link LinkedListMultimap#keySet()}, which preserves key
-   * iteration order, can be used as input class path for {@link StaticLinkageChecker}.
+   * dependencies. The return value of {@link LinkedListMultimap#keySet()} preserves key iteration
+   * order.
    *
    * <p>The values of the returned map for a key (jar file) represent the different Maven dependency
    * paths from {@code artifacts} to the Maven artifact of the jar file.
@@ -72,9 +73,6 @@ public class ClassPathBuilder {
    * @param artifacts Maven artifacts to check
    * @return an ordered map of absolute paths of jar files to one or more Maven dependency paths
    * @throws RepositoryException when there is a problem in retrieving jar files
-   * @see <a
-   *     href="https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Transitive_Dependencies">Maven:
-   *     Introduction to the Dependency Mechanism</a>
    */
   public static LinkedListMultimap<Path, DependencyPath> artifactsToDependencyPaths(
       List<Artifact> artifacts) throws RepositoryException {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
@@ -31,7 +31,12 @@ import org.eclipse.aether.artifact.Artifact;
 
 /**
  * Utility to build a class path (a list of jar files) to be used as input for {@link
- * StaticLinkageChecker}.
+ * StaticLinkageChecker}. The linkage checker picks a class file first found in the class path in
+ * the same manner as Java virtual machine.
+ *
+ * @see <a
+ *     href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/classpath.html#sthref15">Setting
+ *     the Class Path: Specification Order</a>
  */
 public class ClassPathBuilder {
 
@@ -41,14 +46,12 @@ public class ClassPathBuilder {
    * @param artifacts Maven artifacts to check
    * @return list of absolute paths to jar files
    * @throws RepositoryException when there is a problem in retrieving jar files
-   * @see <a
-   *     href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/classpath.html#sthref15">Setting
-   *     the Class Path: Specification Order</a>
    */
   public static ImmutableList<Path> artifactsToClasspath(List<Artifact> artifacts)
       throws RepositoryException {
 
-    LinkedListMultimap<Path, DependencyPath> multimap = artifactsToPaths(artifacts);
+    // LinkedListMultimap keeps the order they were first added to the multimap
+    LinkedListMultimap<Path, DependencyPath> multimap = artifactsToDependencyPaths(artifacts);
     return ImmutableList.copyOf(multimap.keySet());
   }
 
@@ -66,8 +69,8 @@ public class ClassPathBuilder {
    *     href="https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Transitive_Dependencies">Maven:
    *     Introduction to the Dependency Mechanism</a>
    */
-  public static LinkedListMultimap<Path, DependencyPath> artifactsToPaths(List<Artifact> artifacts)
-      throws RepositoryException {
+  public static LinkedListMultimap<Path, DependencyPath> artifactsToDependencyPaths(
+      List<Artifact> artifacts) throws RepositoryException {
     // TODO(#315): Consider using LinkedHashMap<Path, List<DependencyPath>> over Multimap
     // Multimap has many variation with different behaviors.
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.classpath;
+
+import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
+import com.google.cloud.tools.opensource.dependencies.DependencyGraphBuilder;
+import com.google.cloud.tools.opensource.dependencies.DependencyPath;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.LinkedListMultimap;
+import java.nio.file.Path;
+import java.util.List;
+import org.eclipse.aether.RepositoryException;
+import org.eclipse.aether.artifact.Artifact;
+
+/**
+ * Utility to build a class path (a list of jar files) to be used as input for {@link
+ * StaticLinkageChecker}.
+ */
+public class ClassPathBuilder {
+
+  /**
+   * Finds jar file paths for Maven artifacts and their dependencies.
+   *
+   * @param artifacts Maven artifacts to check
+   * @return list of absolute paths to jar files
+   * @throws RepositoryException when there is a problem in retrieving jar files
+   */
+  public static ImmutableList<Path> artifactsToClasspath(List<Artifact> artifacts)
+      throws RepositoryException {
+
+    LinkedListMultimap<Path, DependencyPath> multimap = artifactsToPaths(artifacts);
+    return ImmutableList.copyOf(multimap.keySet());
+  }
+
+
+  // Multimap is a pain, maybe just use LinkedHashMap<Path, List<DependencyPath>>
+  /**
+   * Finds jar file paths for Maven artifacts and their dependencies.
+   *
+   * @param artifacts Maven artifacts to check
+   * @return map absolute paths of jar files to Maven dependency paths
+   * @throws RepositoryException when there is a problem in retrieving jar files
+   */
+  public static LinkedListMultimap<Path, DependencyPath> artifactsToPaths(List<Artifact> artifacts)
+      throws RepositoryException {
+
+    LinkedListMultimap<Path, DependencyPath> multimap = LinkedListMultimap.create();
+    if (artifacts.isEmpty()) {
+      return multimap;
+    }
+    // dependencyGraph holds multiple versions for one artifact key (groupId:artifactId)
+    DependencyGraph dependencyGraph =
+        DependencyGraphBuilder.getStaticLinkageCheckDependencies(artifacts);
+    List<DependencyPath> dependencyPaths = dependencyGraph.list();
+
+    for (DependencyPath dependencyPath : dependencyPaths) {
+      Artifact artifact = dependencyPath.getLeaf();
+      Path jarAbsolutePath = artifact.getFile().toPath().toAbsolutePath();
+      if (!jarAbsolutePath.toString().endsWith(".jar")) {
+        continue;
+      }
+      multimap.put(jarAbsolutePath, dependencyPath);
+    }
+    return multimap;
+  }
+}

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
@@ -34,7 +34,7 @@ public abstract class JarLinkageReport {
   /**
    * Returns the dependency path(s) to this artifact.
    */
-  abstract ImmutableList<DependencyPath> getDependencyPaths();
+//  abstract ImmutableList<DependencyPath> getDependencyPaths();
 
   public abstract ImmutableList<StaticLinkageError<ClassSymbolReference>> getMissingClassErrors();
 
@@ -43,13 +43,12 @@ public abstract class JarLinkageReport {
   public abstract ImmutableList<StaticLinkageError<FieldSymbolReference>> getMissingFieldErrors();
 
   static Builder builder() {
-    return new AutoValue_JarLinkageReport.Builder().setDependencyPaths(ImmutableList.of());
+    return new AutoValue_JarLinkageReport.Builder();
   }
 
   @AutoValue.Builder
   abstract static class Builder {
     abstract Builder setJarPath(Path value);
-    abstract Builder setDependencyPaths(Iterable<DependencyPath> paths);
 
     abstract Builder setMissingClassErrors(
         Iterable<StaticLinkageError<ClassSymbolReference>> errors);
@@ -70,10 +69,11 @@ public abstract class JarLinkageReport {
     int totalErrors = getTotalErrorCount();
 
     builder.append(getJarPath().getFileName() + " (" + totalErrors + " errors):\n");
+    /*
     for (DependencyPath path : getDependencyPaths()) {
       builder.append(indent + "Linked from: " + path);
       builder.append("\n");
-    }
+    } */
     for (StaticLinkageError<ClassSymbolReference> missingClass : getMissingClassErrors()) {
       builder.append(indent + missingClass);
       builder.append("\n");

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.opensource.classpath;
 
 import com.google.auto.value.AutoValue;
-import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.collect.ImmutableList;
 import java.nio.file.Path;
 
@@ -30,11 +29,6 @@ public abstract class JarLinkageReport {
    * Returns the absolute path of the jar file containing source classes of linkage errors
    */
   public abstract Path getJarPath();
-  
-  /**
-   * Returns the dependency path(s) to this artifact.
-   */
-//  abstract ImmutableList<DependencyPath> getDependencyPaths();
 
   public abstract ImmutableList<StaticLinkageError<ClassSymbolReference>> getMissingClassErrors();
 
@@ -69,11 +63,6 @@ public abstract class JarLinkageReport {
     int totalErrors = getTotalErrorCount();
 
     builder.append(getJarPath().getFileName() + " (" + totalErrors + " errors):\n");
-    /*
-    for (DependencyPath path : getDependencyPaths()) {
-      builder.append(indent + "Linked from: " + path);
-      builder.append("\n");
-    } */
     for (StaticLinkageError<ClassSymbolReference> missingClass : getMissingClassErrors()) {
       builder.append(indent + missingClass);
       builder.append("\n");

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
@@ -103,7 +103,7 @@ public class StaticLinkageCheckOption {
       String bomCoordinates = commandLine.getOptionValue("b");
       DefaultArtifact bomArtifact = new DefaultArtifact(bomCoordinates);
       List<Artifact> artifactsInBom = RepositoryUtility.readBom(bomArtifact);
-      return StaticLinkageChecker.artifactsToClasspath(artifactsInBom);
+      return ClassPathBuilder.artifactsToClasspath(artifactsInBom);
     } else if (commandLine.hasOption("a")) {
       String mavenCoordinatesOption = commandLine.getOptionValue("a");
       ImmutableList<Artifact> artifacts =
@@ -112,7 +112,7 @@ public class StaticLinkageCheckOption {
               .stream()
               .map(DefaultArtifact::new)
               .collect(toImmutableList());
-      return StaticLinkageChecker.artifactsToClasspath(artifacts);
+      return ClassPathBuilder.artifactsToClasspath(artifacts);
     } else if (commandLine.hasOption("j")) {
       String jarFiles = commandLine.getOptionValue("j");
       ImmutableList<Path> jarFilesInArguments =

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -128,51 +128,6 @@ public class StaticLinkageChecker {
     System.out.println(report);
   }
 
-  /**
-   * Finds jar file paths for Maven artifacts and their dependencies.
-   *
-   * @param artifacts Maven artifacts to check
-   * @return list of absolute paths to jar files
-   * @throws RepositoryException when there is a problem in retrieving jar files
-   */
-  public static ImmutableList<Path> artifactsToClasspath(List<Artifact> artifacts)
-      throws RepositoryException {
-    
-    LinkedListMultimap<Path, DependencyPath> multimap = artifactsToPaths(artifacts);
-    return ImmutableList.copyOf(multimap.keySet());
-  }
-  
-  
-  // Multimap is a pain, maybe just use LinkedHashMap<Path, List<DependencyPath>>
-  /**
-   * Finds jar file paths for Maven artifacts and their dependencies.
-   *
-   * @param artifacts Maven artifacts to check
-   * @return map absolute paths of jar files to Maven dependency paths
-   * @throws RepositoryException when there is a problem in retrieving jar files
-   */
-  public static LinkedListMultimap<Path, DependencyPath> artifactsToPaths(List<Artifact> artifacts)
-      throws RepositoryException {
-    
-    LinkedListMultimap<Path, DependencyPath> multimap = LinkedListMultimap.create();
-    if (artifacts.isEmpty()) {
-      return multimap;
-    }
-    // dependencyGraph holds multiple versions for one artifact key (groupId:artifactId)
-    DependencyGraph dependencyGraph =
-        DependencyGraphBuilder.getStaticLinkageCheckDependencies(artifacts);
-    List<DependencyPath> dependencyPaths = dependencyGraph.list();
-
-    for (DependencyPath dependencyPath : dependencyPaths) {
-      Artifact artifact = dependencyPath.getLeaf();
-      Path jarAbsolutePath = artifact.getFile().toPath().toAbsolutePath();
-      if (!jarAbsolutePath.toString().endsWith(".jar")) {
-        continue;
-      }
-      multimap.put(jarAbsolutePath, dependencyPath);
-    }
-    return multimap;
-  }
 
   /**
    * Finds linkage errors in the input classpath and generates a static linkage check report.

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -19,19 +19,14 @@ package com.google.cloud.tools.opensource.classpath;
 import static com.google.cloud.tools.opensource.classpath.ClassDumper.getClassHierarchy;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
-import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.ListMultimap;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -63,15 +58,7 @@ public class StaticLinkageChecker {
     ClassDumper dumper = ClassDumper.create(jarPaths);
     return new StaticLinkageChecker(onlyReachable, dumper, entryPoints);
   }
-/*
-  public static StaticLinkageChecker create(boolean onlyReachable,
-      LinkedListMultimap<Path, DependencyPath> paths, ImmutableSet<Path> entryPoints)
-      throws IOException {
-    List<Path> jarPaths = new ArrayList<>(paths.keySet());
-    ClassDumper dumper = ClassDumper.create(jarPaths);
-    return new StaticLinkageChecker(onlyReachable, dumper, entryPoints, paths);
-  }
-*/
+
   /**
    * If true, the report excludes linkage errors on classes that are not reachable
    * from the entry points of the class usage graph.
@@ -82,13 +69,6 @@ public class StaticLinkageChecker {
 
   private final ImmutableSet<Path> entryPoints;
   
-  // private final ListMultimap<Path, DependencyPath> paths;
-/*
-  private StaticLinkageChecker(
-      boolean reportOnlyReachable, ClassDumper classDumper, Iterable<Path> entryPoints) {
-    this(reportOnlyReachable, classDumper, entryPoints, ArrayListMultimap.create());
-  }
-*/
   private StaticLinkageChecker(
       boolean reportOnlyReachable,
       ClassDumper classDumper,
@@ -138,7 +118,6 @@ public class StaticLinkageChecker {
     ImmutableList.Builder<JarLinkageReport> jarLinkageReports = ImmutableList.builder();
     for (Map.Entry<Path, SymbolReferenceSet> entry : jarToSymbols.build().entrySet()) {
       Path jarPath = entry.getKey();
-      // Iterable<DependencyPath> dependencyPaths = this.paths.get(jarPath);
       jarLinkageReports.add(generateLinkageReport(jarPath, entry.getValue()));
     }
 
@@ -162,8 +141,7 @@ public class StaticLinkageChecker {
   @VisibleForTesting
   JarLinkageReport generateLinkageReport(Path jarPath, SymbolReferenceSet symbolReferenceSet) {
     
-    JarLinkageReport.Builder reportBuilder = JarLinkageReport.builder()
-        .setJarPath(jarPath);
+    JarLinkageReport.Builder reportBuilder = JarLinkageReport.builder().setJarPath(jarPath);
 
     // Because the Java compiler ensures that there are no static linkage errors between classes
     // defined in the same jar file, this validation excludes reference within the same jar file.

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -63,7 +63,7 @@ public class StaticLinkageChecker {
     ClassDumper dumper = ClassDumper.create(jarPaths);
     return new StaticLinkageChecker(onlyReachable, dumper, entryPoints);
   }
-  
+/*
   public static StaticLinkageChecker create(boolean onlyReachable,
       LinkedListMultimap<Path, DependencyPath> paths, ImmutableSet<Path> entryPoints)
       throws IOException {
@@ -71,7 +71,7 @@ public class StaticLinkageChecker {
     ClassDumper dumper = ClassDumper.create(jarPaths);
     return new StaticLinkageChecker(onlyReachable, dumper, entryPoints, paths);
   }
-
+*/
   /**
    * If true, the report excludes linkage errors on classes that are not reachable
    * from the entry points of the class usage graph.
@@ -82,22 +82,20 @@ public class StaticLinkageChecker {
 
   private final ImmutableSet<Path> entryPoints;
   
-  private final ListMultimap<Path, DependencyPath> paths;
-
+  // private final ListMultimap<Path, DependencyPath> paths;
+/*
   private StaticLinkageChecker(
       boolean reportOnlyReachable, ClassDumper classDumper, Iterable<Path> entryPoints) {
     this(reportOnlyReachable, classDumper, entryPoints, ArrayListMultimap.create());
   }
-
+*/
   private StaticLinkageChecker(
       boolean reportOnlyReachable,
       ClassDumper classDumper,
-      Iterable<Path> entryPoints,
-      ListMultimap<Path, DependencyPath> paths) {
+      Iterable<Path> entryPoints) {
     this.reportOnlyReachable = reportOnlyReachable;
     this.classDumper = Preconditions.checkNotNull(classDumper);
     this.entryPoints = ImmutableSet.copyOf(entryPoints);
-    this.paths = Preconditions.checkNotNull(paths);
   }
 
   /**
@@ -140,8 +138,8 @@ public class StaticLinkageChecker {
     ImmutableList.Builder<JarLinkageReport> jarLinkageReports = ImmutableList.builder();
     for (Map.Entry<Path, SymbolReferenceSet> entry : jarToSymbols.build().entrySet()) {
       Path jarPath = entry.getKey();
-      Iterable<DependencyPath> dependencyPaths = this.paths.get(jarPath);
-      jarLinkageReports.add(generateLinkageReport(jarPath, entry.getValue(), dependencyPaths));
+      // Iterable<DependencyPath> dependencyPaths = this.paths.get(jarPath);
+      jarLinkageReports.add(generateLinkageReport(jarPath, entry.getValue()));
     }
 
     if (reportOnlyReachable) {
@@ -162,12 +160,10 @@ public class StaticLinkageChecker {
    * @return linkage report for the jar file, which includes linkage errors if any
    */
   @VisibleForTesting
-  JarLinkageReport generateLinkageReport(Path jarPath, SymbolReferenceSet symbolReferenceSet,
-      Iterable<DependencyPath> dependencyPaths) {
+  JarLinkageReport generateLinkageReport(Path jarPath, SymbolReferenceSet symbolReferenceSet) {
     
     JarLinkageReport.Builder reportBuilder = JarLinkageReport.builder()
-        .setJarPath(jarPath)
-        .setDependencyPaths(dependencyPaths);
+        .setJarPath(jarPath);
 
     // Because the Java compiler ensures that there are no static linkage errors between classes
     // defined in the same jar file, this validation excludes reference within the same jar file.

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
@@ -93,7 +93,7 @@ public final class DependencyPath {
   }
 
   // TODO think about index out of bounds
-  Artifact get(int i) {
+  public Artifact get(int i) {
     return path.get(i);
   }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -185,7 +185,7 @@ public class ClassDumperTest {
   public void testMapJarToClasses_classWithDollars()
       throws IOException, RepositoryException {
     Artifact grpcArtifact = new DefaultArtifact("com.google.code.gson:gson:2.6.2");
-    List<Path> paths = StaticLinkageChecker.artifactsToClasspath(ImmutableList.of(grpcArtifact));
+    List<Path> paths = ClassPathBuilder.artifactsToClasspath(ImmutableList.of(grpcArtifact));
     Path gsonJar = paths.get(0);
 
     ImmutableSetMultimap<Path, String> pathToClasses = ClassDumper

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -54,7 +54,7 @@ public class ClassPathBuilderTest {
   public void testArtifactsToPaths_removingDuplicates() throws RepositoryException {
     Artifact grpcArtifact = new DefaultArtifact("io.grpc:grpc-auth:1.15.1");
     ListMultimap<Path, DependencyPath> multimap =
-        ClassPathBuilder.artifactsToPaths(ImmutableList.of(grpcArtifact));
+        ClassPathBuilder.artifactsToDependencyPaths(ImmutableList.of(grpcArtifact));
 
     Set<Path> paths = multimap.keySet();
     long jsr305Count = paths.stream().filter(path -> path.toString().contains("jsr305-")).count();
@@ -76,7 +76,7 @@ public class ClassPathBuilderTest {
 
     Artifact grpcArtifact = new DefaultArtifact("io.grpc:grpc-auth:1.15.1");
     ListMultimap<Path, DependencyPath> multimap =
-        ClassPathBuilder.artifactsToPaths(ImmutableList.of(grpcArtifact));
+        ClassPathBuilder.artifactsToDependencyPaths(ImmutableList.of(grpcArtifact));
 
     Set<Path> paths = multimap.keySet();
 
@@ -167,7 +167,7 @@ public class ClassPathBuilderTest {
     }
 
     JarLinkageReport jarLinkageReport = staticLinkageChecker.generateLinkageReport(httpClientJar,
-        symbolReferenceSet, Collections.emptyList());
+        symbolReferenceSet);
 
     Truth.assertWithMessage("Method references within the same jar file should not be reported")
         .that(jarLinkageReport.getMissingMethodErrors())

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -25,7 +25,6 @@ import com.google.common.truth.Truth;
 import com.google.common.truth.Truth8;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.classpath;
+
+import com.google.cloud.tools.opensource.dependencies.DependencyPath;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ListMultimap;
+import com.google.common.truth.Correspondence;
+import com.google.common.truth.Truth;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.aether.RepositoryException;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClassPathBuilderTest {
+
+  static final Correspondence<Path, String> PATH_FILE_NAMES =
+      new Correspondence<Path, String>() {
+        @Override
+        public boolean compare(Path actual, String expected) {
+          return actual.getFileName().toString().equals(expected);
+        }
+
+        @Override
+        public String toString() {
+          return "has file name equal to";
+        }
+      };
+
+  @Test
+  public void testArtifactsToPaths() throws RepositoryException {
+
+    Artifact grpcArtifact = new DefaultArtifact("io.grpc:grpc-auth:1.15.1");
+    ListMultimap<Path, DependencyPath> multimap =
+        ClassPathBuilder.artifactsToPaths(ImmutableList.of(grpcArtifact));
+
+    Set<Path> paths = multimap.keySet();
+
+    Truth.assertThat(paths)
+        .comparingElementsUsing(PATH_FILE_NAMES)
+        .containsAllOf("grpc-auth-1.15.1.jar", "google-auth-library-credentials-0.9.0.jar");
+    paths.forEach(
+        path ->
+            Truth.assertWithMessage("Every returned path should be an absolute path")
+                .that(path.isAbsolute())
+                .isTrue());
+  }
+
+  @Test
+  public void testCoordinateToClasspath_validCoordinate() throws RepositoryException {
+    Artifact grpcArtifact = new DefaultArtifact("io.grpc:grpc-auth:1.15.1");
+    List<Path> paths = ClassPathBuilder.artifactsToClasspath(ImmutableList.of(grpcArtifact));
+
+    Truth.assertThat(paths)
+        .comparingElementsUsing(PATH_FILE_NAMES)
+        .contains("grpc-auth-1.15.1.jar");
+    Truth.assertThat(paths)
+        .comparingElementsUsing(PATH_FILE_NAMES)
+        .contains("google-auth-library-credentials-0.9.0.jar");
+    paths.forEach(
+        path ->
+            Truth.assertWithMessage("Every returned path should be an absolute path")
+                .that(path.isAbsolute())
+                .isTrue());
+  }
+
+  @Test
+  public void testCoordinateToClasspath_optionalDependency() throws RepositoryException {
+    Artifact bigTableArtifact =
+        new DefaultArtifact("com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha");
+    List<Path> paths =
+        ClassPathBuilder.artifactsToClasspath(ImmutableList.of(bigTableArtifact));
+    Truth.assertThat(paths).comparingElementsUsing(PATH_FILE_NAMES).contains("log4j-1.2.12.jar");
+  }
+
+  @Test
+  public void testCoordinateToClasspath_invalidCoordinate() {
+    Artifact nonExistentArtifact = new DefaultArtifact("io.grpc:nosuchartifact:1.2.3");
+    try {
+      ClassPathBuilder.artifactsToClasspath(ImmutableList.of(nonExistentArtifact));
+      Assert.fail("Invalid Maven coodinate should raise RepositoryException");
+    } catch (RepositoryException ex) {
+      Truth.assertThat(ex.getMessage())
+          .contains("Could not find artifact io.grpc:nosuchartifact:jar:1.2.3");
+    }
+  }
+
+  @Test
+  public void testCoordinateToClasspath_emptyInput() throws RepositoryException {
+    List<Path> jars = ClassPathBuilder.artifactsToClasspath(ImmutableList.of());
+    Truth.assertThat(jars).isEmpty();
+  }
+
+  @Test
+  public void testFindInvalidReferences_selfReferenceFromAbstractClassToInterface()
+      throws RepositoryException, IOException {
+    Artifact bigTableArtifact =
+        new DefaultArtifact("com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha");
+    List<Path> paths =
+        ClassPathBuilder.artifactsToClasspath(ImmutableList.of(bigTableArtifact));
+    Path httpClientJar =
+        paths
+            .stream()
+            .filter(path -> "httpclient-4.5.3.jar".equals(path.getFileName().toString()))
+            .findFirst()
+            .get();
+    StaticLinkageChecker staticLinkageChecker =
+        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+
+    // httpclient-4.5.3 AbstractVerifier has a method reference of
+    // 'void verify(String host, String[] cns, String[] subjectAlts)' to itself and its interface
+    // X509HostnameVerifier has the method.
+    // https://github.com/apache/httpcomponents-client/blob/e2cf733c60f910d17dc5cfc0a77797054a2e322e/httpclient/src/main/java/org/apache/http/conn/ssl/AbstractVerifier.java#L153
+    SymbolReferenceSet symbolReferenceSet = ClassDumper.scanSymbolReferencesInJar(httpClientJar);
+    ClassSymbolReference referenceToGZipInputStreamFactory =
+        ClassSymbolReference.builder()
+            .setSourceClassName("org.apache.http.client.protocol.ResponseContentEncoding")
+            .setTargetClassName("org.apache.http.client.entity.GZIPInputStreamFactory")
+            .build();
+    if (symbolReferenceSet.getClassReferences().contains(referenceToGZipInputStreamFactory)) {
+      System.out.println(
+          "Somehow httpclient-4.5.3 contains GZipInputStreamFactory reference, which is added 4.5.4");
+    }
+
+    JarLinkageReport jarLinkageReport = staticLinkageChecker.generateLinkageReport(httpClientJar,
+        symbolReferenceSet, Collections.emptyList());
+
+    Truth.assertWithMessage("Method references within the same jar file should not be reported")
+        .that(jarLinkageReport.getMissingMethodErrors())
+        .isEmpty();
+  }
+}

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -28,7 +28,6 @@ import com.google.common.truth.Truth8;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -73,7 +73,7 @@ public class StaticLinkageCheckerTest {
         absolutePathOfResource("testdata/grpc-google-cloud-firestore-v1beta1-0.28.0.jar");
     JarLinkageReport jarLinkageReport =
         staticLinkageChecker.generateLinkageReport(
-            jarNotContainingImmutableList, symbolReferenceSet, Collections.emptyList());
+            jarNotContainingImmutableList, symbolReferenceSet);
 
     Truth.assertThat(jarLinkageReport.getMissingMethodErrors()).hasSize(1);
     Assert.assertEquals(
@@ -100,7 +100,7 @@ public class StaticLinkageCheckerTest {
         SymbolReferenceSet.builder().setMethodReferences(methodReferences).build();
 
     JarLinkageReport jarLinkageReport = staticLinkageChecker.generateLinkageReport(paths.get(0),
-        symbolReferenceSet, Collections.emptyList());
+        symbolReferenceSet);
 
     Truth.assertThat(jarLinkageReport.getMissingMethodErrors()).isEmpty();
   }
@@ -248,8 +248,7 @@ public class StaticLinkageCheckerTest {
     JarLinkageReport jarLinkageReport =
         staticLinkageChecker.generateLinkageReport(
             absolutePathOfResource("testdata/gax-1.32.0.jar"),
-            symbolReferenceSet,
-            Collections.emptyList());
+            symbolReferenceSet);
 
     Truth.assertThat(jarLinkageReport.getMissingFieldErrors()).isEmpty();
   }
@@ -275,8 +274,7 @@ public class StaticLinkageCheckerTest {
     JarLinkageReport jarLinkageReport =
         staticLinkageChecker.generateLinkageReport(
             absolutePathOfResource("testdata/gax-1.32.0.jar"),
-            symbolReferenceSet,
-            Collections.emptyList());
+            symbolReferenceSet);
 
     Truth.assertThat(jarLinkageReport.getMissingFieldErrors()).hasSize(1);
     Truth.assertThat(jarLinkageReport.getMissingFieldErrors().get(0).getReference().getFieldName())
@@ -436,8 +434,7 @@ public class StaticLinkageCheckerTest {
     JarLinkageReport jarLinkageReport =
         staticLinkageChecker.generateLinkageReport(
             absolutePathOfResource("testdata/gax-1.32.0.jar"),
-            symbolReferenceSet,
-            Collections.emptyList());
+            symbolReferenceSet);
 
     Truth.assertThat(jarLinkageReport.getMissingClassErrors()).hasSize(1);
     Truth.assertThat(
@@ -469,8 +466,7 @@ public class StaticLinkageCheckerTest {
     JarLinkageReport jarLinkageReport =
         staticLinkageChecker.generateLinkageReport(
             absolutePathOfResource("testdata/gax-1.32.0.jar"),
-            symbolReferenceSet,
-            Collections.emptyList());
+            symbolReferenceSet);
 
     Truth.assertThat(jarLinkageReport.getMissingClassErrors()).isEmpty();
   }
@@ -495,8 +491,7 @@ public class StaticLinkageCheckerTest {
     JarLinkageReport jarLinkageReport =
         staticLinkageChecker.generateLinkageReport(
             absolutePathOfResource("testdata/gax-1.32.0.jar"),
-            symbolReferenceSet,
-            Collections.emptyList());
+            symbolReferenceSet);
 
     Truth.assertThat(jarLinkageReport.getMissingClassErrors()).hasSize(1);
     StaticLinkageError<ClassSymbolReference> classReferenceError =
@@ -659,14 +654,14 @@ public class StaticLinkageCheckerTest {
 
     JarLinkageReport reportWith65First =
         staticLinkageChecker65First.generateLinkageReport(
-            firestoreDependencies.get(0), symbolReferenceSet, Collections.emptyList());
+            firestoreDependencies.get(0), symbolReferenceSet);
     Truth.assertWithMessage("Firestore version 65 does not have CollectionReference.listDocuments")
         .that(reportWith65First.getMissingMethodErrors())
         .hasSize(1);
 
     JarLinkageReport reportWith66First =
         staticLinkageChecker66First.generateLinkageReport(
-            firestoreDependencies.get(0), symbolReferenceSet, Collections.emptyList());
+            firestoreDependencies.get(0), symbolReferenceSet);
     Truth.assertWithMessage("Firestore version 66 has CollectionReference.listDocuments")
         .that(reportWith66First.getMissingMethodErrors())
         .isEmpty();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -17,14 +17,12 @@
 package com.google.cloud.tools.opensource.classpath;
 
 import static com.google.cloud.tools.opensource.classpath.ClassDumperTest.absolutePathOfResource;
+import static com.google.cloud.tools.opensource.classpath.ClassPathBuilderTest.PATH_FILE_NAMES;
 
 import com.google.cloud.tools.opensource.classpath.StaticLinkageError.Reason;
-import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
-import com.google.common.truth.Correspondence;
 import com.google.common.truth.Truth;
 import com.google.common.truth.Truth8;
 import java.io.IOException;
@@ -33,133 +31,15 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.ParseException;
 import org.eclipse.aether.RepositoryException;
-import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class StaticLinkageCheckerTest {
-
-  private static final Correspondence<Path, String> PATH_FILE_NAMES =
-      new Correspondence<Path, String>() {
-        @Override
-        public boolean compare(Path actual, String expected) {
-          return actual.getFileName().toString().equals(expected);
-        }
-
-        @Override
-        public String toString() {
-          return "has file name equal to";
-        }
-      };
-
-  @Test
-  public void testArtifactsToPaths() throws RepositoryException {
-    
-    Artifact grpcArtifact = new DefaultArtifact("io.grpc:grpc-auth:1.15.1");
-    ListMultimap<Path, DependencyPath> multimap =
-        StaticLinkageChecker.artifactsToPaths(ImmutableList.of(grpcArtifact));
-
-    Set<Path> paths = multimap.keySet();
-    
-    Truth.assertThat(paths)
-        .comparingElementsUsing(PATH_FILE_NAMES)
-        .containsAllOf("grpc-auth-1.15.1.jar", "google-auth-library-credentials-0.9.0.jar");
-    paths.forEach(
-        path ->
-            Truth.assertWithMessage("Every returned path should be an absolute path")
-                .that(path.isAbsolute())
-                .isTrue());
-  }
-
-  @Test
-  public void testCoordinateToClasspath_validCoordinate() throws RepositoryException {
-    Artifact grpcArtifact = new DefaultArtifact("io.grpc:grpc-auth:1.15.1");
-    List<Path> paths = StaticLinkageChecker.artifactsToClasspath(ImmutableList.of(grpcArtifact));
-
-    Truth.assertThat(paths)
-        .comparingElementsUsing(PATH_FILE_NAMES)
-        .contains("grpc-auth-1.15.1.jar");
-    Truth.assertThat(paths)
-        .comparingElementsUsing(PATH_FILE_NAMES)
-        .contains("google-auth-library-credentials-0.9.0.jar");
-    paths.forEach(
-        path ->
-            Truth.assertWithMessage("Every returned path should be an absolute path")
-                .that(path.isAbsolute())
-                .isTrue());
-  }
-
-  @Test
-  public void testCoordinateToClasspath_optionalDependency() throws RepositoryException {
-    Artifact bigTableArtifact =
-        new DefaultArtifact("com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha");
-    List<Path> paths =
-        StaticLinkageChecker.artifactsToClasspath(ImmutableList.of(bigTableArtifact));
-    Truth.assertThat(paths).comparingElementsUsing(PATH_FILE_NAMES).contains("log4j-1.2.12.jar");
-  }
-
-  @Test
-  public void testCoordinateToClasspath_invalidCoordinate() {
-    Artifact nonExistentArtifact = new DefaultArtifact("io.grpc:nosuchartifact:1.2.3");
-    try {
-      StaticLinkageChecker.artifactsToClasspath(ImmutableList.of(nonExistentArtifact));
-      Assert.fail("Invalid Maven coodinate should raise RepositoryException");
-    } catch (RepositoryException ex) {
-      Truth.assertThat(ex.getMessage())
-          .contains("Could not find artifact io.grpc:nosuchartifact:jar:1.2.3");
-    }
-  }
-
-  @Test
-  public void testCoordinateToClasspath_emptyInput() throws RepositoryException {
-      List<Path> jars = StaticLinkageChecker.artifactsToClasspath(ImmutableList.of());
-      Truth.assertThat(jars).isEmpty();
-  }
-
-  @Test
-  public void testFindInvalidReferences_selfReferenceFromAbstractClassToInterface()
-      throws RepositoryException, IOException {
-    Artifact bigTableArtifact =
-        new DefaultArtifact("com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha");
-    List<Path> paths =
-        StaticLinkageChecker.artifactsToClasspath(ImmutableList.of(bigTableArtifact));
-    Path httpClientJar =
-        paths
-            .stream()
-            .filter(path -> "httpclient-4.5.3.jar".equals(path.getFileName().toString()))
-            .findFirst()
-            .get();
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
-
-    // httpclient-4.5.3 AbstractVerifier has a method reference of
-    // 'void verify(String host, String[] cns, String[] subjectAlts)' to itself and its interface
-    // X509HostnameVerifier has the method.
-    // https://github.com/apache/httpcomponents-client/blob/e2cf733c60f910d17dc5cfc0a77797054a2e322e/httpclient/src/main/java/org/apache/http/conn/ssl/AbstractVerifier.java#L153
-    SymbolReferenceSet symbolReferenceSet = ClassDumper.scanSymbolReferencesInJar(httpClientJar);
-    ClassSymbolReference referenceToGZipInputStreamFactory =
-        ClassSymbolReference.builder()
-            .setSourceClassName("org.apache.http.client.protocol.ResponseContentEncoding")
-            .setTargetClassName("org.apache.http.client.entity.GZIPInputStreamFactory")
-            .build();
-    if (symbolReferenceSet.getClassReferences().contains(referenceToGZipInputStreamFactory)) {
-      System.out.println(
-          "Somehow httpclient-4.5.3 contains GZipInputStreamFactory reference, which is added 4.5.4");
-    }
-
-    JarLinkageReport jarLinkageReport = staticLinkageChecker.generateLinkageReport(httpClientJar,
-        symbolReferenceSet, Collections.emptyList());
-
-    Truth.assertWithMessage("Method references within the same jar file should not be reported")
-        .that(jarLinkageReport.getMissingMethodErrors())
-        .isEmpty();
-  }
 
   @Test
   public void testFindInvalidReferences_arrayCloneMethod() throws IOException, URISyntaxException {
@@ -274,7 +154,7 @@ public class StaticLinkageCheckerTest {
   public void testCheckLinkageErrorMissingMethodAt_protectedConstructorFromAnonymousClass()
       throws IOException, RepositoryException {
     List<Path> paths =
-        StaticLinkageChecker.artifactsToClasspath(
+        ClassPathBuilder.artifactsToClasspath(
             ImmutableList.of(new DefaultArtifact("junit:junit:4.12")));
     // junit has dependency on hamcrest-core
     StaticLinkageChecker staticLinkageChecker =


### PR DESCRIPTION
Fixes #315 


@elharo Here is the refactoring we discussed yesterday (_why StaticLinkageChecker has two constructors_ etc.)

- New `ClassPathBuilder` is responsible to build a classpath given Maven artifacts.
  Its logic is same as what it was done at StaticLinkageChecker.
- StaticLinkageChecker does not have multiple constructors any more.
- StaticLinkageChecker and JarLinkageReport not to hold `Multimap<Path, DependencyPath>`.
  The caller (DashboardMain) is responsible to keep the multimap of DependencyPath
- The dashboard has a little bit better formatting for static linkage errors
  - `<ul>` tag for "linked from ..." message.
  - bold for related DependencyPath in component.ftl


# Screenshots

## Dashboard now have ul tags for DependencyPath

![image](https://user-images.githubusercontent.com/28604/50703167-44751600-1021-11e9-8cd5-4ed41aa0208b.png)


## Artifact Report: bold font for relevant DependencyPath

![image](https://user-images.githubusercontent.com/28604/50703215-679fc580-1021-11e9-92ba-ceace317e7f5.png)


