### PR TITLE
Fix missing appengine errors

### DIFF
--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -29,12 +29,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.TreeMap;
 
 import freemarker.template.Configuration;
@@ -60,7 +60,6 @@ import com.google.cloud.tools.opensource.dependencies.VersionComparator;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
@@ -169,10 +168,10 @@ public class DashboardMain {
     for (Path path : jarToDependencyPaths.keySet()) {
       for (DependencyPath dependencyPath : jarToDependencyPaths.get(path)) {
         Artifact artifact = dependencyPath.get(0);
-        builder.put(artifact.toString(), jarToLinkageReport.get(path));
+        builder.put(Artifacts.toCoordinates(artifact), jarToLinkageReport.get(path));
       }
     }
-    ImmutableMultimap<String, JarLinkageReport> artifactToLinkageReports = builder.build();
+    ImmutableSetMultimap<String, JarLinkageReport> artifactToLinkageReports = builder.build();
 
     Map<Artifact, ArtifactInfo> artifacts = cache.getInfoMap();
     List<ArtifactResults> table = new ArrayList<>();
@@ -192,7 +191,7 @@ public class DashboardMain {
                   artifact,
                   entry.getValue(),
                   cache.getGlobalDependencies(),
-                  artifactToLinkageReports.get(artifact.toString()),
+                  artifactToLinkageReports.get(Artifacts.toCoordinates(artifact)),
                   jarToDependencyPaths);
           table.add(results);
         }
@@ -248,7 +247,7 @@ public class DashboardMain {
       Artifact artifact,
       ArtifactInfo artifactInfo,
       List<DependencyGraph> globalDependencies,
-      Collection<JarLinkageReport> staticLinkageCheckReports,
+      Set<JarLinkageReport> staticLinkageCheckReports,
       Multimap<Path, DependencyPath> jarToDependencyPaths)
       throws IOException, TemplateException {
 

--- a/dashboard/src/main/resources/css/dashboard.css
+++ b/dashboard/src/main/resources/css/dashboard.css
@@ -58,11 +58,6 @@
    margin-left: 15pt;
  }
 
- li.linked-from-artifact-true {
-   font-weight: bold;
- }
-
-
  /* ----- Statistic ----- */
 .statistics {
   padding-top: 50px;

--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -123,10 +123,10 @@
         <ul class="static-linkage-check-dependency-paths">
           <#list jarToDependencyPaths.get(jarLinkageReport.getJarPath()) as dependencyPath >
             <#assign dependencyPathRoot = dependencyPath.get(0) />
-            <#assign linkedFromArtifact = dependencyPathRoot.getGroupId() == groupId
-                && dependencyPathRoot.getArtifactId() == artifactId>
-            <li class="linked-from-artifact-${linkedFromArtifact?c}">${dependencyPath}
-            </li>
+            <#if dependencyPathRoot.getGroupId() == groupId
+                 && dependencyPathRoot.getArtifactId() == artifactId >
+              <li>${dependencyPath}</li>
+            </#if>
           </#list>
         </ul>
 

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -264,7 +264,7 @@ public class DashboardTest {
 
   @Test
   public void testLinkageErrorsUnderProvidedDependency() throws IOException, ParsingException {
-    // google-cloud-translate has transitive dependency to appengine-api-1.0-sdk
+    // google-cloud-translate has transitive dependency to (problematic) appengine-api-1.0-sdk
     // The path to appengine-api-1.0-sdk includes scope:provided dependency
     Path googleCloudTranslateHtml =
         outputDirectory.resolve("com.google.cloud_google-cloud-translate_1.59.0.html");

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -275,7 +275,7 @@ public class DashboardTest {
       Nodes staticLinkageCheckMessage = document.query("//pre[@class='jar-linkage-report']");
       Truth.assertThat(staticLinkageCheckMessage.size()).isGreaterThan(0);
       Truth.assertThat(staticLinkageCheckMessage.get(0).getValue())
-          .contains("appengine-api-1.0-sdk");
+          .contains("com.google.appengine.api.appidentity.AppIdentityServicePb");
     }
   }
 

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -261,7 +261,24 @@ public class DashboardTest {
           dependencyTree.size() > 0);
     }
   }
-  
+
+  @Test
+  public void testLinkageErrorsUnderProvidedDependency() throws IOException, ParsingException {
+    // google-cloud-translate has transitive dependency to appengine-api-1.0-sdk
+    // The path to appengine-api-1.0-sdk includes scope:provided dependency
+    Path googleCloudTranslateHtml =
+        outputDirectory.resolve("com.google.cloud_google-cloud-translate_1.59.0.html");
+    Assert.assertTrue(Files.isRegularFile(googleCloudTranslateHtml));
+
+    try (InputStream source = Files.newInputStream(googleCloudTranslateHtml)) {
+      Document document = builder.build(source);
+      Nodes staticLinkageCheckMessage = document.query("//pre[@class='jar-linkage-report']");
+      Truth.assertThat(staticLinkageCheckMessage.size()).isGreaterThan(0);
+      Truth.assertThat(staticLinkageCheckMessage.get(0).getValue())
+          .contains("appengine-api-1.0-sdk");
+    }
+  }
+
   private static class SortWithoutVersion implements Comparator<String> {
 
     @Override


### PR DESCRIPTION
Fixes #336. Now appengine errors are shown properly even the dependency path contain `scope:provided`:

![image](https://user-images.githubusercontent.com/28604/52097764-4ab3cf00-259a-11e9-8bb4-d2cf47112cd9.png)


Also artifact report pages stop showing irrelevant dependency paths:

![image](https://user-images.githubusercontent.com/28604/52090356-21397a00-257f-11e9-8916-d79ac057ee7e.png)

"Following paths to the jar file from BOM are found in the dependency tree." is now showing only relevant paths to the artifact, meaning that the first element is the artifact of the report.