### PR TITLE
When no linkage error, artifact report to show zero, rather than empty section.

### DIFF
--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -112,6 +112,7 @@
 
     <h2 id="static-linkage-errors">Static Linkage Check</h2>
 
+    <p id="static-linkage-errors-total">${totalLinkageErrorCount} static linkage error(s)</p>
     <#list jarLinkageReports as jarLinkageReport>
       <#if jarLinkageReport.getTotalErrorCount() gt 0>
         <h3>${jarLinkageReport.getJarPath().getFileName()?html}</h3>

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -279,6 +279,21 @@ public class DashboardTest {
     }
   }
 
+  @Test
+  public void testZeroLinkageErrorShowsZero() throws IOException, ParsingException {
+    // grpc-auth does not have a linkage error, and it should show zero in the section
+    Path zeroLinkageErrorHtml = outputDirectory.resolve("io.grpc_grpc-auth_1.17.1.html");
+    Assert.assertTrue(Files.isRegularFile(zeroLinkageErrorHtml));
+
+    try (InputStream source = Files.newInputStream(zeroLinkageErrorHtml)) {
+      Document document = builder.build(source);
+      Nodes staticLinkageTotalMessage = document.query("//p[@id='static-linkage-errors-total']");
+      Truth.assertThat(staticLinkageTotalMessage.size()).isEqualTo(1);
+      Truth.assertThat(staticLinkageTotalMessage.get(0).getValue())
+          .contains("0 static linkage error(s)");
+    }
+  }
+
   private static class SortWithoutVersion implements Comparator<String> {
 
     @Override


### PR DESCRIPTION
Fixes #403 , a bug introduced yesterday's commit.

### Before this fix
![image](https://user-images.githubusercontent.com/28604/52136542-50e79100-2616-11e9-8acc-cb4fa22a9101.png)


### After this fix
![image](https://user-images.githubusercontent.com/28604/52136584-60ff7080-2616-11e9-9768-7c8a0b454436.png)





