### PR TITLE
Filter unused class reference

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.opensource.classpath;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -533,6 +534,9 @@ class ClassDumper {
 
       ImmutableSet<Integer> targetConstantPoolIndices =
           constantPoolIndexForClass(sourceJavaClass, targetClassName);
+      Verify.verify(
+          !targetConstantPoolIndices.isEmpty(),
+          "The target class symbol reference is not found in source class");
 
       ConstantPool sourceConstantPool = sourceJavaClass.getConstantPool();
       Constant[] constantPoolEntries = sourceConstantPool.getConstantPool();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -351,6 +351,10 @@ public class StaticLinkageChecker {
       }
       return Optional.empty();
     } catch (ClassNotFoundException ex) {
+      if (classDumper.isUnusedClassSymbolReference(reference)) {
+        // The class reference is unused in the source
+        return Optional.empty();
+      }
       return Optional.of(StaticLinkageError.errorMissingTargetClass(reference));
     }
   }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -286,6 +286,8 @@ public class ClassDumperTest {
             .setTargetClassName("org.conscrypt.NativeConstants")
             .build();
 
+    // See the issue below for the analysis of inlined fields in Conscrypt:
+    // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/301
     boolean result = classDumper.isUnusedClassSymbolReference(referenceToUnusedClass);
     Truth.assertWithMessage(
         "As the values in NativeConstants are all inlined. "
@@ -295,7 +297,6 @@ public class ClassDumperTest {
   @Test
   public void testIsUnusedClassSymbolReference_usedClassReference()
       throws IOException, URISyntaxException {
-    // The superclass of AbstractApiService$InnerService (Guava's ApiService) is not in the paths
     ClassDumper classDumper =
         ClassDumper.create(
             ImmutableList.of(absolutePathOfResource("testdata/conscrypt-openjdk-uber-1.4.2.jar")));

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -269,4 +269,24 @@ public class ClassDumperTest {
       Truth.assertThat(classDumper.isSystemClass(nonJavaRuntimeClassName)).isFalse();
     }
   }
+
+  @Test
+  public void testIsUnusedClassSymbolReference_unusedClassReference()
+      throws IOException, URISyntaxException {
+    // The superclass of AbstractApiService$InnerService (Guava's ApiService) is not in the paths
+    ClassDumper classDumper =
+        ClassDumper.create(ImmutableList.of(absolutePathOfResource("testdata/conscrypt-openjdk-uber-1.4.2.jar")));
+
+    ClassSymbolReference referenceToUnusedClass =
+        ClassSymbolReference.builder()
+            .setSourceClassName("org.conscrypt.Conscrypt")
+            .setSubclass(false)
+            .setTargetClassName("org.conscrypt.NativeConstants")
+            .build();
+
+    boolean result = classDumper.isUnusedClassSymbolReference(referenceToUnusedClass);
+    Truth.assertWithMessage(
+        "As the values in NativeConstants are all inlined. "
+            + "There should not be any usage in Conscrypt").that(result).isTrue();
+  }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -343,13 +343,11 @@ public class ClassDumperTest {
               .build();
       classDumper.isUnusedClassSymbolReference(referenceToUnusedClass);
 
-      Assert.fail("It should throw VerifyError when it cannot find a class symbol reference");
-    } catch (ClassFormatException ex) {
+      Assert.fail("It should throw VerifyException when it cannot find a class symbol reference");
+    } catch (VerifyException ex) {
       // pass
       Truth.assertThat(ex.getMessage())
-          .isEqualTo(
-              "Could not find constant pool entry for dummy.NoSuchClass"
-                  + " in org.conscrypt.Conscrypt");
+          .isEqualTo("The target class symbol reference is not found in source class");
     }
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
+import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -31,6 +32,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
+import org.apache.bcel.classfile.ClassFormatException;
 import org.apache.bcel.classfile.ClassParser;
 import org.apache.bcel.classfile.JavaClass;
 import org.eclipse.aether.RepositoryException;
@@ -273,9 +275,9 @@ public class ClassDumperTest {
   @Test
   public void testIsUnusedClassSymbolReference_unusedClassReference()
       throws IOException, URISyntaxException {
-    // The superclass of AbstractApiService$InnerService (Guava's ApiService) is not in the paths
     ClassDumper classDumper =
-        ClassDumper.create(ImmutableList.of(absolutePathOfResource("testdata/conscrypt-openjdk-uber-1.4.2.jar")));
+        ClassDumper.create(
+            ImmutableList.of(absolutePathOfResource("testdata/conscrypt-openjdk-uber-1.4.2.jar")));
 
     ClassSymbolReference referenceToUnusedClass =
         ClassSymbolReference.builder()
@@ -288,5 +290,66 @@ public class ClassDumperTest {
     Truth.assertWithMessage(
         "As the values in NativeConstants are all inlined. "
             + "There should not be any usage in Conscrypt").that(result).isTrue();
+  }
+
+  @Test
+  public void testIsUnusedClassSymbolReference_usedClassReference()
+      throws IOException, URISyntaxException {
+    // The superclass of AbstractApiService$InnerService (Guava's ApiService) is not in the paths
+    ClassDumper classDumper =
+        ClassDumper.create(
+            ImmutableList.of(absolutePathOfResource("testdata/conscrypt-openjdk-uber-1.4.2.jar")));
+
+    List<String> usedClassesInConscrypt =
+        ImmutableList.of(
+            "org.conscrypt.OpenSSLProvider", // Used in instanceof and new
+            "org.conscrypt.Conscrypt$ProviderBuilder", // Used in new and inner class
+            "java.lang.IllegalArgumentException", // Used in new
+            "org.conscrypt.ServerSessionContext", // Used in instanceof
+            "java.util.Properties", // Used in a new
+            "org.conscrypt.NativeCrypto", // Used in a static method call
+            "org.conscrypt.SSLParametersImpl", // Used in a static method call
+            "java.io.IOException", // Used in a catch clause
+            "java.security.KeyManagementException", // Used in throws clause
+            "java.lang.Throwable" // Used in catch clause
+            );
+
+    for (String usedClass : usedClassesInConscrypt) {
+      ClassSymbolReference referenceToUsedClass =
+          ClassSymbolReference.builder()
+              .setSourceClassName("org.conscrypt.Conscrypt")
+              .setSubclass(false)
+              .setTargetClassName(usedClass)
+              .build();
+      Truth.assertWithMessage(usedClass + " should be used in the class file")
+          .that(classDumper.isUnusedClassSymbolReference(referenceToUsedClass))
+          .isFalse();
+    }
+  }
+
+  @Test
+  public void testIsUnusedClassSymbolReference_classSymbolReferenceNotFound()
+      throws IOException, URISyntaxException {
+    ClassDumper classDumper =
+        ClassDumper.create(
+            ImmutableList.of(absolutePathOfResource("testdata/conscrypt-openjdk-uber-1.4.2.jar")));
+
+    try {
+      ClassSymbolReference referenceToUnusedClass =
+          ClassSymbolReference.builder()
+              .setSourceClassName("org.conscrypt.Conscrypt")
+              .setSubclass(false)
+              .setTargetClassName("dummy.NoSuchClass")
+              .build();
+      classDumper.isUnusedClassSymbolReference(referenceToUnusedClass);
+
+      Assert.fail("It should throw VerifyError when it cannot find a class symbol reference");
+    } catch (ClassFormatException ex) {
+      // pass
+      Truth.assertThat(ex.getMessage())
+          .isEqualTo(
+              "Could not find constant pool entry for dummy.NoSuchClass"
+                  + " in org.conscrypt.Conscrypt");
+    }
   }
 }


### PR DESCRIPTION
This change is to suppress missing class messages, when the class is is unused in the source. Fixes #301.

The following places are searched by `ClassDumper.isUnusedClassSymbolReference`: 
<ul>
   <li>Superclass and interfaces
   <li>Type signatures of fields and methods
   <li>Constant pool entries that refer to a CONSTANT_Class_info structure
   <li>Java Virtual Machine instructions that takes a symbolic reference to a class
   <li>The exception table and exception handlers of methods
</ul>