### PR TITLE
DashboardTest speedup

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -65,7 +65,6 @@ import org.apache.bcel.generic.Type;
 import org.apache.bcel.util.ClassPath;
 import org.apache.bcel.util.ClassPathRepository;
 import org.apache.bcel.util.Repository;
-import org.apache.bcel.util.SyntheticRepository;
 
 /**
  * Class to read symbol references in Java class files and to verify the availability of references

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckClassPath.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckClassPath.java
@@ -31,7 +31,7 @@ import org.apache.bcel.util.ClassPath;
  *
  * <p>Background: BCEL's {@link ClassPath#getInputStream(String, String)} uses the system class
  * loader to read class files when {@link
- * org.apache.bcel.util.SyntheticRepository#loadClass(String)} is called, meaning that it loads
+ * org.apache.bcel.util.ClassPathRepository#loadClass(String)} is called, meaning that it loads
  * other classes outside the class path specified at its constructor argument. In other words,
  * classes used in this cloud-opensource-java project (including Guava 26) would be unexpectedly
  * loaded by the system class loader when running static linkage check, if BCEL's {@link ClassPath}


### PR DESCRIPTION
Fixes #352.

@elharo Would you try this branch and confirm you also see the improvement?

Circle CI observed 8x speedup:

Before

> [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 290.585 s - in com.google.cloud.tools.opensource.dashboard.DashboardTest
https://circleci.com/gh/GoogleCloudPlatform/cloud-opensource-java/818

After

> [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 36.029 s - in com.google.cloud.tools.opensource.dashboard.DashboardTest
https://circleci.com/gh/GoogleCloudPlatform/cloud-opensource-java/821
