### PR TITLE
To be able to build a class path for spring-cloud-gcp-starter-pubsub

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -35,6 +35,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Attribute;
@@ -71,6 +72,8 @@ import org.apache.bcel.util.Repository;
  * in them, through the input class path for a static linkage check.
  */
 class ClassDumper {
+
+  private static final Logger logger = Logger.getLogger(ClassDumper.class.getName());
 
   private final ImmutableList<Path> inputClassPath;
   private final Repository classRepository;
@@ -551,9 +554,15 @@ class ClassDumper {
 
       ImmutableSet<Integer> targetConstantPoolIndices =
           constantPoolIndexForClass(sourceJavaClass, targetClassName);
-      Verify.verify(
-          !targetConstantPoolIndices.isEmpty(),
-          "The target class symbol reference is not found in source class");
+      if (targetConstantPoolIndices.isEmpty()) {
+        logger.warning(
+            "The target class "
+                + targetClassName
+                + " symbol reference is not found in source class "
+                + sourceClassName);
+        // Cannot say the target unused
+        return false;
+      }
 
       ConstantPool sourceConstantPool = sourceJavaClass.getConstantPool();
       Constant[] constantPoolEntries = sourceConstantPool.getConstantPool();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -34,7 +34,6 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Attribute;
@@ -71,8 +70,6 @@ import org.apache.bcel.util.Repository;
  * in them, through the input class path for a static linkage check.
  */
 class ClassDumper {
-
-  private static final Logger logger = Logger.getLogger(ClassDumper.class.getName());
 
   private final ImmutableList<Path> inputClassPath;
   private final Repository classRepository;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.opensource.classpath;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -555,13 +554,9 @@ class ClassDumper {
       ImmutableSet<Integer> targetConstantPoolIndices =
           constantPoolIndexForClass(sourceJavaClass, targetClassName);
       if (targetConstantPoolIndices.isEmpty()) {
-        logger.warning(
-            "The target class "
-                + targetClassName
-                + " symbol reference is not found in source class "
-                + sourceClassName);
-        // Cannot say the target unused
-        return false;
+        // This reference is not found in sourceJavaClass any more. This means that there exist
+        // overlapping classes in the class path and that the first one does not use target class.
+        return true;
       }
 
       ConstantPool sourceConstantPool = sourceJavaClass.getConstantPool();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -93,6 +93,8 @@ public class StaticLinkageChecker {
     CommandLine commandLine = StaticLinkageCheckOption.readCommandLine(arguments);
     ImmutableList<Path> inputClasspath =
         StaticLinkageCheckOption.generateInputClasspath(commandLine);
+    logger.info("Input class path size: " + inputClasspath.size());
+
     // TODO(suztomo): take command-line option to choose entry point classes for reachability
     ImmutableSet<Path> entryPoints = ImmutableSet.of(inputClasspath.get(0));
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -335,20 +335,12 @@ public class ClassDumperTest {
         ClassDumper.create(
             ImmutableList.of(absolutePathOfResource("testdata/conscrypt-openjdk-uber-1.4.2.jar")));
 
-    try {
-      ClassSymbolReference referenceToUnusedClass =
-          ClassSymbolReference.builder()
-              .setSourceClassName("org.conscrypt.Conscrypt")
-              .setSubclass(false)
-              .setTargetClassName("dummy.NoSuchClass")
-              .build();
-      classDumper.isUnusedClassSymbolReference(referenceToUnusedClass);
-
-      Assert.fail("It should throw VerifyException when it cannot find a class symbol reference");
-    } catch (VerifyException ex) {
-      // pass
-      Truth.assertThat(ex.getMessage())
-          .isEqualTo("The target class symbol reference is not found in source class");
-    }
+    ClassSymbolReference referenceToUnusedClass =
+        ClassSymbolReference.builder()
+            .setSourceClassName("org.conscrypt.Conscrypt")
+            .setSubclass(false)
+            .setTargetClassName("dummy.NoSuchClass")
+            .build();
+    Truth.assertThat(classDumper.isUnusedClassSymbolReference(referenceToUnusedClass)).isTrue();
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -70,7 +70,7 @@ public class ClassPathBuilderTest {
     Path opencensusApiPath = opencensusApiPathFound.get();
     Truth.assertWithMessage("Opencensus API should have multiple dependency paths")
         .that(multimap.get(opencensusApiPath).size())
-        .isGreaterThan(1);
+        .isEqualTo(1);
   }
 
   @Test
@@ -183,27 +183,5 @@ public class ClassPathBuilderTest {
     Artifact jamonApiArtifact = new DefaultArtifact("com.google.guava:guava-gwt:jar:20.0");
     List<Path> paths = ClassPathBuilder.artifactsToClasspath(ImmutableList.of(jamonApiArtifact));
     Truth.assertThat(paths).isNotEmpty();
-  }
-
-  @Test
-  public void testArtifactToClasspath_reportAggregatedRepositoryException()
-      throws RepositoryException {
-    // jamon has transitive dependency to jmxtools, which does not exist in Maven central
-    Artifact jamonApiArtifact = new DefaultArtifact("com.jamonapi:jamon:2.81");
-    try {
-      ClassPathBuilder.artifactsToClasspath(ImmutableList.of(jamonApiArtifact));
-      Assert.fail();
-    } catch (AggregatedRepositoryException ex) {
-      ImmutableList<ExceptionAndPath> failures = ex.getUnderlyingFailures();
-      Truth.assertThat(failures).isNotEmpty();
-      long jmxToolFailureCount = failures.stream().filter(
-          failure -> {
-            List<DependencyNode> path = failure.getPath();
-            return "jmxtools".equals(path.get(path.size()-1).getArtifact().getArtifactId());
-          }
-      ).count();
-
-      Truth.assertThat(jmxToolFailureCount).isEqualTo(1);
-    }
   }
 }


### PR DESCRIPTION
Fixes #367

Now StaticLinkageChecker can run against a heavy dependency graph by `org.springframework.cloud:spring-cloud-gcp-starter-pubsub:1.1.0.RELEASE`. This builds a class path of 1466 jar files.

- `DependencyGraphBuilder.levelOrder` not to visit same node twice when called by StaticLinkageChecker.
- `DependencyGraphBuilder.isSafeResolutionException` checks the condition to abort graph building as per https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/365#discussion_r250581145
- `ClassDumper.isUnusedClassSymbolReference` to return true if the target class is not found in source class.

