### PR TITLE
add summary for static linkage errors

### DIFF
--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/ArtifactResults.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/ArtifactResults.java
@@ -42,8 +42,8 @@ public final class ArtifactResults {
     this.exceptionMessage = exceptionMessage;
   }
 
-  void addResult(String testName, int result) {
-    results.put(testName, result);
+  void addResult(String testName, int failures) {
+    results.put(testName, failures);
   }
 
   /**

--- a/dashboard/src/main/resources/templates/dashboard.ftl
+++ b/dashboard/src/main/resources/templates/dashboard.ftl
@@ -14,10 +14,30 @@
           <h2 class="artifact-count">${table?size}</h2>
           <span class="desc">Total Artifacts Checked</span>
         </div>
+        <div class="statistic-item statistic-item-red">
+          <h2 class="artifact-count"><@countFailures name="Static Linkage Errors"/></h2>
+          <span class="desc">Have Static Linkage Errors</span>
+        </div>
       </div>
     </section>
     
     <h2>Artifact Details</h2>
+    
+    <#macro countFailures name>
+      <#assign total = 0>
+      <#list table as row>    
+        <#if row.getResult(name)?? >
+          <#assign failure_count = row.getFailureCount(name)>
+          <#if failure_count gt 0 >
+            <#assign total = total + 1>
+          </#if>
+        <#else>
+          <#-- Null means there's an exception and test couldn't run -->
+          <#assign total = total + 1>
+        </#if>
+      </#list>
+      ${total}
+    </#macro>
     
     <#macro testResult row name>
       <#if row.getResult(name)?? ><#-- checking isNotNull() -->

--- a/dashboard/src/main/resources/templates/dashboard.ftl
+++ b/dashboard/src/main/resources/templates/dashboard.ftl
@@ -21,8 +21,6 @@
       </div>
     </section>
     
-    <h2>Artifact Details</h2>
-    
     <#macro countFailures name>
       <#assign total = 0>
       <#list table as row>    
@@ -38,6 +36,8 @@
       </#list>
       ${total}
     </#macro>
+    
+    <h2>Artifact Details</h2>
     
     <#macro testResult row name>
       <#if row.getResult(name)?? ><#-- checking isNotNull() -->

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -189,7 +189,7 @@ public class DashboardTest {
       Nodes artifactCount = document.query("//h2[@class='artifact-count']");
       Assert.assertTrue(artifactCount.size() > 0);
       for (int i = 0; i < artifactCount.size(); i++) {
-        String value = artifactCount.get(i).getValue();
+        String value = artifactCount.get(i).getValue().trim();
         Assert.assertTrue(value, Integer.parseInt(value) > 0);
       }            
     }

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -72,11 +72,15 @@ public class FreemarkerTest {
     StaticLinkageCheckReport staticLinkageCheckReport =
         StaticLinkageCheckReport.create(ImmutableList.of());
     
-    Artifact artifact = new DefaultArtifact("io.grpc:grpc-context:1.15.0");
-    ArtifactResults results = new ArtifactResults(artifact);
-    results.addResult("Static Linkage Errors", 56);
+    Artifact artifact1 = new DefaultArtifact("io.grpc:grpc-context:1.15.0");
+    ArtifactResults results1 = new ArtifactResults(artifact1);
+    results1.addResult("Static Linkage Errors", 56);
     
-    List<ArtifactResults> table = ImmutableList.of();
+    Artifact artifact2 = new DefaultArtifact("grpc:grpc:1.15.0");
+    ArtifactResults results2 = new ArtifactResults(artifact2);
+    results2.addResult("Static Linkage Errors", 0);
+    
+    List<ArtifactResults> table = ImmutableList.of(results1, results2);
     List<DependencyGraph> globalDependencies = ImmutableList.of();
     Multimap<Path, DependencyPath> jarToDependencyPaths = LinkedListMultimap.create();
     DashboardMain.generateDashboard(configuration, outputDirectory, table, globalDependencies,
@@ -92,7 +96,7 @@ public class FreemarkerTest {
       Integer.parseInt(counts.get(i).getValue().trim());
     }
     
-    Assert.assertEquals(56, Integer.parseInt(counts.get(1).getValue().trim()));
+    Assert.assertEquals(1, Integer.parseInt(counts.get(1).getValue().trim()));
   }
 
 }

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.dashboard;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.cloud.tools.opensource.classpath.StaticLinkageCheckReport;
+import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
+import com.google.cloud.tools.opensource.dependencies.DependencyPath;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.io.MoreFiles;
+import com.google.common.io.RecursiveDeleteOption;
+
+import freemarker.template.Configuration;
+import freemarker.template.TemplateException;
+import nu.xom.Builder;
+import nu.xom.Document;
+import nu.xom.Nodes;
+import nu.xom.ParsingException;
+import nu.xom.ValidityException;
+
+
+/**
+ * Unit tests for FreeMarker logic without reading any JAR files. 
+ */
+public class FreemarkerTest {
+
+  private static Path outputDirectory;
+  private Builder builder = new Builder();
+
+  @BeforeClass
+  public static void setUp() throws IOException {
+    outputDirectory = Files.createDirectories(Paths.get("target", "dashboard"));
+  }
+
+  @AfterClass
+  public static void cleanUp() throws IOException {
+    MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
+  }
+
+  @Test
+  public void testCountFailures() throws IOException, TemplateException, ValidityException, ParsingException {
+    Configuration configuration = DashboardMain.configureFreemarker();
+
+    StaticLinkageCheckReport staticLinkageCheckReport =
+        StaticLinkageCheckReport.create(ImmutableList.of());
+    
+    Artifact artifact = new DefaultArtifact("io.grpc:grpc-context:1.15.0");
+    ArtifactResults results = new ArtifactResults(artifact);
+    results.addResult("Static Linkage Errors", 56);
+    
+    List<ArtifactResults> table = ImmutableList.of();
+    List<DependencyGraph> globalDependencies = ImmutableList.of();
+    Multimap<Path, DependencyPath> jarToDependencyPaths = LinkedListMultimap.create();
+    DashboardMain.generateDashboard(configuration, outputDirectory, table, globalDependencies,
+        staticLinkageCheckReport, jarToDependencyPaths);
+    
+    Path dashboardHtml = outputDirectory.resolve("dashboard.html");
+    Assert.assertTrue(Files.isRegularFile(dashboardHtml));
+    Document document = builder.build(dashboardHtml.toFile());
+
+    Nodes counts = document.query("//h2[@class='artifact-count']");
+    Assert.assertTrue(counts.size() > 0);
+    for (int i = 0; i < counts.size(); i++) {
+      Integer.parseInt(counts.get(i).getValue().trim());
+    }
+    
+    Assert.assertEquals(56, Integer.parseInt(counts.get(1).getValue().trim()));
+  }
+
+}


### PR DESCRIPTION
@suztomo 

This also does some refactoring to separate the HTML generation from analysis of the Java libraries so they can be more easily and quickly tested. 

![image](https://user-images.githubusercontent.com/1005544/51482283-0cc9d600-1d64-11e9-93a6-fc97bcf75841.png)
