### PR TITLE
Renaming StaticLinkageChecker to Classpath Checker

### DIFF
--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -47,8 +47,8 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 
 import com.google.cloud.tools.opensource.classpath.ClassPathBuilder;
 import com.google.cloud.tools.opensource.classpath.ClasspathCheckReport;
-import com.google.cloud.tools.opensource.classpath.JarLinkageReport;
 import com.google.cloud.tools.opensource.classpath.ClasspathChecker;
+import com.google.cloud.tools.opensource.classpath.JarLinkageReport;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraphBuilder;

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.opensource.dashboard;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
-import com.google.cloud.tools.opensource.classpath.ClasspathCheckReport;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -47,6 +46,7 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 
 import com.google.cloud.tools.opensource.classpath.ClassPathBuilder;
+import com.google.cloud.tools.opensource.classpath.ClasspathCheckReport;
 import com.google.cloud.tools.opensource.classpath.JarLinkageReport;
 import com.google.cloud.tools.opensource.classpath.ClasspathChecker;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;

--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -110,7 +110,7 @@
     </#if>
 
 
-    <h2 id="static-linkage-errors">Static Linkage Check</h2>
+    <h2 id="static-linkage-errors">Classpath Check</h2>
 
     <p id="static-linkage-errors-total">${totalLinkageErrorCount} static linkage error(s)</p>
     <#list jarLinkageReports as jarLinkageReport>

--- a/dashboard/src/main/resources/templates/dashboard.ftl
+++ b/dashboard/src/main/resources/templates/dashboard.ftl
@@ -78,8 +78,8 @@
       <tr>
         <th>Artifact</th>
         <th title=
-                "Static linkage check result for the artifact and transitive dependencies. PASS means all symbol references have valid referents.">
-          Static Linkage Check</th>
+                "Classpath check result for the artifact and transitive dependencies. PASS means all symbol references have valid referents.">
+          Classpath Check</th>
         <th title=
           "For each transitive dependency the library pulls in, the highest version found anywhere in the dependency tree is picked.">
           Upper Bounds</th>

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -42,7 +42,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.cloud.tools.opensource.classpath.JarLinkageReport;
-import com.google.cloud.tools.opensource.classpath.StaticLinkageCheckReport;
+import com.google.cloud.tools.opensource.classpath.ClasspathCheckReport;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
 import com.google.common.collect.ImmutableList;
@@ -81,11 +81,11 @@ public class DashboardUnavailableArtifactTest {
     
     ArtifactCache cache = new ArtifactCache();
     cache.setInfoMap(map);
-    StaticLinkageCheckReport staticLinkageCheckReport =
-        StaticLinkageCheckReport.create(ImmutableList.of());
+    ClasspathCheckReport classpathCheckReport =
+        ClasspathCheckReport.create(ImmutableList.of());
     List<ArtifactResults> artifactResults =
         DashboardMain.generateReports(
-            configuration, outputDirectory, cache, staticLinkageCheckReport,
+            configuration, outputDirectory, cache, classpathCheckReport,
             LinkedListMultimap.create());
 
     Assert.assertEquals(
@@ -126,7 +126,7 @@ public class DashboardUnavailableArtifactTest {
     table.add(errorArtifactResult);
 
     Iterable<JarLinkageReport> list = new ArrayList<>();
-    StaticLinkageCheckReport report = StaticLinkageCheckReport.create(list);
+    ClasspathCheckReport report = ClasspathCheckReport.create(list);
     DashboardMain.generateDashboard(
         configuration, outputDirectory, table, null, report, LinkedListMultimap.create());
 

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
-import com.google.cloud.tools.opensource.classpath.ClasspathCheckReport;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -30,6 +29,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.google.cloud.tools.opensource.classpath.ClasspathCheckReport;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
 import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.collect.ImmutableList;

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
+import com.google.cloud.tools.opensource.classpath.ClasspathCheckReport;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,7 +30,6 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.google.cloud.tools.opensource.classpath.StaticLinkageCheckReport;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
 import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.collect.ImmutableList;
@@ -69,8 +69,8 @@ public class FreemarkerTest {
   public void testCountFailures() throws IOException, TemplateException, ValidityException, ParsingException {
     Configuration configuration = DashboardMain.configureFreemarker();
 
-    StaticLinkageCheckReport staticLinkageCheckReport =
-        StaticLinkageCheckReport.create(ImmutableList.of());
+    ClasspathCheckReport classpathCheckReport =
+        ClasspathCheckReport.create(ImmutableList.of());
     
     Artifact artifact1 = new DefaultArtifact("io.grpc:grpc-context:1.15.0");
     ArtifactResults results1 = new ArtifactResults(artifact1);
@@ -84,7 +84,7 @@ public class FreemarkerTest {
     List<DependencyGraph> globalDependencies = ImmutableList.of();
     Multimap<Path, DependencyPath> jarToDependencyPaths = LinkedListMultimap.create();
     DashboardMain.generateDashboard(configuration, outputDirectory, table, globalDependencies,
-        staticLinkageCheckReport, jarToDependencyPaths);
+        classpathCheckReport, jarToDependencyPaths);
     
     Path dashboardHtml = outputDirectory.resolve("dashboard.html");
     Assert.assertTrue(Files.isRegularFile(dashboardHtml));

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -1,6 +1,6 @@
-# Static Linkage Checker
+# Classpath Checker
 
-Static Linkage Checker is a tool that finds [static linkage errors](
+Classpath Checker is a tool that finds [static linkage errors](
 ../library-best-practices/glossary.md#static-linkage-error)
 on a class path and reports the errors to the console.
 It scans the class files in the class path for references to other classes and
@@ -10,7 +10,7 @@ a given set of entry point classes.
 
 ### Use Cases
  
-There are two use cases for Static Linkage Checker:
+There are two use cases for Classpath Checker:
 
 - **For library/application developers** the tool finds static linkage
   errors in their projects, and will help to avoid incompatible versions of libraries
@@ -42,7 +42,7 @@ There are two use cases for Static Linkage Checker:
 
 The input of the tool is either the Maven coordinate of a BOM, 
 a list of Maven coordinates, or a list of class and jar files in the filesystem.
-All of these inputs are converted to a class path for the static linkage check,
+All of these inputs are converted to a class path for the classpath check,
 which is the _input class path_.
 
 When the input is a Maven BOM, the elements in the BOM are

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -68,7 +68,7 @@ import org.apache.bcel.util.Repository;
 
 /**
  * Class to read symbol references in Java class files and to verify the availability of references
- * in them, through the input class path for a static linkage check.
+ * in them, through the input class path for a classpath check.
  */
 class ClassDumper {
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckOption.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckOption.java
@@ -47,10 +47,10 @@ import org.eclipse.aether.artifact.DefaultArtifact;
  * </ul>
  *
  * @see <a href=
- *    "https://github.com/GoogleCloudPlatform/cloud-opensource-java/tree/master/dependencies#input">
- *    Classpath Checker: Input</a>
+ *     "https://github.com/GoogleCloudPlatform/cloud-opensource-java/tree/master/dependencies#input">
+ *     Classpath Checker: Input</a>
  */
-public class StaticLinkageCheckOption {
+public class ClasspathCheckOption {
 
   private static final Options options = configureOptions();
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckReport.java
@@ -21,16 +21,16 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
 /**
- * The result of a static linkage check.
+ * The result of a classpath check.
  */
 @AutoValue
-public abstract class StaticLinkageCheckReport {
+public abstract class ClasspathCheckReport {
 
   public abstract ImmutableList<JarLinkageReport> getJarLinkageReports();
 
   @VisibleForTesting
-  public static StaticLinkageCheckReport create(Iterable<JarLinkageReport> jarLinkageReports) {
-    return new AutoValue_StaticLinkageCheckReport(ImmutableList.copyOf(jarLinkageReports));
+  public static ClasspathCheckReport create(Iterable<JarLinkageReport> jarLinkageReports) {
+    return new AutoValue_ClasspathCheckReport(ImmutableList.copyOf(jarLinkageReports));
   }
   
   @Override

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClasspathChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClasspathChecker.java
@@ -45,18 +45,18 @@ import org.eclipse.aether.RepositoryException;
 /**
  * A tool to find static linkage errors for a class path.
  */
-public class StaticLinkageChecker {
+public class ClasspathChecker {
 
-  private static final Logger logger = Logger.getLogger(StaticLinkageChecker.class.getName());
+  private static final Logger logger = Logger.getLogger(ClasspathChecker.class.getName());
 
-  public static StaticLinkageChecker create(
+  public static ClasspathChecker create(
       boolean onlyReachable, List<Path> jarPaths, Iterable<Path> entryPoints)
       throws IOException {
     Preconditions.checkArgument(
         !jarPaths.isEmpty(),
         "The linkage classpath is empty. Specify input to supply one or more jar files");
     ClassDumper dumper = ClassDumper.create(jarPaths);
-    return new StaticLinkageChecker(onlyReachable, dumper, entryPoints);
+    return new ClasspathChecker(onlyReachable, dumper, entryPoints);
   }
 
   /**
@@ -69,7 +69,7 @@ public class StaticLinkageChecker {
 
   private final ImmutableSet<Path> entryPoints;
   
-  private StaticLinkageChecker(
+  private ClasspathChecker(
       boolean reportOnlyReachable,
       ClassDumper classDumper,
       Iterable<Path> entryPoints) {
@@ -80,7 +80,7 @@ public class StaticLinkageChecker {
 
   /**
    * Given Maven coordinates or list of the jar files as file names in filesystem, outputs the
-   * report of static linkage check.
+   * report of classpath check.
    *
    * @throws IOException when there is a problem in reading a jar file
    * @throws RepositoryException when there is a problem in resolving the Maven coordinates to jar
@@ -97,16 +97,16 @@ public class StaticLinkageChecker {
     ImmutableSet<Path> entryPoints = ImmutableSet.of(inputClasspath.get(0));
 
     boolean onlyReachable = commandLine.hasOption("r");
-    StaticLinkageChecker staticLinkageChecker = create(onlyReachable, inputClasspath, entryPoints);
-    StaticLinkageCheckReport report = staticLinkageChecker.findLinkageErrors();
+    ClasspathChecker classpathChecker = create(onlyReachable, inputClasspath, entryPoints);
+    ClasspathCheckReport report = classpathChecker.findLinkageErrors();
 
     System.out.println(report);
   }
 
   /**
-   * Finds linkage errors in the input classpath and generates a static linkage check report.
+   * Finds linkage errors in the input classpath and generates a classpath check report.
    */
-  public StaticLinkageCheckReport findLinkageErrors() throws IOException {
+  public ClasspathCheckReport findLinkageErrors() throws IOException {
     ImmutableList<Path> jarPaths = classDumper.getInputClassPath();
 
     ImmutableMap.Builder<Path, SymbolReferenceSet> jarToSymbols = ImmutableMap.builder();
@@ -127,7 +127,7 @@ public class StaticLinkageChecker {
       throw new UnsupportedOperationException("reportOnlyReachable is not yet implemented");
     }
 
-    return StaticLinkageCheckReport.create(jarLinkageReports.build());
+    return ClasspathCheckReport.create(jarLinkageReports.build());
   }
 
   /**

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClasspathChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClasspathChecker.java
@@ -89,10 +89,9 @@ public class ClasspathChecker {
    */
   public static void main(String[] arguments)
       throws IOException, RepositoryException, ParseException {
-    
-    CommandLine commandLine = StaticLinkageCheckOption.readCommandLine(arguments);
-    ImmutableList<Path> inputClasspath =
-        StaticLinkageCheckOption.generateInputClasspath(commandLine);
+
+    CommandLine commandLine = ClasspathCheckOption.readCommandLine(arguments);
+    ImmutableList<Path> inputClasspath = ClasspathCheckOption.generateInputClasspath(commandLine);
     // TODO(suztomo): take command-line option to choose entry point classes for reachability
     ImmutableSet<Path> entryPoints = ImmutableSet.of(inputClasspath.get(0));
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckClassPath.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckClassPath.java
@@ -49,7 +49,7 @@ public class LinkageCheckClassPath extends ClassPath {
   private final ClassLoader extensionClassLoader;
 
   /**
-   * Constructs a class path for classpath check.
+   * Constructs a classpath for check.
    *
    * @param paths list of absolute paths for the elements in the class path
    */

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckClassPath.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckClassPath.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 import org.apache.bcel.util.ClassPath;
 
 /**
- * Class path to load class files for {@link StaticLinkageChecker}. When loading a resource for a
+ * Class path to load class files for {@link ClasspathChecker}. When loading a resource for a
  * class, {@link LinkageCheckClassPath} ensures that the class file comes from only the extension
  * class loader or the class path specified at the constructor argument.
  *
@@ -34,7 +34,7 @@ import org.apache.bcel.util.ClassPath;
  * org.apache.bcel.util.ClassPathRepository#loadClass(String)} is called, meaning that it loads
  * other classes outside the class path specified at its constructor argument. In other words,
  * classes used in this cloud-opensource-java project (including Guava 26) would be unexpectedly
- * loaded by the system class loader when running static linkage check, if BCEL's {@link ClassPath}
+ * loaded by the system class loader when running classpath check, if BCEL's {@link ClassPath}
  * is naively used.
  *
  * <p>This class is introduced to avoid the mix-up of the class paths. It loads resources only from
@@ -49,7 +49,7 @@ public class LinkageCheckClassPath extends ClassPath {
   private final ClassLoader extensionClassLoader;
 
   /**
-   * Constructs a class path for static linkage check.
+   * Constructs a class path for classpath check.
    *
    * @param paths list of absolute paths for the elements in the class path
    */

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
@@ -47,8 +47,8 @@ import org.eclipse.aether.artifact.DefaultArtifact;
  * </ul>
  *
  * @see <a href=
- *    "https://github.com/GoogleCloudPlatform/cloud-opensource-java/tree/master/dependencies#input">Static
- *     Linkage Checker: Input</a>
+ *    "https://github.com/GoogleCloudPlatform/cloud-opensource-java/tree/master/dependencies#input">
+ *    Classpath Checker: Input</a>
  */
 public class StaticLinkageCheckOption {
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/StaticLinkageCheckOption.java
@@ -37,7 +37,7 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 
 /**
- * Option for {@link StaticLinkageChecker}. To construct an input class path, the checker requires
+ * Option for {@link ClasspathChecker}. To construct an input class path, the checker requires
  * exactly one of the following types of input:
  *
  * <ul>
@@ -66,7 +66,7 @@ public class StaticLinkageCheckOption {
       checkInput(commandLine);
       return commandLine;
     } catch (ParseException ex) {
-      helpFormatter.printHelp("StaticLinkageChecker", options);
+      helpFormatter.printHelp("ClasspathChecker", options);
       throw ex;
     }
   }
@@ -147,7 +147,7 @@ public class StaticLinkageCheckOption {
               .collect(toImmutableList());
       return jarFilesInArguments;
     } else {
-      helpFormatter.printHelp("StaticLinkageChecker", options);
+      helpFormatter.printHelp("ClasspathChecker", options);
       throw new ParseException("Missing argument");
     }
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -122,7 +122,7 @@ public final class RepositoryUtility {
           public boolean selectDependency(Dependency dependency) {
             Artifact artifact = dependency.getArtifact();
             Map<String, String> properties = artifact.getProperties();
-            // Because StaticLinkageChecker only checks jar file, zip files are not needed
+            // Because ClasspathChecker only checks jar file, zip files are not needed
             return !"zip".equals(properties.get("type"));
           }
 
@@ -135,11 +135,11 @@ public final class RepositoryUtility {
 
     // This combination of DependencySelector comes from the default specified in
     // `MavenRepositorySystemUtils.newSession`.
-    // StaticLinkageChecker needs to include 'provided' scope.
+    // ClasspathChecker needs to include 'provided' scope.
     DependencySelector dependencySelector =
         new AndDependencySelector(
             // ScopeDependencySelector takes exclusions. 'Provided' scope is not here to avoid
-            // false positive in StaticLinkageChecker.
+            // false positive in ClasspathChecker.
             new ScopeDependencySelector("test"),
             new OptionalDependencySelector(),
             new ExclusionDependencySelector(),

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -150,8 +150,8 @@ public class ClassPathBuilderTest {
             .filter(path -> "httpclient-4.5.3.jar".equals(path.getFileName().toString()))
             .findFirst()
             .get();
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     // httpclient-4.5.3 AbstractVerifier has a method reference of
     // 'void verify(String host, String[] cns, String[] subjectAlts)' to itself and its interface
@@ -169,7 +169,7 @@ public class ClassPathBuilderTest {
           "Somehow httpclient-4.5.3 contains GZipInputStreamFactory reference, which is added 4.5.4");
     }
 
-    JarLinkageReport jarLinkageReport = staticLinkageChecker.generateLinkageReport(httpClientJar,
+    JarLinkageReport jarLinkageReport = classpathChecker.generateLinkageReport(httpClientJar,
         symbolReferenceSet);
 
     Truth.assertWithMessage("Method references within the same jar file should not be reported")

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckOptionTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckOptionTest.java
@@ -32,7 +32,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class StaticLinkageCheckOptionTest {
+public class ClasspathCheckOptionTest {
 
   @After
   public void cleanup() {
@@ -43,7 +43,7 @@ public class StaticLinkageCheckOptionTest {
   @Test
   public void parseCommandLineOptions_shortOptions_bom() throws ParseException {
     CommandLine parsedOption =
-        StaticLinkageCheckOption.readCommandLine("-b", "abc.com:dummy:1.2", "-r");
+        ClasspathCheckOption.readCommandLine("-b", "abc.com:dummy:1.2", "-r");
 
     Assert.assertEquals("abc.com:dummy:1.2", parsedOption.getOptionObject('b'));
   }
@@ -51,7 +51,7 @@ public class StaticLinkageCheckOptionTest {
   @Test
   public void parseCommandLineOptions_duplicates() {
     try {
-      StaticLinkageCheckOption.readCommandLine(
+      ClasspathCheckOption.readCommandLine(
           "--artifacts",
           "abc.com:abc:1.1,abc.com:abc-util:1.2",
           "-b",
@@ -68,7 +68,7 @@ public class StaticLinkageCheckOptionTest {
   @Test
   public void testReadCommandLine_multipleArtifacts() throws ParseException {
     CommandLine commandLine =
-        StaticLinkageCheckOption.readCommandLine(
+        ClasspathCheckOption.readCommandLine(
             "--artifacts", "abc.com:abc:1.1,abc.com:abc-util:1.2", "--report-only-reachable");
     Truth.assertThat(commandLine.getOptionValues("a")).hasLength(2);
   }
@@ -76,8 +76,7 @@ public class StaticLinkageCheckOptionTest {
   @Test
   public void testReadCommandLine_multipleJars() throws ParseException {
     CommandLine commandLine =
-        StaticLinkageCheckOption.readCommandLine(
-            "-j", "/foo/bar/A.jar,/foo/bar/B.jar,/foo/bar/C.jar");
+        ClasspathCheckOption.readCommandLine("-j", "/foo/bar/A.jar,/foo/bar/B.jar,/foo/bar/C.jar");
     Truth.assertThat(commandLine.getOptionValues("j")).hasLength(3);
   }
 
@@ -85,7 +84,7 @@ public class StaticLinkageCheckOptionTest {
   @Test
   public void parseCommandLineOptions_invalidOption() {
     try {
-      StaticLinkageCheckOption.readCommandLine("-x"); // No such option
+      ClasspathCheckOption.readCommandLine("-x"); // No such option
       Assert.fail();
     } catch (ParseException ex) {
       Assert.assertEquals("Unrecognized option: -x", ex.getMessage());
@@ -96,9 +95,8 @@ public class StaticLinkageCheckOptionTest {
   public void testConfigureAdditionalMavenRepositories_addingSpringRepository()
       throws ParseException, RepositoryException {
     CommandLine commandLine =
-        StaticLinkageCheckOption.readCommandLine(
-            "-m", "https://repo.spring.io/milestone");
-    StaticLinkageCheckOption.setRepositories(commandLine);
+        ClasspathCheckOption.readCommandLine("-m", "https://repo.spring.io/milestone");
+    ClasspathCheckOption.setRepositories(commandLine);
 
     // This artifact does not exist in Maven central, but it is in Spring's repository
     // Spring-asm is used here because it does not have complex dependencies
@@ -112,9 +110,9 @@ public class StaticLinkageCheckOptionTest {
   public void testConfigureAdditionalMavenRepositories_notToUseMavenCentral()
       throws ParseException {
     CommandLine commandLine =
-        StaticLinkageCheckOption.readCommandLine(
+        ClasspathCheckOption.readCommandLine(
             "-m", "https://repo.spring.io/milestone", "--no-maven-central");
-    StaticLinkageCheckOption.setRepositories(commandLine);
+    ClasspathCheckOption.setRepositories(commandLine);
 
     CollectRequest collectRequest = new CollectRequest();
     RepositoryUtility.addRepositoriesToRequest(collectRequest);
@@ -135,10 +133,9 @@ public class StaticLinkageCheckOptionTest {
 
   private static void assertMavenRepositoryIsInvalid(String repositoryUrl)
       throws ParseException {
-    CommandLine commandLine =
-        StaticLinkageCheckOption.readCommandLine("-m", repositoryUrl);
+    CommandLine commandLine = ClasspathCheckOption.readCommandLine("-m", repositoryUrl);
     try {
-      StaticLinkageCheckOption.setRepositories(commandLine);
+      ClasspathCheckOption.setRepositories(commandLine);
       Assert.fail("URL " + repositoryUrl + " should be invalidated");
     } catch (ParseException ex) {
       // pass
@@ -147,17 +144,16 @@ public class StaticLinkageCheckOptionTest {
 
   @Test
   public void testConfigureAdditionalMavenRepositories_fileRepositoryUrl() throws ParseException {
-    CommandLine commandLine =
-        StaticLinkageCheckOption.readCommandLine("-m", "file:///var/tmp");
+    CommandLine commandLine = ClasspathCheckOption.readCommandLine("-m", "file:///var/tmp");
 
     // This method should not raise an exception
-    StaticLinkageCheckOption.setRepositories(commandLine);
+    ClasspathCheckOption.setRepositories(commandLine);
   }
 
   @Test
   public void testReadCommandLine_multipleRepositoriesSeparatedByComma() throws ParseException {
     CommandLine commandLine =
-        StaticLinkageCheckOption.readCommandLine(
+        ClasspathCheckOption.readCommandLine(
             "-m", "file:///var/tmp,https://repo.spring.io/milestone");
     Truth.assertThat(commandLine.getOptionValues("m")).hasLength(2);
   }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckReportTest.java
@@ -26,10 +26,10 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class StaticLinkageCheckReportTest {
+public class ClasspathCheckReportTest {
   
   private JarLinkageReport jarLinkageReport;
-  private StaticLinkageCheckReport staticLinkageCheckReport;
+  private ClasspathCheckReport classpathCheckReport;
 
   @Before
   public void createDummyJarLinkageReport() {
@@ -77,33 +77,33 @@ public class StaticLinkageCheckReportTest {
             .setMissingFieldErrors(missingFieldErrors)
             .build();
 
-    staticLinkageCheckReport =
-        StaticLinkageCheckReport.create(ImmutableList.of(jarLinkageReport));
+    classpathCheckReport =
+        ClasspathCheckReport.create(ImmutableList.of(jarLinkageReport));
   }
 
   @Test
   public void testJarLinkageReportToString() {
-    Truth.assertThat(staticLinkageCheckReport.toString()).startsWith("c (3 errors)");
+    Truth.assertThat(classpathCheckReport.toString()).startsWith("c (3 errors)");
   }
   
   @Test
   public void testToString() {
-    Truth.assertThat(staticLinkageCheckReport.toString()).contains(jarLinkageReport.toString());
+    Truth.assertThat(classpathCheckReport.toString()).contains(jarLinkageReport.toString());
   }
   
   @Test
   public void testToStringNoErrors() {
-    staticLinkageCheckReport = StaticLinkageCheckReport.create(Collections.emptyList());
-    Assert.assertEquals("No static linkage errors\n", staticLinkageCheckReport.toString());
+    classpathCheckReport = ClasspathCheckReport.create(Collections.emptyList());
+    Assert.assertEquals("No static linkage errors\n", classpathCheckReport.toString());
   }
   
   @Test
   public void testCreation() {
-    Assert.assertEquals(1, staticLinkageCheckReport.getJarLinkageReports().size());
-    Assert.assertEquals(jarLinkageReport, staticLinkageCheckReport.getJarLinkageReports().get(0));
+    Assert.assertEquals(1, classpathCheckReport.getJarLinkageReports().size());
+    Assert.assertEquals(jarLinkageReport, classpathCheckReport.getJarLinkageReports().get(0));
     Assert.assertEquals(
         "ClassA",
-        staticLinkageCheckReport
+        classpathCheckReport
             .getJarLinkageReports()
             .get(0)
             .getMissingClassErrors()

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckerTest.java
@@ -637,7 +637,7 @@ public class ClasspathCheckerTest {
         jarLinkageReport.getMissingClassErrors().get(0);
     Truth.assertThat(classReferenceError.getReason()).isEqualTo(Reason.INACCESSIBLE_CLASS);
     Truth.assertWithMessage(
-            "Even when the superclass is unavailable, it should report the location of InnerService")
+            "When the superclass is unavailable, it should report the location of InnerService")
         .that(classReferenceError.getTargetClassLocation().toString())
         .endsWith("testdata/api-common-1.7.0.jar");
   }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckerTest.java
@@ -648,9 +648,9 @@ public class ClasspathCheckerTest {
     String bomCoordinates = "com.google.cloud:cloud-oss-bom:pom:1.0.0-SNAPSHOT";
 
     CommandLine parsedOption =
-        StaticLinkageCheckOption.readCommandLine("-b", bomCoordinates);
+        ClasspathCheckOption.readCommandLine("-b", bomCoordinates);
     ImmutableList<Path> inputClasspath =
-        StaticLinkageCheckOption.generateInputClasspath(parsedOption);
+        ClasspathCheckOption.generateInputClasspath(parsedOption);
     Truth.assertThat(inputClasspath).isNotEmpty();
     // These 2 files are the first 2 artifacts in the BOM
     Truth.assertWithMessage("The files should match the elements in the BOM")
@@ -673,8 +673,8 @@ public class ClasspathCheckerTest {
             + "com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha";
     String[] arguments = {"--artifacts", mavenCoordinates};
 
-    CommandLine parsedOption = StaticLinkageCheckOption.readCommandLine(arguments);
-    List<Path> inputClasspath = StaticLinkageCheckOption.generateInputClasspath(parsedOption);
+    CommandLine parsedOption = ClasspathCheckOption.readCommandLine(arguments);
+    List<Path> inputClasspath = ClasspathCheckOption.generateInputClasspath(parsedOption);
 
     Truth.assertWithMessage(
             "The first 2 items in the classpath should be the 2 artifacts in the input")
@@ -701,11 +701,11 @@ public class ClasspathCheckerTest {
     // Because such case is possible, ClasspathChecker should not abort execution when
     // the unavailable dependency is under certain condition
     CommandLine parsedOption =
-        StaticLinkageCheckOption.readCommandLine(
+        ClasspathCheckOption.readCommandLine(
             "--artifacts", "com.google.guava:guava-gwt:20.0");
 
     ImmutableList<Path> inputClasspath =
-        StaticLinkageCheckOption.generateInputClasspath(parsedOption);
+        ClasspathCheckOption.generateInputClasspath(parsedOption);
 
     Truth.assertThat(inputClasspath)
         .comparingElementsUsing(PATH_FILE_NAMES)
@@ -719,11 +719,11 @@ public class ClasspathCheckerTest {
     //   org.apache.tomcat:tomcat-jasper:jar:8.0.9
     //     org.eclipse.jdt.core.compiler:ecj:jar:4.4RC4 (not found in Maven central)
     CommandLine parsedOption =
-        StaticLinkageCheckOption.readCommandLine(
+        ClasspathCheckOption.readCommandLine(
             "--artifacts", "org.apache.tomcat:tomcat-jasper:8.0.9");
 
     try {
-      StaticLinkageCheckOption.generateInputClasspath(parsedOption);
+      ClasspathCheckOption.generateInputClasspath(parsedOption);
       Assert.fail(
           "Because the unavailable dependency is not optional, it should throw an exception");
     } catch (RepositoryException ex) {
@@ -738,8 +738,8 @@ public class ClasspathCheckerTest {
       throws RepositoryException, ParseException {
 
     CommandLine parsedOption =
-        StaticLinkageCheckOption.readCommandLine("--jars", "dir1/foo.jar,dir2/bar.jar,baz.jar");
-    List<Path> inputClasspath = StaticLinkageCheckOption.generateInputClasspath(parsedOption);
+        ClasspathCheckOption.readCommandLine("--jars", "dir1/foo.jar,dir2/bar.jar,baz.jar");
+    List<Path> inputClasspath = ClasspathCheckOption.generateInputClasspath(parsedOption);
 
     Truth.assertThat(inputClasspath)
         .comparingElementsUsing(PATH_FILE_NAMES)

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckerTest.java
@@ -38,18 +38,18 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class StaticLinkageCheckerTest {
+public class ClasspathCheckerTest {
 
   @Test
   public void testFindInvalidReferences_arrayCloneMethod() throws IOException, URISyntaxException {
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/guava-23.5-jre.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     // Array's clone is available in Java runtime and thus should not be reported as linkage error
     MethodSymbolReference arrayClone =
         MethodSymbolReference.builder()
-            .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
+            .setSourceClassName(ClasspathCheckReportTest.class.getName())
             .setTargetClassName("[Lio.grpc.InternalKnownTransport;")
             .setInterfaceMethod(false)
             .setMethodName("clone")
@@ -59,7 +59,7 @@ public class StaticLinkageCheckerTest {
     // ImmutableList does not have clone method
     MethodSymbolReference invalidCloneOnNonArray =
         MethodSymbolReference.builder()
-            .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
+            .setSourceClassName(ClasspathCheckReportTest.class.getName())
             .setTargetClassName("com.google.common.collect.ImmutableList")
             .setInterfaceMethod(false)
             .setMethodName("clone")
@@ -73,7 +73,7 @@ public class StaticLinkageCheckerTest {
     Path jarNotContainingImmutableList =
         absolutePathOfResource("testdata/grpc-google-cloud-firestore-v1beta1-0.28.0.jar");
     JarLinkageReport jarLinkageReport =
-        staticLinkageChecker.generateLinkageReport(
+        classpathChecker.generateLinkageReport(
             jarNotContainingImmutableList, symbolReferenceSet);
 
     Truth.assertThat(jarLinkageReport.getMissingMethodErrors()).hasSize(1);
@@ -85,12 +85,12 @@ public class StaticLinkageCheckerTest {
   public void testFindInvalidReferences_constructorInAbstractClass()
       throws IOException, URISyntaxException {
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/guava-23.5-jre.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     MethodSymbolReference methodSymbolReference =
         MethodSymbolReference.builder()
-            .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
+            .setSourceClassName(ClasspathCheckReportTest.class.getName())
             .setTargetClassName(
                 "com.google.common.collect.LinkedHashMultimapGwtSerializationDependencies")
             .setInterfaceMethod(false)
@@ -101,7 +101,7 @@ public class StaticLinkageCheckerTest {
     SymbolReferenceSet symbolReferenceSet =
         SymbolReferenceSet.builder().setMethodReferences(methodReferences).build();
 
-    JarLinkageReport jarLinkageReport = staticLinkageChecker.generateLinkageReport(paths.get(0),
+    JarLinkageReport jarLinkageReport = classpathChecker.generateLinkageReport(paths.get(0),
         symbolReferenceSet);
 
     Truth.assertThat(jarLinkageReport.getMissingMethodErrors()).isEmpty();
@@ -111,13 +111,13 @@ public class StaticLinkageCheckerTest {
   public void testCheckLinkageErrorMissingInterfaceMethodAt_interfaceAndClassSeparation()
       throws IOException, URISyntaxException {
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/guava-23.5-jre.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     // ImmutableList is an abstract class, but setting isInterfaceMethod = true
     MethodSymbolReference methodSymbolReference =
         MethodSymbolReference.builder()
-            .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
+            .setSourceClassName(ClasspathCheckReportTest.class.getName())
             .setTargetClassName("com.google.common.collect.ImmutableList")
             .setInterfaceMethod(true) // This is invalid
             .setMethodName("get")
@@ -125,7 +125,7 @@ public class StaticLinkageCheckerTest {
             .build();
     // When it's verified against interfaces, it should generate an error
     Optional<StaticLinkageError<MethodSymbolReference>> errorFound =
-        staticLinkageChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
+        classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isPresent();
     Truth.assertThat(errorFound.get().getReason()).isEqualTo(Reason.INCOMPATIBLE_CLASS_CHANGE);
@@ -135,13 +135,13 @@ public class StaticLinkageCheckerTest {
   public void testCheckLinkageErrorMissingMethodAt_interfaceAndClassSeparation()
       throws IOException, URISyntaxException {
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/guava-23.5-jre.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     // ClassToInstanceMap is an interface, but setting isInterfaceMethod = false
     MethodSymbolReference methodSymbolReference =
         MethodSymbolReference.builder()
-            .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
+            .setSourceClassName(ClasspathCheckReportTest.class.getName())
             .setTargetClassName("com.google.common.collect.ClassToInstanceMap")
             .setInterfaceMethod(false) // This is invalid
             .setMethodName("getInstance")
@@ -149,7 +149,7 @@ public class StaticLinkageCheckerTest {
             .build();
     // When it's verified against classes, it should generate an error
     Optional<StaticLinkageError<MethodSymbolReference>> errorFound =
-        staticLinkageChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
+        classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isPresent();
     Truth.assertThat(errorFound.get().getReason()).isEqualTo(Reason.INCOMPATIBLE_CLASS_CHANGE);
@@ -159,13 +159,13 @@ public class StaticLinkageCheckerTest {
   public void testCheckLinkageErrorMissingInterfaceMethodAt_missingInterfaceMethod()
       throws IOException, URISyntaxException {
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/guava-23.5-jre.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     // ClassToInstanceMap is an interface
     MethodSymbolReference methodSymbolReference =
         MethodSymbolReference.builder()
-            .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
+            .setSourceClassName(ClasspathCheckReportTest.class.getName())
             .setTargetClassName("com.google.common.collect.ClassToInstanceMap")
             .setInterfaceMethod(true)
             .setMethodName("noSuchMethod")
@@ -173,7 +173,7 @@ public class StaticLinkageCheckerTest {
             .build();
     // There is no such method on ClassToInstanceMap
     Optional<StaticLinkageError<MethodSymbolReference>> errorFound =
-        staticLinkageChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
+        classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isPresent();
     Truth.assertThat(errorFound.get().getReason()).isEqualTo(Reason.SYMBOL_NOT_FOUND);
@@ -183,20 +183,20 @@ public class StaticLinkageCheckerTest {
   public void testFindInvalidReferences_interfaceNotImplementedAtAbstractClass()
       throws IOException, URISyntaxException {
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/guava-23.5-jre.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     // ImmutableList is an abstract class that implements List, but does not implement get() method
     MethodSymbolReference methodSymbolReference =
         MethodSymbolReference.builder()
-            .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
+            .setSourceClassName(ClasspathCheckReportTest.class.getName())
             .setTargetClassName("com.google.common.collect.ImmutableList")
             .setInterfaceMethod(false)
             .setMethodName("get")
             .setDescriptor("(I)Ljava/lang/Object;")
             .build();
     Optional<StaticLinkageError<MethodSymbolReference>> errorFound =
-        staticLinkageChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
+        classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isEmpty();
   }
@@ -205,13 +205,13 @@ public class StaticLinkageCheckerTest {
   public void testCheckLinkageErrorMissingMethodAt_privateConstructor()
       throws IOException, URISyntaxException {
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/guava-23.5-jre.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     // ImmutableList is an abstract class that implements List, but does not implement get() method
     MethodSymbolReference methodSymbolReference =
         MethodSymbolReference.builder()
-            .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
+            .setSourceClassName(ClasspathCheckReportTest.class.getName())
             .setTargetClassName("com.google.common.base.Absent")
             .setInterfaceMethod(false)
             // The constructor with zero arguments is marked as private
@@ -220,7 +220,7 @@ public class StaticLinkageCheckerTest {
             .build();
 
     Optional<StaticLinkageError<MethodSymbolReference>> errorFound =
-        staticLinkageChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
+        classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isPresent();
     Truth.assertThat(errorFound.get().getReason()).isEqualTo(Reason.INACCESSIBLE_CLASS);
@@ -233,8 +233,8 @@ public class StaticLinkageCheckerTest {
         ClassPathBuilder.artifactsToClasspath(
             ImmutableList.of(new DefaultArtifact("junit:junit:4.12")));
     // junit has dependency on hamcrest-core
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     // ImmutableList is an abstract class that implements List, but does not implement get() method
     MethodSymbolReference methodSymbolReference =
@@ -248,7 +248,7 @@ public class StaticLinkageCheckerTest {
             .build();
 
     Optional<StaticLinkageError<MethodSymbolReference>> errorFound =
-        staticLinkageChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
+        classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     // JLS 6.6.2.2 says
     // If the access is by an anonymous class instance creation expression of the form
@@ -260,13 +260,13 @@ public class StaticLinkageCheckerTest {
   public void testCheckLinkageErrorMissingMethodAt_privateMethod()
       throws IOException, URISyntaxException {
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/guava-23.5-jre.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     // ImmutableList is an abstract class that implements List, but does not implement get() method
     MethodSymbolReference methodSymbolReference =
         MethodSymbolReference.builder()
-            .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
+            .setSourceClassName(ClasspathCheckReportTest.class.getName())
             .setTargetClassName("com.google.common.base.Absent")
             .setInterfaceMethod(false)
             // This method is marked as private
@@ -275,7 +275,7 @@ public class StaticLinkageCheckerTest {
             .build();
 
     Optional<StaticLinkageError<MethodSymbolReference>> errorFound =
-        staticLinkageChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
+        classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isPresent();
     Truth.assertThat(errorFound.get().getReason()).isEqualTo(Reason.INACCESSIBLE_CLASS);
@@ -285,13 +285,13 @@ public class StaticLinkageCheckerTest {
   public void testCheckLinkageErrorMissingMethodAt_privateStaticMethod()
       throws IOException, URISyntaxException {
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/guava-23.5-jre.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     // ImmutableList is an abstract class that implements List, but does not implement get() method
     MethodSymbolReference privateStaticReference =
         MethodSymbolReference.builder()
-            .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
+            .setSourceClassName(ClasspathCheckReportTest.class.getName())
             .setTargetClassName("com.google.common.base.Ascii")
             .setInterfaceMethod(false)
             // This method is marked as private
@@ -300,7 +300,7 @@ public class StaticLinkageCheckerTest {
             .build();
 
     Optional<StaticLinkageError<MethodSymbolReference>> errorFound =
-        staticLinkageChecker.checkLinkageErrorMissingMethodAt(privateStaticReference);
+        classpathChecker.checkLinkageErrorMissingMethodAt(privateStaticReference);
 
     Truth8.assertThat(errorFound).isPresent();
     Truth.assertThat(errorFound.get().getReason()).isEqualTo(Reason.INACCESSIBLE_MEMBER);
@@ -311,12 +311,12 @@ public class StaticLinkageCheckerTest {
     List<Path> paths =
         ImmutableList.of(
             absolutePathOfResource("testdata/grpc-google-cloud-firestore-v1beta1-0.28.0.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     FieldSymbolReference validFieldReference =
         FieldSymbolReference.builder()
-            .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
+            .setSourceClassName(ClasspathCheckReportTest.class.getName())
             .setTargetClassName("com.google.firestore.v1beta1.FirestoreGrpc")
             .setFieldName("SERVICE_NAME") // valid in grpc-google-cloud-firestore-v1beta1-0.28.0
             .build();
@@ -325,7 +325,7 @@ public class StaticLinkageCheckerTest {
         SymbolReferenceSet.builder().setFieldReferences(fieldReferences).build();
 
     JarLinkageReport jarLinkageReport =
-        staticLinkageChecker.generateLinkageReport(
+        classpathChecker.generateLinkageReport(
             absolutePathOfResource("testdata/gax-1.32.0.jar"),
             symbolReferenceSet);
 
@@ -337,12 +337,12 @@ public class StaticLinkageCheckerTest {
     List<Path> paths =
         ImmutableList.of(
             absolutePathOfResource("testdata/grpc-google-cloud-firestore-v1beta1-0.28.0.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     FieldSymbolReference invalidFieldReference =
         FieldSymbolReference.builder()
-            .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
+            .setSourceClassName(ClasspathCheckReportTest.class.getName())
             .setTargetClassName("com.google.firestore.v1beta1.FirestoreGrpc")
             .setFieldName("DUMMY_FIELD") // non-existent as of version 0.28.0
             .build();
@@ -351,7 +351,7 @@ public class StaticLinkageCheckerTest {
         SymbolReferenceSet.builder().setFieldReferences(fieldReferences).build();
 
     JarLinkageReport jarLinkageReport =
-        staticLinkageChecker.generateLinkageReport(
+        classpathChecker.generateLinkageReport(
             absolutePathOfResource("testdata/gax-1.32.0.jar"),
             symbolReferenceSet);
 
@@ -368,8 +368,8 @@ public class StaticLinkageCheckerTest {
       throws IOException, URISyntaxException {
     // The class path does not include Guava.
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/api-common-1.7.0.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     // Guava class should not be found in the class path
     String guavaClass =
@@ -384,7 +384,7 @@ public class StaticLinkageCheckerTest {
 
     // There should be an error reported for the reference
     Optional<StaticLinkageError<ClassSymbolReference>> classSymbolError =
-        staticLinkageChecker.checkLinkageErrorMissingClassAt(invalidClassReference);
+        classpathChecker.checkLinkageErrorMissingClassAt(invalidClassReference);
     Truth8.assertThat(classSymbolError).isPresent();
     Truth.assertThat(classSymbolError.get().getReference()).isEqualTo(invalidClassReference);
   }
@@ -395,20 +395,20 @@ public class StaticLinkageCheckerTest {
     List<Path> paths =
         ImmutableList.of(
             absolutePathOfResource("testdata/grpc-google-cloud-firestore-v1beta1-0.28.0.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     // FirestoreGrpc class exists in the jar file
     ClassSymbolReference invalidClassReference =
         ClassSymbolReference.builder()
-            .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
+            .setSourceClassName(ClasspathCheckReportTest.class.getName())
             .setSubclass(false)
             .setTargetClassName("com.google.firestore.v1beta1.FirestoreGrpc")
             .build();
 
     // There should not be an error reported for the reference
     Optional<StaticLinkageError<ClassSymbolReference>> classSymbolError =
-        staticLinkageChecker.checkLinkageErrorMissingClassAt(invalidClassReference);
+        classpathChecker.checkLinkageErrorMissingClassAt(invalidClassReference);
     Truth8.assertThat(classSymbolError).isEmpty();
   }
 
@@ -418,8 +418,8 @@ public class StaticLinkageCheckerTest {
     List<Path> paths =
         ImmutableList.of(
             absolutePathOfResource("testdata/grpc-google-cloud-firestore-v1beta1-0.28.0.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     ClassSymbolReference invalidClassReference =
         ClassSymbolReference.builder()
@@ -429,7 +429,7 @@ public class StaticLinkageCheckerTest {
             .build();
 
     Optional<StaticLinkageError<ClassSymbolReference>> classSymbolError =
-        staticLinkageChecker.checkLinkageErrorMissingClassAt(invalidClassReference);
+        classpathChecker.checkLinkageErrorMissingClassAt(invalidClassReference);
     Truth8.assertThat(classSymbolError).isPresent();
     Truth.assertThat(classSymbolError.get().getReason())
         .isEqualTo(Reason.INCOMPATIBLE_CLASS_CHANGE);
@@ -446,8 +446,8 @@ public class StaticLinkageCheckerTest {
                 new DefaultArtifact("cglib:cglib:2.2_beta1"),
                 new DefaultArtifact("org.ow2.asm:asm:4.2")));
 
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     ClassSymbolReference invalidClassReference =
         ClassSymbolReference.builder()
@@ -457,7 +457,7 @@ public class StaticLinkageCheckerTest {
             .build();
 
     Optional<StaticLinkageError<ClassSymbolReference>> classSymbolError =
-        staticLinkageChecker.checkLinkageErrorMissingClassAt(invalidClassReference);
+        classpathChecker.checkLinkageErrorMissingClassAt(invalidClassReference);
     Truth8.assertThat(classSymbolError).isPresent();
     Truth.assertWithMessage(
             "ClassWriter.verify, which DebuggingClassWriter overrides, is final in asm 4")
@@ -470,16 +470,16 @@ public class StaticLinkageCheckerTest {
       throws IOException, URISyntaxException {
     FieldSymbolReference privateFieldReference =
         FieldSymbolReference.builder()
-            .setSourceClassName(StaticLinkageCheckerTest.class.getName())
+            .setSourceClassName(ClasspathCheckerTest.class.getName())
             .setTargetClassName("com.google.api.pathtemplate.PathTemplate")
             .setFieldName("SLASH_SPLITTER")
             .build();
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/api-common-1.7.0.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     Optional<StaticLinkageError<FieldSymbolReference>> errorFound =
-        staticLinkageChecker.checkLinkageErrorMissingFieldAt(privateFieldReference);
+        classpathChecker.checkLinkageErrorMissingFieldAt(privateFieldReference);
 
     Truth8.assertThat(errorFound).isPresent();
     Truth.assertWithMessage("PathTemplate.SLASH_SPLITTER is private field and not accessible.")
@@ -507,15 +507,15 @@ public class StaticLinkageCheckerTest {
             .build();
 
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/guava-23.5-jre.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     Optional<StaticLinkageError<FieldSymbolReference>> errorOnSamePackage =
-        staticLinkageChecker.checkLinkageErrorMissingFieldAt(accessFromSamePackage);
+        classpathChecker.checkLinkageErrorMissingFieldAt(accessFromSamePackage);
     Truth8.assertThat(errorOnSamePackage).isEmpty();
 
     Optional<StaticLinkageError<FieldSymbolReference>> errorOnDifferentPackage =
-        staticLinkageChecker.checkLinkageErrorMissingFieldAt(accessFromDifferentPackage);
+        classpathChecker.checkLinkageErrorMissingFieldAt(accessFromDifferentPackage);
     Truth8.assertThat(errorOnDifferentPackage).isPresent();
 
     Truth.assertWithMessage(
@@ -537,13 +537,13 @@ public class StaticLinkageCheckerTest {
             .build();
 
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/guava-23.5-jre.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     // Because StringCharSource is in the same package, the source class is not suitable
     // for this class.
     Optional<StaticLinkageError<FieldSymbolReference>> errorFound =
-        staticLinkageChecker.checkLinkageErrorMissingFieldAt(referenceFromSubclass);
+        classpathChecker.checkLinkageErrorMissingFieldAt(referenceFromSubclass);
     Truth8.assertThat(errorFound).isEmpty();
   }
 
@@ -553,8 +553,8 @@ public class StaticLinkageCheckerTest {
     List<Path> paths =
         ImmutableList.of(
             absolutePathOfResource("testdata/grpc-google-cloud-firestore-v1beta1-0.28.0.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     String nonExistentClassName = "io.grpc.MethodDescriptor";
     ClassSymbolReference invalidClassReference =
@@ -569,7 +569,7 @@ public class StaticLinkageCheckerTest {
         SymbolReferenceSet.builder().setClassReferences(classSymbolReferences).build();
 
     JarLinkageReport jarLinkageReport =
-        staticLinkageChecker.generateLinkageReport(
+        classpathChecker.generateLinkageReport(
             absolutePathOfResource("testdata/gax-1.32.0.jar"),
             symbolReferenceSet);
 
@@ -587,12 +587,12 @@ public class StaticLinkageCheckerTest {
     List<Path> paths =
         ImmutableList.of(
             absolutePathOfResource("testdata/grpc-google-cloud-firestore-v1beta1-0.28.0.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     ClassSymbolReference publicClassReference =
         ClassSymbolReference.builder()
-            .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
+            .setSourceClassName(ClasspathCheckReportTest.class.getName())
             .setSubclass(false)
             // This inner class is defined as public in firestore-v1beta1-0.28.0.jar
             .setTargetClassName("com.google.firestore.v1beta1.FirestoreGrpc$FirestoreStub")
@@ -602,7 +602,7 @@ public class StaticLinkageCheckerTest {
         SymbolReferenceSet.builder().setClassReferences(classReferences).build();
 
     JarLinkageReport jarLinkageReport =
-        staticLinkageChecker.generateLinkageReport(
+        classpathChecker.generateLinkageReport(
             absolutePathOfResource("testdata/gax-1.32.0.jar"),
             symbolReferenceSet);
 
@@ -613,12 +613,12 @@ public class StaticLinkageCheckerTest {
   public void testFindClassReferences_privateClass() throws IOException, URISyntaxException {
     // The superclass of AbstractApiService$InnerService (Guava's ApiService) is not in the paths
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/api-common-1.7.0.jar"));
-    StaticLinkageChecker staticLinkageChecker =
-        StaticLinkageChecker.create(false, paths, ImmutableSet.copyOf(paths));
+    ClasspathChecker classpathChecker =
+        ClasspathChecker.create(false, paths, ImmutableSet.copyOf(paths));
 
     ClassSymbolReference referenceToPrivateClass =
         ClassSymbolReference.builder()
-            .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
+            .setSourceClassName(ClasspathCheckReportTest.class.getName())
             .setSubclass(false)
             // This private inner class is defined in firestore-v1beta1-0.28.0.jar
             .setTargetClassName("com.google.api.core.AbstractApiService$InnerService")
@@ -628,7 +628,7 @@ public class StaticLinkageCheckerTest {
         SymbolReferenceSet.builder().setClassReferences(fieldReferences).build();
 
     JarLinkageReport jarLinkageReport =
-        staticLinkageChecker.generateLinkageReport(
+        classpathChecker.generateLinkageReport(
             absolutePathOfResource("testdata/gax-1.32.0.jar"),
             symbolReferenceSet);
 
@@ -698,7 +698,7 @@ public class StaticLinkageCheckerTest {
     //         org.mortbay.jasper:apache-jsp:jar:8.0.9.M3 (compile)
     //           org.apache.tomcat:tomcat-jasper:jar:8.0.9 (compile, optional:true)
     //             org.eclipse.jdt.core.compiler:ecj:jar:4.4RC4 (not found in Maven central)
-    // Because such case is possible, StaticLinkageChecker should not abort execution when
+    // Because such case is possible, ClasspathChecker should not abort execution when
     // the unavailable dependency is under certain condition
     CommandLine parsedOption =
         StaticLinkageCheckOption.readCommandLine(
@@ -764,8 +764,8 @@ public class StaticLinkageCheckerTest {
             absolutePathOfResource("testdata/google-cloud-firestore-0.66.0-beta.jar"));
     pathsForJarWithVersion65First.addAll(firestoreDependencies);
 
-    StaticLinkageChecker staticLinkageChecker65First =
-        StaticLinkageChecker.create(
+    ClasspathChecker classpathChecker65First =
+        ClasspathChecker.create(
             true,
             pathsForJarWithVersion65First,
             ImmutableSet.copyOf(pathsForJarWithVersion65First));
@@ -775,15 +775,15 @@ public class StaticLinkageCheckerTest {
             absolutePathOfResource("testdata/google-cloud-firestore-0.66.0-beta.jar"),
             absolutePathOfResource("testdata/google-cloud-firestore-0.65.0-beta.jar"));
     pathsForJarWithVersion66First.addAll(firestoreDependencies);
-    StaticLinkageChecker staticLinkageChecker66First =
-        StaticLinkageChecker.create(
+    ClasspathChecker classpathChecker66First =
+        ClasspathChecker.create(
             true,
             pathsForJarWithVersion66First,
             ImmutableSet.copyOf(pathsForJarWithVersion66First));
 
     MethodSymbolReference listDocument =
         MethodSymbolReference.builder()
-            .setSourceClassName(StaticLinkageCheckReportTest.class.getName())
+            .setSourceClassName(ClasspathCheckReportTest.class.getName())
             .setTargetClassName("com.google.cloud.firestore.CollectionReference")
             .setInterfaceMethod(false)
             .setMethodName("listDocuments")
@@ -793,14 +793,14 @@ public class StaticLinkageCheckerTest {
         SymbolReferenceSet.builder().setMethodReferences(ImmutableList.of(listDocument)).build();
 
     JarLinkageReport reportWith65First =
-        staticLinkageChecker65First.generateLinkageReport(
+        classpathChecker65First.generateLinkageReport(
             firestoreDependencies.get(0), symbolReferenceSet);
     Truth.assertWithMessage("Firestore version 65 does not have CollectionReference.listDocuments")
         .that(reportWith65First.getMissingMethodErrors())
         .hasSize(1);
 
     JarLinkageReport reportWith66First =
-        staticLinkageChecker66First.generateLinkageReport(
+        classpathChecker66First.generateLinkageReport(
             firestoreDependencies.get(0), symbolReferenceSet);
     Truth.assertWithMessage("Firestore version 66 has CollectionReference.listDocuments")
         .that(reportWith66First.getMissingMethodErrors())
@@ -816,9 +816,9 @@ public class StaticLinkageCheckerTest {
         ClassPathBuilder.artifactsToClasspath(
             ImmutableList.of(new DefaultArtifact("org.slf4j:slf4j-api:jar:1.7.21")));
 
-    StaticLinkageChecker staticLinkageChecker = StaticLinkageChecker.create(false, paths, paths);
+    ClasspathChecker classpathChecker = ClasspathChecker.create(false, paths, paths);
 
-    StaticLinkageCheckReport linkageErrors = staticLinkageChecker.findLinkageErrors();
+    ClasspathCheckReport linkageErrors = classpathChecker.findLinkageErrors();
 
     JarLinkageReport slf4jLinkageReport = linkageErrors.getJarLinkageReports().get(0);
     Truth.assertThat(slf4jLinkageReport.getMissingClassErrors()).isEmpty();
@@ -834,9 +834,9 @@ public class StaticLinkageCheckerTest {
     List<Path> paths =
         ImmutableList.of(
             absolutePathOfResource("testdata/grpc-google-cloud-firestore-v1beta1-0.28.0.jar"));
-    StaticLinkageChecker staticLinkageChecker = StaticLinkageChecker.create(false, paths, paths);
+    ClasspathChecker classpathChecker = ClasspathChecker.create(false, paths, paths);
 
-    StaticLinkageCheckReport linkageErrors = staticLinkageChecker.findLinkageErrors();
+    ClasspathCheckReport linkageErrors = classpathChecker.findLinkageErrors();
 
     JarLinkageReport firestoreLinkageReport = linkageErrors.getJarLinkageReports().get(0);
     Truth.assertThat(firestoreLinkageReport.getMissingClassErrors()).isNotEmpty();


### PR DESCRIPTION
Fixes #405.
This change is to rename the following classes:

- `StaticLinkageChecker` -> `Classpath Checker`
- `StaticLinakgeCheckReport` -> `ClasspathCheckReport`
- `StaticLinkageCheckOption` -> `ClasspathCheckOption`
