### PR TITLE
Glossary to clarify class path

### DIFF
--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -3,7 +3,7 @@ Java Dependency Glossary
 
 - **Class path**: an ordered list of jar files, zip files, or directories, each of which
   contains Java class files.
-  A class loader searches a class file by its name through path entries in a class path.
+  A class loader searches a class file by its name through the path entries in a class path.
   When there are two or more path entries (for example, jar files) that contains class files with
   the same name in a class path, the class file in the first path entry in the class path
   is available for use, and the other class files in the rest of the path entries are unavailable

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -3,11 +3,10 @@ Java Dependency Glossary
 
 - **Class path**: an ordered list of jar files, zip files, or directories, each of which
   contains Java class files.
-  A class loader searches a class file by its name through the path entries in a class path.
-  When there are two or more path entries (for example, jar files) that contains class files with
+  A class loader searches for a class file by its name through the path entries in a class path.
+  When there are two or more path entries (for example, jar files) that contain class files with
   the same name in a class path, the class file in the first path entry in the class path
-  is available for use, and the other class files in the rest of the path entries are unavailable
-  through the class path.
+  is available for use, and the other class files with the same name are unavailable.
 
 ### Types of conflicts and compatibility
 

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -6,7 +6,7 @@ Java Dependency Glossary
   A class loader searches a class file by its name through path entries in a class path.
   When there are two or more path entries (for example, jar files) that contains class files with
   the same name in a class path, the class file in the first path entry in the class path
-  is picked up, and the other class files in the rest of path entries are unavailable
+  is available for use, and the other class files in the rest of the path entries are unavailable
   through the class path.
 
 ### Types of conflicts and compatibility
@@ -33,8 +33,8 @@ Java Dependency Glossary
 - **Linkage conflict**: a linkage error when the signature, return type,
   modifiers, or throws declaration of a non-private method, field, or class
   in a dependency has changed (or removed) in an incompatible way between
-  the version supplied at compile time and the version available in the class path
-  at runtime.
+  the version of a class file supplied at compile time and the version available in
+  the runtime class path.
   For example, a public method may be removed from a class or an extended
   class may be made final.
   - Or, another perspective: In cases where binary compatibility and source

--- a/library-best-practices/glossary.md
+++ b/library-best-practices/glossary.md
@@ -1,6 +1,14 @@
 Java Dependency Glossary
 ------------------------
 
+- **Class path**: an ordered list of jar files, zip files, or directories, each of which
+  contains Java class files.
+  A class loader searches a class file by its name through path entries in a class path.
+  When there are two or more path entries (for example, jar files) that contains class files with
+  the same name in a class path, the class file in the first path entry in the class path
+  is picked up, and the other class files in the rest of path entries are unavailable
+  through the class path.
+
 ### Types of conflicts and compatibility
 
 <a name="linkage-error"></a>
@@ -25,7 +33,8 @@ Java Dependency Glossary
 - **Linkage conflict**: a linkage error when the signature, return type,
   modifiers, or throws declaration of a non-private method, field, or class
   in a dependency has changed (or removed) in an incompatible way between
-  the version supplied at compile time and the version invoked at runtime.
+  the version supplied at compile time and the version available in the class path
+  at runtime.
   For example, a public method may be removed from a class or an extended
   class may be made final.
   - Or, another perspective: In cases where binary compatibility and source


### PR DESCRIPTION
Fixes #314 

This change clarifies a class file is _unavailable_ in a class path if it's shadowed by another class file in another path entry in the class path.

# Questions from the issue

> If a reference is satisfied by the first appearance of a class in the classpath but not the second, is that a static linkage error or not?

It's not a static linkage error, because the second class is not in _available classes in the class path_.

> If a reference is satisfied by the second appearance of a class in the classpath but not the first, is that a static linkage error or not?

Yes, it's a static linkage error. The first one, which is not satisfying a reference, is  in _available classes in the class path_.


@elharo What do you think?
