### PR TITLE
Jlbp3 special case

### DIFF
--- a/library-best-practices/JLBP-3.md
+++ b/library-best-practices/JLBP-3.md
@@ -36,7 +36,7 @@ Definition of semantic versioning (SemVer): https://semver.org
     features) that is exposed through a library's public API
   - Adding a new class
   - Adding a new method
-- Special case: maintainers need not increase a library's major version when
-  a new release only drops the support of an end-of-life Java version that is
-  not widely used by the consumers of the library and the release does not make
-  any breaking surface change.
+- Special case: Maintainers need not increase a library's major version when
+  a new release does not make any breaking surface change and the release only
+  drops the support of an end-of-life Java version that is not widely used by
+  the consumers of the library.

--- a/library-best-practices/JLBP-3.md
+++ b/library-best-practices/JLBP-3.md
@@ -36,7 +36,7 @@ Definition of semantic versioning (SemVer): https://semver.org
     features) that is exposed through a library's public API
   - Adding a new class
   - Adding a new method
-- Special case: Maintainers need not increase a library's major version when
+- Special case: Maintainers need not increment a library's major version when
   a new release does not make any breaking surface change and the release only
   drops the support of an end-of-life Java version that is not widely used by
   the consumers of the library.

--- a/library-best-practices/JLBP-3.md
+++ b/library-best-practices/JLBP-3.md
@@ -36,7 +36,7 @@ Definition of semantic versioning (SemVer): https://semver.org
     features) that is exposed through a library's public API
   - Adding a new class
   - Adding a new method
-- Special case: Merely bumping up the minimum required Java version (and not
-  making any breaking surface changes) does not necessarily mean that a
-  library should bump its major version, because new Java versions break
-  very little surface from prior versions.
+- Special case: maintainers need not increase a library's major version when
+  a new release only drops the support of an end-of-life Java version that is
+  not widely used by the consumers of the library and the release does not make
+  any breaking surface change.

--- a/library-best-practices/JLBP-3.md
+++ b/library-best-practices/JLBP-3.md
@@ -36,7 +36,6 @@ Definition of semantic versioning (SemVer): https://semver.org
     features) that is exposed through a library's public API
   - Adding a new class
   - Adding a new method
-- Special case: Maintainers need not increment a library's major version when
-  a new release does not make any breaking surface change and the release only
-  drops the support of an end-of-life Java version that is not widely used by
+- Special case: Maintainers do not have to increment a library's major version when
+  a release is only to drop the support of an end-of-life Java version that is not widely used by
   the consumers of the library.


### PR DESCRIPTION
Fixes #371

@garrettjonesgoogle Updated the sentence incorporating your input. PTAL.

- "does not necessarily mean that" -> "need not" -> "do not have to"
- bump -> increment (more precise specific word)
- It's human (maintainers) who increase major version. Using active voice. https://developers.google.com/style/anthropomorphism
- Focus on "end-of-life Java version" rather than "new Java version breaks very little surface"
