### PR TITLE
Not to fetch type:zip artifacts

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -161,9 +161,25 @@ class ClassDumper {
 
     SymbolReferenceSet.Builder symbolTableBuilder = SymbolReferenceSet.builder();
     for (JavaClass javaClass : listClassesInJar(jarFilePath)) {
+      if (!isCompatibleClassFileVersion(javaClass)) {
+        continue;
+      }
       symbolTableBuilder.addAll(scanSymbolReferencesInClass(javaClass));
     }
     return symbolTableBuilder.build();
+  }
+
+  /**
+   * Returns true if {@code javaClass} file format is compatible with this tool. As of January 2019,
+   * Java 8 is supported.
+   *
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.1">Java
+   *     Virtual Machine Specification: The ClassFile Structure: minor_version, major_version</a>
+   */
+  private static boolean isCompatibleClassFileVersion(JavaClass javaClass) {
+    int classFileMajorVersion = javaClass.getMajor();
+    // TODO(#343): Java 11 support
+    return 45 <= classFileMajorVersion && classFileMajorVersion <= 52;
   }
 
   private static SymbolReferenceSet scanSymbolReferencesInClass(JavaClass javaClass) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
@@ -53,7 +53,9 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 public class StaticLinkageCheckOption {
   
   private static final Options options = configureOptions();
-  
+
+  private static final HelpFormatter helpFormatter = new HelpFormatter();
+
   static CommandLine readCommandLine(String[] arguments) throws ParseException {
     // TODO is this reentrant? Can we reuse it? 
     // https://issues.apache.org/jira/browse/CLI-291
@@ -64,7 +66,6 @@ public class StaticLinkageCheckOption {
       checkInput(commandLine);
       return commandLine;
     } catch (ParseException ex) {
-      HelpFormatter helpFormatter = new HelpFormatter();
       helpFormatter.printHelp("StaticLinkageChecker", options);
       throw ex;
     }
@@ -121,6 +122,7 @@ public class StaticLinkageCheckOption {
               .collect(toImmutableList());
       return jarFilesInArguments;
     } else {
+      helpFormatter.printHelp("StaticLinkageChecker", options);
       throw new ParseException("Missing argument");
     }
   }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -28,6 +28,7 @@ import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.truth.Truth;
 
 public class DependencyGraphBuilderTest {
@@ -87,6 +88,18 @@ public class DependencyGraphBuilderTest {
     }
     
     Truth.assertThat(coordinates).contains("com.google.code.findbugs:jsr305:jar:3.0.2");
+  }
+
+  @Test
+  public void testGetDirectDependencies_nonExistentZipDependency()
+      throws DependencyCollectionException, DependencyResolutionException {
+    // This artifact depends on log4j-api-java9 (type:zip), which does not exist in Maven central.
+    DefaultArtifact log4j2 = new DefaultArtifact("org.apache.logging.log4j:log4j-api:2.11.1");
+
+    // This should not raise DependencyResolutionException
+    DependencyGraph completeDependencies =
+        DependencyGraphBuilder.getStaticLinkageCheckDependencyGraph(ImmutableList.of(log4j2));
+    Truth.assertThat(completeDependencies.list()).isNotEmpty();
   }
 
   @Test


### PR DESCRIPTION
Fixes #339.

- `RepositoryUtility.newSessionWithProvidedScope` to exclude artifact with type:zip
- `ClassDumper.scanSymbolReferencesInJar` to skip extract class files compiled with Java 9 or higher
  As this tool runs on Java 8, it cannot determine Java 9-specific classes are available in JRE or not.
  #343 is created to track support for Java 9 or higher.