### PR TITLE
Classes checking class existence

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -514,7 +514,7 @@ class ClassDumper {
    * Returns true if {@link SymbolReference#getSourceClassName()} has a method that has an exception
    * handler for {@link NoClassDefFoundError}.
    */
-  boolean isSourceClassCheckingNoClassDefFoundError(SymbolReference reference) {
+  boolean catchesNoClassDefFoundError(SymbolReference reference) {
     String sourceClassName = reference.getSourceClassName();
     try {
       JavaClass sourceJavaClass = loadJavaClass(sourceClassName);
@@ -542,7 +542,7 @@ class ClassDumper {
           "The source class in the reference is no longer available in the class path", ex);
     }
 
-    // The source class does not have a method that catches NoClassDefFoundERror
+    // The source class does not have a method that catches NoClassDefFoundError
     return false;
   }
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -511,8 +511,8 @@ class ClassDumper {
   }
 
   /**
-   * Returns true if the source class has a method that has an exception handler for {@link
-   * NoClassDefFoundError}.
+   * Returns true if {@link SymbolReference#getSourceClassName()} has a method that has an exception
+   * handler for {@link NoClassDefFoundError}.
    */
   boolean isSourceClassCheckingNoClassDefFoundError(SymbolReference reference) {
     String sourceClassName = reference.getSourceClassName();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageChecker.java
@@ -242,7 +242,7 @@ public class StaticLinkageChecker {
       // The class is in class path but the symbol is not found
       return Optional.of(StaticLinkageError.errorMissingMember(reference, classFileLocation));
     } catch (ClassNotFoundException ex) {
-      if (classDumper.isSourceClassCheckingNoClassDefFoundError(reference)) {
+      if (classDumper.catchesNoClassDefFoundError(reference)) {
         return Optional.empty();
       }
       return Optional.of(StaticLinkageError.errorMissingTargetClass(reference));
@@ -281,7 +281,7 @@ public class StaticLinkageChecker {
       // The field was not found in the class from the classpath
       return Optional.of(StaticLinkageError.errorMissingMember(reference, classFileLocation));
     } catch (ClassNotFoundException ex) {
-      if (classDumper.isSourceClassCheckingNoClassDefFoundError(reference)) {
+      if (classDumper.catchesNoClassDefFoundError(reference)) {
         return Optional.empty();
       }
       return Optional.of(StaticLinkageError.errorMissingTargetClass(reference));
@@ -358,7 +358,7 @@ public class StaticLinkageChecker {
       return Optional.empty();
     } catch (ClassNotFoundException ex) {
       if (classDumper.isUnusedClassSymbolReference(reference)
-          || classDumper.isSourceClassCheckingNoClassDefFoundError(reference)) {
+          || classDumper.catchesNoClassDefFoundError(reference)) {
         // The class reference is unused in the source
         return Optional.empty();
       }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -808,7 +808,7 @@ public class StaticLinkageCheckerTest {
   }
 
   @Test
-  public void testFindLinkageErrors_classesCatchingNoClassDefFoundErrorInSlf4j()
+  public void testFindLinkageErrors_catchesNoClassDefFoundError()
       throws RepositoryException, IOException {
     // SLF4J classes catch NoClassDefFoundError to detect the availability of logger backends
     // the tool should not show errors for such classes.
@@ -827,7 +827,7 @@ public class StaticLinkageCheckerTest {
   }
 
   @Test
-  public void testFindLinkageErrors_classNotfoundWhenClassesNotCatchingNoClassDefFoundError()
+  public void testFindLinkageErrors_doesNotCatchNoClassDefFoundError()
       throws URISyntaxException, IOException {
     // Checking Firestore jar file without its dependency should have linkage errors
     // Note that FirestoreGrpc.java does not have catch clause of NoClassDefFoundError

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -806,4 +806,23 @@ public class StaticLinkageCheckerTest {
         .that(reportWith66First.getMissingMethodErrors())
         .isEmpty();
   }
+
+  @Test
+  public void testFindLinkageErrors_classesCatchingNoClassDefFoundErrorInSlf4j()
+      throws RepositoryException, IOException {
+    // SLF4J classes catch NoClassDefFoundError to detect the availability of logger backends
+    // the tool should not show errors for such classes.
+    List<Path> paths =
+        ClassPathBuilder.artifactsToClasspath(
+            ImmutableList.of(new DefaultArtifact("org.slf4j:slf4j-api:jar:1.7.21")));
+
+    StaticLinkageChecker staticLinkageChecker = StaticLinkageChecker.create(false, paths, paths);
+
+    StaticLinkageCheckReport linkageErrors = staticLinkageChecker.findLinkageErrors();
+
+    JarLinkageReport slf4jLinkageReport = linkageErrors.getJarLinkageReports().get(0);
+    Truth.assertThat(slf4jLinkageReport.getMissingClassErrors()).isEmpty();
+    Truth.assertThat(slf4jLinkageReport.getMissingFieldErrors()).isEmpty();
+    Truth.assertThat(slf4jLinkageReport.getMissingMethodErrors()).isEmpty();
+  }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckerTest.java
@@ -825,4 +825,22 @@ public class StaticLinkageCheckerTest {
     Truth.assertThat(slf4jLinkageReport.getMissingFieldErrors()).isEmpty();
     Truth.assertThat(slf4jLinkageReport.getMissingMethodErrors()).isEmpty();
   }
+
+  @Test
+  public void testFindLinkageErrors_classNotfoundWhenClassesNotCatchingNoClassDefFoundError()
+      throws URISyntaxException, IOException {
+    // Checking Firestore jar file without its dependency should have linkage errors
+    // Note that FirestoreGrpc.java does not have catch clause of NoClassDefFoundError
+    List<Path> paths =
+        ImmutableList.of(
+            absolutePathOfResource("testdata/grpc-google-cloud-firestore-v1beta1-0.28.0.jar"));
+    StaticLinkageChecker staticLinkageChecker = StaticLinkageChecker.create(false, paths, paths);
+
+    StaticLinkageCheckReport linkageErrors = staticLinkageChecker.findLinkageErrors();
+
+    JarLinkageReport firestoreLinkageReport = linkageErrors.getJarLinkageReports().get(0);
+    Truth.assertThat(firestoreLinkageReport.getMissingClassErrors()).isNotEmpty();
+    Truth.assertThat(firestoreLinkageReport.getMissingMethodErrors()).isNotEmpty();
+    Truth.assertThat(firestoreLinkageReport.getMissingFieldErrors()).isNotEmpty();
+  }
 }


### PR DESCRIPTION
Fixes #392.

This change is to filter errors on `CLASS_NOT_FOUND` when the source class has a method that catches `NoClassDefFoundError`. For example `org.slf4j.LoggerFactory` has:

```
    private final static void bind() {
        try {
...
            // the next line does the binding
            StaticLoggerBinder.getSingleton();
...
        } catch (NoClassDefFoundError ncde) {
            String msg = ncde.getMessage();
            if (messageContainsOrgSlf4jImplStaticLoggerBinder(msg)) {
                INITIALIZATION_STATE = NOP_FALLBACK_INITIALIZATION;
```

The catch clause is compiled to exception handlers in class file.


# Result

With this change, grpc-netty shows "PASS":

![image](https://user-images.githubusercontent.com/28604/52133943-707bbb00-2610-11e9-9c5d-73de690fc282.png)
