### PR TITLE
Dashboard to use ul tags for source classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
 
     environment:
       # Customize the JVM maximum heap limit
-      MAVEN_OPTS: -Xmx1024m -XX:MaxPermSize=128m
+      MAVEN_OPTS: -Xmx2048m -XX:MaxPermSize=128m
 
     
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
 
     environment:
       # Customize the JVM maximum heap limit
-      MAVEN_OPTS: -Xmx2048m -XX:MaxPermSize=128m
+      MAVEN_OPTS: -Xmx1024m -XX:MaxPermSize=128m
 
     
     steps:

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -81,15 +81,6 @@
           <mainClass>com.google.cloud.tools.opensource.dashboard.DashboardMain</mainClass>
         </configuration>
       </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <!-- To avoid ForkedBooter loading issue -->
-            <useSystemClassLoader>false</useSystemClassLoader>
-            <argLine>-Xms128m -Xmx2048m</argLine>
-          </configuration>
-        </plugin>
     </plugins>
   </build>
 

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -364,7 +364,7 @@ public class DashboardMain {
       templateData.put("jarLinkageReports", classpathCheckReport.getJarLinkageReports());
       templateData.put("jarToDependencyPaths", jarToDependencyPaths);
 
-      // Accessing Static method in Freemarker
+      // Accessing Static method 'countFailures' from Freemarker template
       // https://freemarker.apache.org/docs/pgui_misc_beanwrapper.html#autoid_60
       DefaultObjectWrapper wrapper = new DefaultObjectWrapperBuilder(Configuration.VERSION_2_3_28)
           .build();

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -63,6 +63,7 @@ import com.google.cloud.tools.opensource.dependencies.VersionComparator;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
@@ -284,10 +285,11 @@ public class DashboardMain {
       Template report = configuration.getTemplate("/templates/component.ftl");
 
       // Jar to DependencyPaths which start with the artifact for this report
-      Multimap<Path, DependencyPath> jarToDependencyPathsForArtifact =
-          Multimaps.filterValues(
+      ImmutableMultimap<Path, DependencyPath> jarToDependencyPathsForArtifact =
+          ImmutableMultimap.copyOf(Multimaps.filterValues(
               jarToDependencyPaths,
-              dependencyPath -> coordinates.equals(Artifacts.toCoordinates(dependencyPath.get(0))));
+              dependencyPath -> coordinates
+                  .equals(Artifacts.toCoordinates(dependencyPath.get(0)))));
 
       Map<String, Object> templateData = new HashMap<>();
       templateData.put("groupId", artifact.getGroupId());

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.opensource.dashboard;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
-import com.google.common.collect.ImmutableMultimap;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -61,6 +60,7 @@ import com.google.cloud.tools.opensource.dependencies.VersionComparator;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.opensource.dashboard;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
+import com.google.common.collect.ImmutableListMultimap;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -41,6 +42,8 @@ import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import freemarker.template.Version;
+import java.util.stream.Collector;
+import org.apache.maven.artifact.ArtifactUtils;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -279,14 +282,12 @@ public class DashboardMain {
           DependencyTreeFormatter.buildDependencyPathTree(dependencyPaths);
       Template report = configuration.getTemplate("/templates/component.ftl");
 
-      // Jar to DependencyPaths, which starts with the artifact for this report
+      // Jar to DependencyPaths which start with the artifact for this report
       ImmutableMultimap.Builder<Path, DependencyPath> jarToDependencyPathsForArtifact =
           ImmutableMultimap.builder();
       jarToDependencyPaths.forEach(
           (path, dependencyPath) -> {
-            Artifact dependencyPathRoot = dependencyPath.get(0);
-            if (dependencyPathRoot.getGroupId().equals(artifact.getGroupId())
-                && dependencyPathRoot.getArtifactId().equals(artifact.getArtifactId())) {
+            if (coordinates.equals(Artifacts.toCoordinates(dependencyPath.get(0)))) {
               jarToDependencyPathsForArtifact.put(path, dependencyPath);
             }
           });

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -299,8 +299,7 @@ public class DashboardMain {
       templateData.put("upperBoundFailures", upperBoundFailures);
       templateData.put("globalUpperBoundFailures", globalUpperBoundFailures);
       templateData.put("lastUpdated", LocalDateTime.now());
-      // Explicit casting avoids Freemarker's error on `AbstractListMultimap.get` in CircleCI
-      templateData.put("dependencyTree", (LinkedListMultimap<?, ?>) dependencyTree);
+      templateData.put("dependencyTree", dependencyTree);
       templateData.put("dependencyRootNode", Iterables.getFirst(dependencyTree.values(), null));
       templateData.put("jarLinkageReports", staticLinkageCheckReports);
       templateData.put("jarToDependencyPaths", jarToDependencyPathsForArtifact.build());

--- a/dashboard/src/main/resources/css/dashboard.css
+++ b/dashboard/src/main/resources/css/dashboard.css
@@ -54,8 +54,18 @@
    margin-bottom: 0;
  }
 
- .static-linkage-check-dependency-paths {
-   margin-left: 15pt;
+ .static-linkage-check-dependency-paths, .jar-linkage-report {
+   margin-left: 1em;
+ }
+
+ p.jar-linkage-report-cause {
+   margin-bottom: 0pt;
+   margin-left: 2em;
+ }
+
+ ul.jar-linkage-report-cause {
+   margin-top: 0em;
+   margin-left: 3em;
  }
 
  /* ----- Statistic ----- */

--- a/dashboard/src/main/resources/css/dashboard.css
+++ b/dashboard/src/main/resources/css/dashboard.css
@@ -69,7 +69,7 @@
  }
 
  ul.jar-linkage-report-cause > li {
-   font: 1em 'Droid Sans Mono', monospace
+   font: 1em 'Droid Sans Mono', monospace;
  }
 
  /* ----- Statistic ----- */

--- a/dashboard/src/main/resources/css/dashboard.css
+++ b/dashboard/src/main/resources/css/dashboard.css
@@ -36,20 +36,20 @@
    line-height: normal;
  }
  
- .PASS {
+ .pass {
    background-color: lightgreen;
    font-weight: bold;
  }
- .FAIL {
+ .fail {
    background-color: pink;
    font-weight: bold;
  }
- .UNAVAILABLE {
+ .unavailable {
    background-color: gray;
    font-weight: bold;
  }
 
- p.DEPENDENCY_TREE_NODE {
+ p.dependency-tree-node {
    margin-top: 0;
    margin-bottom: 0;
  }
@@ -59,13 +59,17 @@
  }
 
  p.jar-linkage-report-cause {
-   margin-bottom: 0pt;
+   margin-bottom: 0;
    margin-left: 2em;
  }
 
  ul.jar-linkage-report-cause {
-   margin-top: 0em;
+   margin-top: 0;
    margin-left: 3em;
+ }
+
+ ul.jar-linkage-report-cause > li {
+   font: 1em 'Droid Sans Mono', monospace
  }
 
  /* ----- Statistic ----- */

--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -115,9 +115,7 @@
 
     <p id="static-linkage-errors-total">${totalLinkageErrorCount} static linkage error(s)</p>
     <#list jarLinkageReports as jarLinkageReport>
-      <#if jarLinkageReport.getTotalErrorCount() gt 0>
-        <@formatJarLinkageReport jarLinkageReport jarToDependencyPaths/>
-      </#if>
+      <@formatJarLinkageReport jarLinkageReport jarToDependencyPaths/>
     </#list>
 
     <h2>Dependencies</h2>

--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -127,7 +127,7 @@
 
         <#list causeToSourceClasses.keySet() as key >
           <p class="jar-linkage-report-cause">${key?html} Referenced from</p>
-          <ul>
+          <ul class="jar-linkage-report-cause">
             <#list causeToSourceClasses.get(key) as sourceClass>
               <li class="jar-linkage-report-source-class"><code>${sourceClass?html}</code></li>
             </#list>

--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -1,4 +1,5 @@
 <html lang="en-US">
+  <#include "macros.ftl">
   <head>
     <title>Google Cloud Platform Dependency Analysis Report for ${groupId}:${artifactId}:${version}</title>
     <link rel="stylesheet" type="text/css" href="dashboard.css" />
@@ -115,38 +116,7 @@
     <p id="static-linkage-errors-total">${totalLinkageErrorCount} static linkage error(s)</p>
     <#list jarLinkageReports as jarLinkageReport>
       <#if jarLinkageReport.getTotalErrorCount() gt 0>
-        <h3>${jarLinkageReport.getJarPath().getFileName()?html}</h3>
-        <#assign causeToSourceClasses = jarLinkageReport.getCauseToSourceClasses() />
-        <#assign errorPlural = jarLinkageReport.getTotalErrorCount() gt 1 />
-        <#assign causePlural = causeToSourceClasses.keySet()?size gt 1 />
-        <#assign linkageErrors = jarLinkageReport.getTotalErrorCount()
-        + " linkage error" + errorPlural?string('s', '') />
-        <#assign classes = causeToSourceClasses.keySet()?size
-        + " class" + causePlural?string('es', '') />
-        <p class="jar-linkage-report">${linkageErrors} in ${classes}</p>
-
-        <#list causeToSourceClasses.keySet() as key >
-          <p class="jar-linkage-report-cause">${key?html} Referenced from</p>
-          <ul class="jar-linkage-report-cause">
-            <#list causeToSourceClasses.get(key) as sourceClass>
-              <li class="jar-linkage-report-source-class"><code>${sourceClass?html}</code></li>
-            </#list>
-          </ul>
-        </#list>
-
-        <p class="static-linkage-check-dependency-paths">
-          Following paths to the jar file from BOM are found in the dependency tree.
-        </p>
-        <ul class="static-linkage-check-dependency-paths">
-          <#list jarToDependencyPaths.get(jarLinkageReport.getJarPath()) as dependencyPath >
-            <#assign dependencyPathRoot = dependencyPath.get(0) />
-            <#if dependencyPathRoot.getGroupId() == groupId
-                 && dependencyPathRoot.getArtifactId() == artifactId >
-              <li>${dependencyPath}</li>
-            </#if>
-          </#list>
-        </ul>
-
+        <@formatJarLinkageReport jarLinkageReport jarToDependencyPaths/>
       </#if>
     </#list>
 
@@ -157,23 +127,6 @@
     <#else>
       <p>Dependency information is unavailable</p>
     </#if>
-
-    <#macro formatDependencyNode currentNode parent>
-      <#if parent == currentNode>
-        <#assign label = 'root' />
-      <#else>
-        <#assign label = 'parent: ' + parent.getLeaf() />
-      </#if>
-      <p class="DEPENDENCY_TREE_NODE" title="${label}">${currentNode.getLeaf()}</p>
-      <ul>
-        <#list dependencyTree.get(currentNode) as childNode>
-          <li class="DEPENDENCY_TREE_NODE">
-            <@formatDependencyNode childNode currentNode />
-          </li>
-        </#list>
-      </ul>
-    </#macro>
-
     <hr />
     <p id='updated'>Last generated at ${lastUpdated}</p>
   </body>

--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -116,7 +116,23 @@
     <#list jarLinkageReports as jarLinkageReport>
       <#if jarLinkageReport.getTotalErrorCount() gt 0>
         <h3>${jarLinkageReport.getJarPath().getFileName()?html}</h3>
-        <pre class="jar-linkage-report">${jarLinkageReport.formatByGroup()?html}</pre>
+        <#assign causeToSourceClasses = jarLinkageReport.getCauseToSourceClasses() />
+        <#assign errorPlural = jarLinkageReport.getTotalErrorCount() gt 1 />
+        <#assign causePlural = causeToSourceClasses.keySet()?size gt 1 />
+        <#assign linkageErrors = jarLinkageReport.getTotalErrorCount()
+        + " linkage error" + errorPlural?string('s', '') />
+        <#assign classes = causeToSourceClasses.keySet()?size
+        + " class" + causePlural?string('es', '') />
+        <p class="jar-linkage-report">${linkageErrors} in ${classes}</p>
+
+        <#list causeToSourceClasses.keySet() as key >
+          <p class="jar-linkage-report-cause">${key?html} Referenced from</p>
+          <ul>
+            <#list causeToSourceClasses.get(key) as sourceClass>
+              <li class="jar-linkage-report-source-class"><code>${sourceClass?html}</code></li>
+            </#list>
+          </ul>
+        </#list>
 
         <p class="static-linkage-check-dependency-paths">
           Following paths to the jar file from BOM are found in the dependency tree.

--- a/dashboard/src/main/resources/templates/dashboard.ftl
+++ b/dashboard/src/main/resources/templates/dashboard.ftl
@@ -110,7 +110,24 @@
     <#list jarLinkageReports as jarLinkageReport>
       <#if jarLinkageReport.getTotalErrorCount() gt 0>
         <h3>${jarLinkageReport.getJarPath().getFileName()?html}</h3>
-        <pre id="static-linkage-errors">${jarLinkageReport.formatByGroup()?html}</pre>
+
+        <#assign causeToSourceClasses = jarLinkageReport.getCauseToSourceClasses() />
+        <#assign errorPlural = jarLinkageReport.getTotalErrorCount() gt 1 />
+        <#assign causePlural = causeToSourceClasses.keySet()?size gt 1 />
+        <#assign linkageErrors = jarLinkageReport.getTotalErrorCount()
+        + " linkage error" + errorPlural?string('s', '') />
+        <#assign classes = causeToSourceClasses.keySet()?size
+        + " class" + causePlural?string('es', '') />
+        <p class="jar-linkage-report">${linkageErrors} in ${classes}</p>
+
+        <#list causeToSourceClasses.keySet() as key >
+          <p class="jar-linkage-report-cause">${key?html} Referenced from</p>
+          <ul>
+            <#list causeToSourceClasses.get(key) as sourceClass>
+              <li class="jar-linkage-report-source-class"><code>${sourceClass?html}</code></li>
+            </#list>
+          </ul>
+        </#list>
 
         <p class="static-linkage-check-dependency-paths">
           Following paths to the jar file from BOM are found in the dependency tree.

--- a/dashboard/src/main/resources/templates/dashboard.ftl
+++ b/dashboard/src/main/resources/templates/dashboard.ftl
@@ -16,19 +16,23 @@
           <span class="desc">Total Artifacts Checked</span>
         </div>
         <div class="statistic-item statistic-item-red">
-          <h2 class="artifact-count"><@countFailures name="Static Linkage Errors"/></h2>
+          <h2 class="artifact-count">${dashboardMain.countFailures(table, "Static Linkage Errors")}
+          </h2>
           <span class="desc">Have Static Linkage Errors</span>
         </div>
         <div class="statistic-item statistic-item-yellow">
-          <h2 class="artifact-count"><@countFailures name="Upper Bounds"/></h2>
+          <h2 class="artifact-count">${dashboardMain.countFailures(table, "Upper Bounds")}
+          </h2>
           <span class="desc">Have Upper Bounds Errors</span>
         </div>
         <div class="statistic-item statistic-item-orange">
-          <h2 class="artifact-count"><@countFailures name="Global Upper Bounds"/></h2>
+          <h2 class="artifact-count">${dashboardMain.countFailures(table, "Global Upper Bounds")}
+          </h2>
           <span class="desc">Have Global Upper Bounds Errors</span>
         </div>
         <div class="statistic-item statistic-item-blue">
-          <h2 class="artifact-count"><@countFailures name="Dependency Convergence"/></h2>
+          <h2 class="artifact-count">${dashboardMain.countFailures(table, "Dependency Convergence")}
+          </h2>
           <span class="desc">Fail to Converge</span>
         </div>
       </div>
@@ -70,9 +74,7 @@
     <h2>Static Linkage Errors</h2>
 
     <#list jarLinkageReports as jarLinkageReport>
-      <#if jarLinkageReport.getTotalErrorCount() gt 0>
-        <@formatJarLinkageReport jarLinkageReport jarToDependencyPaths/>
-      </#if>
+      <@formatJarLinkageReport jarLinkageReport jarToDependencyPaths/>
     </#list>
 
     <hr />      

--- a/dashboard/src/main/resources/templates/dashboard.ftl
+++ b/dashboard/src/main/resources/templates/dashboard.ftl
@@ -1,4 +1,5 @@
 <html lang="en-US">
+  <#include "macros.ftl">
   <head>
     <title>Google Cloud Platform Java Open Source Dependency Dashboard</title>
     
@@ -32,48 +33,9 @@
         </div>
       </div>
     </section>
-    
-    <#macro countFailures name>
-      <#assign total = 0>
-      <#list table as row>    
-        <#if row.getResult(name)?? >
-          <#assign failure_count = row.getFailureCount(name)>
-          <#if failure_count gt 0 >
-            <#assign total = total + 1>
-          </#if>
-        <#else>
-          <#-- Null means there's an exception and test couldn't run -->
-          <#assign total = total + 1>
-        </#if>
-      </#list>
-      ${total}
-    </#macro>
-    
+
     <h2>Artifact Details</h2>
-    
-    <#macro testResult row name>
-      <#if row.getResult(name)?? ><#-- checking isNotNull() -->
-        <#-- When it's not null, the test ran. It's either PASS or FAIL -->
-        <#assign test_label = row.getResult(name)?then('PASS', 'FAIL')>
-        <#assign failure_count = row.getFailureCount(name)>
-      <#else>
-        <#-- Null means there's an exception and test couldn't run -->
-        <#assign test_label = "UNAVAILABLE">
-      </#if>
-      <td class='${test_label}' title="${row.getExceptionMessage()!""}">
-        <#if row.getResult(name)?? >
-          <#assign page_anchor =  name?replace(" ", "-")?lower_case />
-          <a href="${row.getCoordinates()?replace(":", "_")}.html#${page_anchor}">
-            <#if failure_count == 1>1 FAILURE
-            <#elseif failure_count gt 1>${failure_count} FAILURES
-            <#else>PASS
-            </#if>
-          </a>
-        <#else>UNAVAILABLE
-        </#if>
-      </td>
-    </#macro>
-    
+
     <table class="dependency-dashboard">
       <tr>
         <th>Artifact</th>
@@ -109,35 +71,7 @@
 
     <#list jarLinkageReports as jarLinkageReport>
       <#if jarLinkageReport.getTotalErrorCount() gt 0>
-        <h3>${jarLinkageReport.getJarPath().getFileName()?html}</h3>
-
-        <#assign causeToSourceClasses = jarLinkageReport.getCauseToSourceClasses() />
-        <#assign errorPlural = jarLinkageReport.getTotalErrorCount() gt 1 />
-        <#assign causePlural = causeToSourceClasses.keySet()?size gt 1 />
-        <#assign linkageErrors = jarLinkageReport.getTotalErrorCount()
-        + " linkage error" + errorPlural?string('s', '') />
-        <#assign classes = causeToSourceClasses.keySet()?size
-        + " class" + causePlural?string('es', '') />
-        <p class="jar-linkage-report">${linkageErrors} in ${classes}</p>
-
-        <#list causeToSourceClasses.keySet() as key >
-          <p class="jar-linkage-report-cause">${key?html} Referenced from</p>
-          <ul class="jar-linkage-report-cause">
-            <#list causeToSourceClasses.get(key) as sourceClass>
-              <li class="jar-linkage-report-source-class"><code>${sourceClass?html}</code></li>
-            </#list>
-          </ul>
-        </#list>
-
-        <p class="static-linkage-check-dependency-paths">
-          Following paths to the jar file from BOM are found in the dependency tree.
-        </p>
-        <ul class="static-linkage-check-dependency-paths">
-          <#list jarToDependencyPaths.get(jarLinkageReport.getJarPath()) as dependencyPath >
-            <li>${dependencyPath}</li>
-          </#list>
-        </ul>
-
+        <@formatJarLinkageReport jarLinkageReport jarToDependencyPaths/>
       </#if>
     </#list>
 

--- a/dashboard/src/main/resources/templates/dashboard.ftl
+++ b/dashboard/src/main/resources/templates/dashboard.ftl
@@ -12,27 +12,23 @@
     <section class="statistics">
       <div class="container">
         <div class="statistic-item statistic-item-green">
-          <h2 class="artifact-count">${table?size}</h2>
+          <h2>${table?size}</h2>
           <span class="desc">Total Artifacts Checked</span>
         </div>
         <div class="statistic-item statistic-item-red">
-          <h2 class="artifact-count">${dashboardMain.countFailures(table, "Static Linkage Errors")}
-          </h2>
+          <h2>${dashboardMain.countFailures(table, "Static Linkage Errors")}</h2>
           <span class="desc">Have Static Linkage Errors</span>
         </div>
         <div class="statistic-item statistic-item-yellow">
-          <h2 class="artifact-count">${dashboardMain.countFailures(table, "Upper Bounds")}
-          </h2>
+          <h2>${dashboardMain.countFailures(table, "Upper Bounds")}</h2>
           <span class="desc">Have Upper Bounds Errors</span>
         </div>
         <div class="statistic-item statistic-item-orange">
-          <h2 class="artifact-count">${dashboardMain.countFailures(table, "Global Upper Bounds")}
-          </h2>
+          <h2>${dashboardMain.countFailures(table, "Global Upper Bounds")}</h2>
           <span class="desc">Have Global Upper Bounds Errors</span>
         </div>
         <div class="statistic-item statistic-item-blue">
-          <h2 class="artifact-count">${dashboardMain.countFailures(table, "Dependency Convergence")}
-          </h2>
+          <h2>${dashboardMain.countFailures(table, "Dependency Convergence")}</h2>
           <span class="desc">Fail to Converge</span>
         </div>
       </div>

--- a/dashboard/src/main/resources/templates/dashboard.ftl
+++ b/dashboard/src/main/resources/templates/dashboard.ftl
@@ -122,7 +122,7 @@
 
         <#list causeToSourceClasses.keySet() as key >
           <p class="jar-linkage-report-cause">${key?html} Referenced from</p>
-          <ul>
+          <ul class="jar-linkage-report-cause">
             <#list causeToSourceClasses.get(key) as sourceClass>
               <li class="jar-linkage-report-source-class"><code>${sourceClass?html}</code></li>
             </#list>

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -1,0 +1,81 @@
+<#macro formatJarLinkageReport jarLinkageReport jarToDependencyPaths>
+  <h3>${jarLinkageReport.getJarPath().getFileName()?html}</h3>
+
+  <#assign causeToSourceClasses = jarLinkageReport.getCauseToSourceClasses() />
+  <#assign errorPlural = jarLinkageReport.getTotalErrorCount() gt 1 />
+  <#assign causePlural = causeToSourceClasses.keySet()?size gt 1 />
+  <#assign linkageErrors = jarLinkageReport.getTotalErrorCount()
+  + " linkage error" + errorPlural?string('s', '') />
+  <#assign classes = causeToSourceClasses.keySet()?size
+  + " class" + causePlural?string('es', '') />
+  <p class="jar-linkage-report">${linkageErrors} in ${classes}</p>
+
+  <#list causeToSourceClasses.keySet() as key >
+    <p class="jar-linkage-report-cause">${key?html} Referenced from</p>
+    <ul class="jar-linkage-report-cause">
+      <#list causeToSourceClasses.get(key) as sourceClass>
+        <li class="jar-linkage-report-source-class"><code>${sourceClass?html}</code></li>
+      </#list>
+    </ul>
+  </#list>
+  <p class="static-linkage-check-dependency-paths">
+    Following paths to the jar file from BOM are found in the dependency tree.
+  </p>
+  <ul class="static-linkage-check-dependency-paths">
+    <#list jarToDependencyPaths.get(jarLinkageReport.getJarPath()) as dependencyPath >
+      <li>${dependencyPath}</li>
+    </#list>
+  </ul>
+</#macro>
+<#macro formatDependencyNode currentNode parent>
+  <#if parent == currentNode>
+    <#assign label = 'root' />
+  <#else>
+    <#assign label = 'parent: ' + parent.getLeaf() />
+  </#if>
+  <p class="DEPENDENCY_TREE_NODE" title="${label}">${currentNode.getLeaf()}</p>
+  <ul>
+    <#list dependencyTree.get(currentNode) as childNode>
+      <li class="DEPENDENCY_TREE_NODE">
+        <@formatDependencyNode childNode currentNode />
+      </li>
+    </#list>
+  </ul>
+</#macro>
+<#macro countFailures name>
+  <#assign total = 0>
+  <#list table as row>
+    <#if row.getResult(name)?? >
+      <#assign failure_count = row.getFailureCount(name)>
+      <#if failure_count gt 0 >
+        <#assign total = total + 1>
+      </#if>
+    <#else>
+    <#-- Null means there's an exception and test couldn't run -->
+      <#assign total = total + 1>
+    </#if>
+  </#list>
+  ${total}
+</#macro>
+<#macro testResult row name>
+  <#if row.getResult(name)?? ><#-- checking isNotNull() -->
+  <#-- When it's not null, the test ran. It's either PASS or FAIL -->
+    <#assign test_label = row.getResult(name)?then('PASS', 'FAIL')>
+    <#assign failure_count = row.getFailureCount(name)>
+  <#else>
+  <#-- Null means there's an exception and test couldn't run -->
+    <#assign test_label = "UNAVAILABLE">
+  </#if>
+  <td class='${test_label}' title="${row.getExceptionMessage()!""}">
+    <#if row.getResult(name)?? >
+      <#assign page_anchor =  name?replace(" ", "-")?lower_case />
+      <a href="${row.getCoordinates()?replace(":", "_")}.html#${page_anchor}">
+        <#if failure_count == 1>1 FAILURE
+        <#elseif failure_count gt 1>${failure_count} FAILURES
+        <#else>PASS
+        </#if>
+      </a>
+    <#else>UNAVAILABLE
+    </#if>
+  </td>
+</#macro>

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -62,8 +62,7 @@
     <#if row.getResult(name)?? >
       <#assign page_anchor =  name?replace(" ", "-")?lower_case />
       <a href="${row.getCoordinates()?replace(":", "_")}.html#${page_anchor}">
-        <#if failure_count == 1>1 FAILURE
-        <#elseif failure_count gt 1>${failure_count} FAILURES
+        <#if failure_count gt 0>${pluralize(failure_count, "FAILURE", "FAILURES")}
         <#else>PASS
         </#if>
       </a>

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -1,11 +1,11 @@
 <#function pluralize number singlarNoun pluralNoun>
   <#local plural = number gt 1 />
-  <#return plural?string(number + " " + pluralNoun, number + " " + singlarNoun)>
+  <#return number + " " + plural?string(pluralNoun, singlarNoun)>
 </#function>
 
 <#macro formatJarLinkageReport jarLinkageReport jarToDependencyPaths>
   <#if jarLinkageReport.getCauseToSourceClassesSize() gt 0>
-  <h3>${jarLinkageReport.getJarPath().getFileName()?html}</h3>
+    <h3>${jarLinkageReport.getJarPath().getFileName()?html}</h3>
 
     <#assign causeToSourceClasses = jarLinkageReport.getCauseToSourceClasses() />
     <#assign linkageErrors = pluralize(jarLinkageReport.getCauseToSourceClassesSize(),
@@ -15,21 +15,21 @@
     <p class="jar-linkage-report">${linkageErrors} in ${classes}</p>
 
     <#list causeToSourceClasses.keySet() as errorCause >
-    <p class="jar-linkage-report-cause">${errorCause?html}, referenced from</p>
-    <ul class="jar-linkage-report-cause">
-      <#list causeToSourceClasses.get(errorCause) as sourceClass>
-        <li>${sourceClass?html}</li>
+      <p class="jar-linkage-report-cause">${errorCause?html}, referenced from</p>
+      <ul class="jar-linkage-report-cause">
+        <#list causeToSourceClasses.get(errorCause) as sourceClass>
+          <li>${sourceClass?html}</li>
+        </#list>
+      </ul>
+    </#list>
+    <p class="static-linkage-check-dependency-paths">
+      The following paths to the jar file from BOM are found in the dependency tree.
+    </p>
+    <ul class="static-linkage-check-dependency-paths">
+      <#list jarToDependencyPaths.get(jarLinkageReport.getJarPath()) as dependencyPath >
+        <li>${dependencyPath}</li>
       </#list>
     </ul>
-    </#list>
-  <p class="static-linkage-check-dependency-paths">
-    The following paths to the jar file from BOM are found in the dependency tree.
-  </p>
-  <ul class="static-linkage-check-dependency-paths">
-    <#list jarToDependencyPaths.get(jarLinkageReport.getJarPath()) as dependencyPath >
-      <li>${dependencyPath}</li>
-    </#list>
-  </ul>
   </#if>
 </#macro>
 

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -1,62 +1,54 @@
+<#function pluralize number singlarNoun pluralNoun>
+  <#local plural = number gt 1 />
+  <#return plural?string(number + " " + pluralNoun, number + " " + singlarNoun)>
+</#function>
+
 <#macro formatJarLinkageReport jarLinkageReport jarToDependencyPaths>
+  <#if jarLinkageReport.getCauseToSourceClassesSize() gt 0>
   <h3>${jarLinkageReport.getJarPath().getFileName()?html}</h3>
 
-  <#assign causeToSourceClasses = jarLinkageReport.getCauseToSourceClasses() />
-  <#assign errorPlural = jarLinkageReport.getTotalErrorCount() gt 1 />
-  <#assign causePlural = causeToSourceClasses.keySet()?size gt 1 />
-  <#assign linkageErrors = jarLinkageReport.getTotalErrorCount()
-  + " linkage error" + errorPlural?string('s', '') />
-  <#assign classes = causeToSourceClasses.keySet()?size
-  + " class" + causePlural?string('es', '') />
-  <p class="jar-linkage-report">${linkageErrors} in ${classes}</p>
+    <#assign causeToSourceClasses = jarLinkageReport.getCauseToSourceClasses() />
+    <#assign linkageErrors = pluralize(jarLinkageReport.getCauseToSourceClassesSize(),
+    "linkage error", "linkage errors") />
+    <#assign classes = pluralize(causeToSourceClasses.keySet()?size,
+    "class", "classes") />
+    <p class="jar-linkage-report">${linkageErrors} in ${classes}</p>
 
-  <#list causeToSourceClasses.keySet() as key >
-    <p class="jar-linkage-report-cause">${key?html} Referenced from</p>
+    <#list causeToSourceClasses.keySet() as errorCause >
+    <p class="jar-linkage-report-cause">${errorCause?html}, referenced from</p>
     <ul class="jar-linkage-report-cause">
-      <#list causeToSourceClasses.get(key) as sourceClass>
-        <li class="jar-linkage-report-source-class"><code>${sourceClass?html}</code></li>
+      <#list causeToSourceClasses.get(errorCause) as sourceClass>
+        <li>${sourceClass?html}</li>
       </#list>
     </ul>
-  </#list>
+    </#list>
   <p class="static-linkage-check-dependency-paths">
-    Following paths to the jar file from BOM are found in the dependency tree.
+    The following paths to the jar file from BOM are found in the dependency tree.
   </p>
   <ul class="static-linkage-check-dependency-paths">
     <#list jarToDependencyPaths.get(jarLinkageReport.getJarPath()) as dependencyPath >
       <li>${dependencyPath}</li>
     </#list>
   </ul>
+  </#if>
 </#macro>
+
 <#macro formatDependencyNode currentNode parent>
   <#if parent == currentNode>
     <#assign label = 'root' />
   <#else>
     <#assign label = 'parent: ' + parent.getLeaf() />
   </#if>
-  <p class="DEPENDENCY_TREE_NODE" title="${label}">${currentNode.getLeaf()}</p>
+  <p class="dependency-tree-node" title="${label}">${currentNode.getLeaf()}</p>
   <ul>
     <#list dependencyTree.get(currentNode) as childNode>
-      <li class="DEPENDENCY_TREE_NODE">
+      <li class="dependency-tree-node">
         <@formatDependencyNode childNode currentNode />
       </li>
     </#list>
   </ul>
 </#macro>
-<#macro countFailures name>
-  <#assign total = 0>
-  <#list table as row>
-    <#if row.getResult(name)?? >
-      <#assign failure_count = row.getFailureCount(name)>
-      <#if failure_count gt 0 >
-        <#assign total = total + 1>
-      </#if>
-    <#else>
-    <#-- Null means there's an exception and test couldn't run -->
-      <#assign total = total + 1>
-    </#if>
-  </#list>
-  ${total}
-</#macro>
+
 <#macro testResult row name>
   <#if row.getResult(name)?? ><#-- checking isNotNull() -->
   <#-- When it's not null, the test ran. It's either PASS or FAIL -->
@@ -66,7 +58,7 @@
   <#-- Null means there's an exception and test couldn't run -->
     <#assign test_label = "UNAVAILABLE">
   </#if>
-  <td class='${test_label}' title="${row.getExceptionMessage()!""}">
+  <td class='${test_label?lower_case}' title="${row.getExceptionMessage()!""}">
     <#if row.getResult(name)?? >
       <#assign page_anchor =  name?replace(" ", "-")?lower_case />
       <a href="${row.getCoordinates()?replace(":", "_")}.html#${page_anchor}">

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -109,25 +109,9 @@ public class DashboardTest {
       for (int i = 1; i < tr.size(); i++) { // start at 1 to skip header row
         Nodes td = tr.get(i).query("td");
         Assert.assertEquals(Artifacts.toCoordinates(artifacts.get(i - 1)), td.get(0).getValue());
-        Element firstResult = (Element) (td.get(1));
-        Truth.assertThat(firstResult.getValue().replaceAll("\\s", ""))
-            .containsMatch("PASS|\\d+FAILURES?");
-        Truth.assertThat(firstResult.getAttributeValue("class")).isAnyOf("pass", "fail");
-
-        Element secondResult = (Element) (td.get(2));
-        Truth.assertThat(secondResult.getValue().replaceAll("\\s", ""))
-            .containsMatch("PASS|\\d+FAILURES?");
-        Truth.assertThat(secondResult.getAttributeValue("class")).isAnyOf("pass", "fail");
-
-        Element thirdResult = (Element) (td.get(3));
-        Truth.assertThat(thirdResult.getValue().replaceAll("\\s", ""))
-            .containsMatch("PASS|\\d+FAILURES?");
-        Truth.assertThat(thirdResult.getAttributeValue("class")).isAnyOf("pass", "fail");
-
-        Element fourthResult = (Element) (td.get(4));
-        Truth.assertThat(fourthResult.getValue().replaceAll("\\s", ""))
-            .containsMatch("PASS|\\d+FAILURES?");
-        Truth.assertThat(fourthResult.getAttributeValue("class")).isAnyOf("pass", "fail");
+        for (int j = 1; j < 5; ++j) {
+          assertValidCellValue((Element) td.get(j));
+        }
       }
       Nodes href = document.query("//tr/td[@class='artifact-name']/a/@href");
       for (int i = 0; i < href.size(); i++) {
@@ -186,14 +170,23 @@ public class DashboardTest {
       
       Nodes stable = document.query("//p[@id='stable-notice']");
       Assert.assertEquals(0, stable.size());
-      
-      Nodes artifactCount = document.query("//h2[@class='artifact-count']");
+
+      Nodes artifactCount = document
+          .query("//div[@class='statistic-item statistic-item-green']/h2");
       Assert.assertTrue(artifactCount.size() > 0);
       for (int i = 0; i < artifactCount.size(); i++) {
         String value = artifactCount.get(i).getValue().trim();
         Assert.assertTrue(value, Integer.parseInt(value) > 0);
       }            
     }
+  }
+
+  private static void assertValidCellValue(Element cellElement) {
+    String cellValue = cellElement.getValue().replaceAll("\\s", "");
+    Truth.assertThat(cellValue).containsMatch("PASS|\\d+FAILURES?");
+    Truth.assertWithMessage("It should not use plural for 1 item").that(cellValue)
+        .doesNotContainMatch("1 FAILURES");
+    Truth.assertThat(cellElement.getAttributeValue("class")).isAnyOf("pass", "fail");
   }
 
   @Test

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -112,22 +112,22 @@ public class DashboardTest {
         Element firstResult = (Element) (td.get(1));
         Truth.assertThat(firstResult.getValue().replaceAll("\\s", ""))
             .containsMatch("PASS|\\d+FAILURES?");
-        Truth.assertThat(firstResult.getAttributeValue("class")).isAnyOf("PASS", "FAIL");
+        Truth.assertThat(firstResult.getAttributeValue("class")).isAnyOf("pass", "fail");
 
         Element secondResult = (Element) (td.get(2));
         Truth.assertThat(secondResult.getValue().replaceAll("\\s", ""))
             .containsMatch("PASS|\\d+FAILURES?");
-        Truth.assertThat(secondResult.getAttributeValue("class")).isAnyOf("PASS", "FAIL");
+        Truth.assertThat(secondResult.getAttributeValue("class")).isAnyOf("pass", "fail");
 
         Element thirdResult = (Element) (td.get(3));
         Truth.assertThat(thirdResult.getValue().replaceAll("\\s", ""))
             .containsMatch("PASS|\\d+FAILURES?");
-        Truth.assertThat(thirdResult.getAttributeValue("class")).isAnyOf("PASS", "FAIL");
+        Truth.assertThat(thirdResult.getAttributeValue("class")).isAnyOf("pass", "fail");
 
         Element fourthResult = (Element) (td.get(4));
         Truth.assertThat(fourthResult.getValue().replaceAll("\\s", ""))
             .containsMatch("PASS|\\d+FAILURES?");
-        Truth.assertThat(fourthResult.getAttributeValue("class")).isAnyOf("PASS", "FAIL");
+        Truth.assertThat(fourthResult.getAttributeValue("class")).isAnyOf("pass", "fail");
       }
       Nodes href = document.query("//tr/td[@class='artifact-name']/a/@href");
       for (int i = 0; i < href.size(); i++) {
@@ -238,7 +238,7 @@ public class DashboardTest {
       // There's a pre tag for dependency
       Assert.assertEquals(1, presDependencyMediation.size());
 
-      Nodes presDependencyTree = document.query("//p[@class='DEPENDENCY_TREE_NODE']");
+      Nodes presDependencyTree = document.query("//p[@class='dependency-tree-node']");
       Assert.assertTrue("Dependency Tree should be shown in dashboard",
           presDependencyTree.size() > 0);
     }
@@ -260,7 +260,7 @@ public class DashboardTest {
           document.query("//pre[@class='suggested-dependency-mediation']");
       Assert.assertTrue("For failed component, suggested dependency should be shown",
           presDependencyMediation.size() >= 1);
-      Nodes dependencyTree = document.query("//p[@class='DEPENDENCY_TREE_NODE']");
+      Nodes dependencyTree = document.query("//p[@class='dependency-tree-node']");
       Assert.assertTrue("Dependency Tree should be shown in dashboard even when FAILED",
           dependencyTree.size() > 0);
     }
@@ -277,7 +277,7 @@ public class DashboardTest {
     try (InputStream source = Files.newInputStream(googleCloudTranslateHtml)) {
       Document document = builder.build(source);
       Nodes staticLinkageCheckMessage =
-          document.query("//li[@class='jar-linkage-report-source-class']");
+          document.query("//ul[@class='jar-linkage-report-cause']/li");
       Truth.assertThat(staticLinkageCheckMessage.size()).isGreaterThan(0);
       Truth.assertThat(staticLinkageCheckMessage.get(0).getValue())
           .contains("com.google.appengine.api.appidentity.AppIdentityServicePb");

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -152,7 +152,7 @@ public class DashboardTest {
       // TODO these should all be separate tests for the different components
       Node linkage = document.query("//p[@class='jar-linkage-report']").get(0);
       // grpc-testing-1.17.1, shown as first item in linkage errors, has these errors
-      Assert.assertTrue(linkage.getValue().contains("9 linkage errors in 3 classes"));
+      Assert.assertTrue(linkage.getValue().contains("3 linkage errors in 3 classes"));
 
       Nodes li = document.query("//ul[@id='recommended']/li");
       Assert.assertTrue(li.size() > 100);
@@ -207,7 +207,7 @@ public class DashboardTest {
       Nodes staticLinkageCheckMessage = document.query("//p[@class='jar-linkage-report']");
       Assert.assertEquals(1, staticLinkageCheckMessage.size());
       Truth.assertThat(staticLinkageCheckMessage.get(0).getValue())
-          .contains("4 linkage errors in 2 classes");
+          .contains("2 linkage errors in 2 classes");
 
       Nodes jarLinkageReportNode = document.query("//p[@class='jar-linkage-report-cause']");
       boolean foundJmdkError = false;

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -145,13 +145,13 @@ public class DashboardUnavailableArtifactTest {
         Artifacts.toCoordinates(validArtifact), tdForValidArtifact.get(0).getValue());
     Element firstResult = (Element) (tdForValidArtifact.get(2));
     Truth.assertThat(firstResult.getValue().trim()).isEqualTo("PASS");
-    Truth.assertThat(firstResult.getAttributeValue("class")).isEqualTo("PASS");
+    Truth.assertThat(firstResult.getAttributeValue("class")).isEqualTo("pass");
 
     Nodes tdForErrorArtifact = tr.get(2).query("td");
     Assert.assertEquals(
         Artifacts.toCoordinates(invalidArtifact), tdForErrorArtifact.get(0).getValue());
     Element secondResult = (Element) (tdForErrorArtifact.get(2));
     Truth.assertThat(secondResult.getValue().trim()).isEqualTo("UNAVAILABLE");
-    Truth.assertThat(secondResult.getAttributeValue("class")).isEqualTo("UNAVAILABLE");
+    Truth.assertThat(secondResult.getAttributeValue("class")).isEqualTo("unavailable");
   }
 }

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -35,8 +35,7 @@ import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.io.MoreFiles;
-import com.google.common.io.RecursiveDeleteOption;
+import com.google.common.truth.Truth;
 
 import freemarker.template.Configuration;
 import freemarker.template.TemplateException;
@@ -62,7 +61,7 @@ public class FreemarkerTest {
 
   @AfterClass
   public static void cleanUp() throws IOException {
-    MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
+    // MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
   }
 
   @Test
@@ -90,13 +89,13 @@ public class FreemarkerTest {
     Assert.assertTrue(Files.isRegularFile(dashboardHtml));
     Document document = builder.build(dashboardHtml.toFile());
 
-    Nodes counts = document.query("//h2[@class='artifact-count']");
+    // xom's query cannot specify partial class field, e.g., 'statistic-item'
+    Nodes counts = document.query("//div[@class='container']/div/h2");
     Assert.assertTrue(counts.size() > 0);
     for (int i = 0; i < counts.size(); i++) {
       Integer.parseInt(counts.get(i).getValue().trim());
     }
-    
-    Assert.assertEquals(1, Integer.parseInt(counts.get(1).getValue().trim()));
+    // Static Linkage Errors
+    Truth.assertThat(counts.get(1).getValue().trim()).isEqualTo("1");
   }
-
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckReport.java
@@ -37,7 +37,7 @@ public abstract class ClasspathCheckReport {
   public String toString() {
     StringBuilder builder = new StringBuilder();
     for (JarLinkageReport jarLinkageReport : getJarLinkageReports()) {
-      if (jarLinkageReport.getTotalErrorCount() > 0) {
+      if (jarLinkageReport.getCauseToSourceClassesSize() > 0) {
         builder.append(jarLinkageReport.toString());
         builder.append('\n');
       }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
@@ -121,13 +121,13 @@ public abstract class JarLinkageReport {
           allErrorsForKey.stream()
               .map(StaticLinkageError::getReference)
               .map(SymbolReference::getSourceClassName)
+              .map(className -> className.split("\\$")[0]) // Removing duplicate inner classes
               .collect(toImmutableSet()));
     }
     return builder.build();
   }
 
   public int getTotalErrorCount() {
-    return getMissingClassErrors().size() + getMissingMethodErrors().size()
-        + getMissingFieldErrors().size();
+    return getCauseToSourceClasses().size();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
@@ -71,7 +71,7 @@ public abstract class JarLinkageReport {
   public String toString() {
     String indent = "  ";
     StringBuilder builder = new StringBuilder();
-    int totalErrors = getTotalErrorCount();
+    int totalErrors = getCauseToSourceClassesSize();
 
     builder.append(getJarPath().getFileName() + " (" + totalErrors + " errors):\n");
     for (StaticLinkageError<ClassSymbolReference> missingClass : getMissingClassErrors()) {
@@ -127,7 +127,7 @@ public abstract class JarLinkageReport {
     return builder.build();
   }
 
-  public int getTotalErrorCount() {
+  public int getCauseToSourceClassesSize() {
     return getCauseToSourceClasses().size();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
@@ -89,7 +89,7 @@ public abstract class JarLinkageReport {
     return builder.toString();
   }
 
-  /** Returns map from the cause of linkage errors and class names affected by the errors. */
+  /** Returns map from the cause of linkage errors to class names affected by the errors. */
   public ImmutableMultimap<LinkageErrorCause, String> getCauseToSourceClasses() {
     ImmutableListMultimap<LinkageErrorCause, StaticLinkageError<ClassSymbolReference>>
         groupedClassErrors = Multimaps.index(getMissingClassErrors(), LinkageErrorCause::from);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorCause.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorCause.java
@@ -60,19 +60,19 @@ abstract class LinkageErrorCause {
     StringBuilder builder = new StringBuilder(getSymbol());
     switch (getReason()) {
       case CLASS_NOT_FOUND:
-        builder.append(" is not found. ");
+        builder.append(" is not found");
         break;
       case INACCESSIBLE_CLASS:
-        builder.append(" is not accessible. ");
+        builder.append(" is not accessible");
         break;
       case INCOMPATIBLE_CLASS_CHANGE:
-        builder.append(" has changed incompatibly. ");
+        builder.append(" has changed incompatibly");
         break;
       case SYMBOL_NOT_FOUND:
-        builder.append(" is not found. ");
+        builder.append(" is not found");
         break;
       case INACCESSIBLE_MEMBER:
-        builder.append(" is not accessible. ");
+        builder.append(" is not accessible");
         break;
     }
     return builder.toString();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
@@ -115,7 +115,7 @@ public class JarLinkageReportTest {
 
   @Test
   public void testGetTotalErrorCount() {
-    Assert.assertEquals(4, jarLinkageReport.getTotalErrorCount());
+    Assert.assertEquals(4, jarLinkageReport.getCauseToSourceClassesSize());
   }
 
   @Test

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
@@ -135,30 +135,4 @@ public class JarLinkageReportTest {
         jarLinkageReport.toString());
   }
 
-  @Test
-  public void testFormatByGroup() {
-    Assert.assertEquals(
-        "4 linkage errors in 3 classes\n"
-            + "  ClassA is not found. Referenced by: ClassB, ClassC\n"
-            + "  ClassA.methodX is not found. Referenced by: ClassB\n"
-            + "  ClassC is not found. Referenced by: ClassD\n",
-        jarLinkageReport.formatByGroup());
-  }
-
-  @Test
-  public void testFormatByGroup_singleError() {
-    missingClassErrors = ImmutableList.of();
-    missingFieldErrors = ImmutableList.of();
-    missingMethodErrors = ImmutableList.of(linkageErrorMissingMethod);
-
-    jarLinkageReport =
-        JarLinkageReport.builder()
-            .setJarPath(Paths.get("a", "b", "c"))
-            .setMissingMethodErrors(missingMethodErrors)
-            .setMissingClassErrors(missingClassErrors)
-            .setMissingFieldErrors(missingFieldErrors)
-            .build();
-    String report = jarLinkageReport.formatByGroup();
-    Assert.assertTrue(report, report.startsWith("1 linkage error in 1 class\n"));
-  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
           <configuration>
             <!-- To avoid ForkedBooter loading issue -->
             <useSystemClassLoader>false</useSystemClassLoader>
+            <argLine>-Xms128m -Xmx2048m</argLine>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
As part of #395 

- From pre tags to ul tags for list of source classes.
  Formatting has moved from `JarLinkageReport` to .ftl files.
- Removed duplicate count for inner classes
- Fixed freaky build failure ([CircleCI](https://circleci.com/gh/GoogleCloudPlatform/cloud-opensource-java/tree/source_class_ul)) by applying surefire-plugin config at root project.
- New file `macros.ftl` to write Freemarker macro. Shared between dashboard.ftl and component.ftl.

Now dashboard looks like this:

![image](https://user-images.githubusercontent.com/28604/52503616-1c467d00-2bb4-11e9-9472-d2375d99419d.png)

