### PR TITLE
Show simplified message when dependency paths can be grouped

### DIFF
--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -420,7 +420,7 @@ public class DashboardMain {
    * DependencyPath}s. The summary explains common patterns ({@code groupId:artifactId}) in the path
    * elements. The returned map does not have a key for a jar file when the length of its {@link
    * DependencyPath} list is smaller than {@link #SUMMARIZING_DEPENDENCY_PATH_SIZE_THRESHOLD} or a
-   * common pattern is not found among the items.
+   * common pattern is not found among the elements in the paths.
    *
    * <p>Using this summary in the BOM dashboard avoids repetitive items in the {@link
    * DependencyPath} list that share the same root problem caused by widely-used libraries, for
@@ -453,7 +453,7 @@ public class DashboardMain {
 
       // When dependencyPaths is not empty, versionlessCoordinates is not null
       if (dependencyPaths.size() > SUMMARIZING_DEPENDENCY_PATH_SIZE_THRESHOLD
-          && versionlessCoordinates.size() > 1) { // The last element is always same among paths
+          && versionlessCoordinates.size() > 1) { // The last elements are always same among paths
         StringBuilder messageBuilder = new StringBuilder();
         messageBuilder.append("There are " + dependencyPaths.size() + " paths to the artifact. ");
         messageBuilder.append("All of them have the same artifacts: ");

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -432,29 +432,29 @@ public class DashboardMain {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 
     for (Path jar : jarToDependencyPaths.keySet()) {
-      // To keep order of the common artifact when shown in dashboard
-      LinkedHashSet<String> versionlessCoordinates = null; // null for 1st iteration
-      boolean firstIteration = true;
+      LinkedHashSet<String> commonVersionlessCoordinates = null; // null for 1st iteration
       List<DependencyPath> dependencyPaths = jarToDependencyPaths.get(jar);
+
       for (DependencyPath dependencyPath : dependencyPaths) {
         // List of versionless coordinates ("groupId:artifactId")
         ImmutableList<String> versionlessCoordinatesInPath =
             dependencyPath.getPath().stream().map(Artifacts::makeKey).collect(toImmutableList());
-        if (firstIteration) {
-          firstIteration = false;
-          versionlessCoordinates = Sets.newLinkedHashSet(versionlessCoordinatesInPath);
+        if (commonVersionlessCoordinates == null) {
+          // For 1st iteration, initializes the intersection set with LinkedHashSet, which keeps
+          // the order of the common artifacts.
+          commonVersionlessCoordinates = Sets.newLinkedHashSet(versionlessCoordinatesInPath);
         } else {
           // intersection of elements in DependencyPaths
-          versionlessCoordinates.retainAll(versionlessCoordinatesInPath);
+          commonVersionlessCoordinates.retainAll(versionlessCoordinatesInPath);
         }
       }
 
       // When dependencyPaths is not empty, versionlessCoordinates is not null
       if (dependencyPaths.size() > SUMMARIZING_DEPENDENCY_PATH_SIZE_THRESHOLD
-          && versionlessCoordinates.size() > 1) { // The last elements are always same among paths
+          && commonVersionlessCoordinates.size() > 1) { // The last paths elements are always same
         StringBuilder messageBuilder = new StringBuilder();
         messageBuilder.append("Artifacts '");
-        messageBuilder.append(Joiner.on(" > ").join(versionlessCoordinates));
+        messageBuilder.append(Joiner.on(" > ").join(commonVersionlessCoordinates));
         messageBuilder.append("' exist in all " + dependencyPaths.size() + " dependency paths. ");
         messageBuilder.append("Example path: ");
         messageBuilder.append(dependencyPaths.get(0));

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.opensource.dashboard;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
+import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -438,7 +439,6 @@ public class DashboardMain {
 
       Set<String> commonVersionlessArtifacts = commonVersionlessArtifacts(dependencyPaths);
 
-      // When dependencyPaths is not empty, versionlessCoordinates is not null
       if (dependencyPaths.size() > MINIMUM_NUMBER_DEPENDENCY_PATHS
           && commonVersionlessArtifacts.size() > 1) { // The last paths elements are always same
         builder.put(
@@ -451,6 +451,8 @@ public class DashboardMain {
   }
 
   private static Set<String> commonVersionlessArtifacts(List<DependencyPath> dependencyPaths) {
+    Preconditions.checkArgument(
+        !dependencyPaths.isEmpty(), "Dependency paths for a jar should not be empty");
     Set<String> versionlessCoordinatesIntersection = null; // null for 1st iteration
     for (DependencyPath dependencyPath : dependencyPaths) {
       // List of versionless coordinates ("groupId:artifactId")
@@ -465,6 +467,7 @@ public class DashboardMain {
         versionlessCoordinatesIntersection.retainAll(versionlessCoordinatesInPath);
       }
     }
+    // Because dependencyPaths is not empty, always returns non-null
     return versionlessCoordinatesIntersection;
   }
 

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -432,29 +432,29 @@ public class DashboardMain {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 
     for (Path jar : jarToDependencyPaths.keySet()) {
-      LinkedHashSet<String> commonVersionlessCoordinates = null; // null for 1st iteration
+      LinkedHashSet<String> versionlessCoordinatesIntersection = null; // null for 1st iteration
       List<DependencyPath> dependencyPaths = jarToDependencyPaths.get(jar);
 
       for (DependencyPath dependencyPath : dependencyPaths) {
         // List of versionless coordinates ("groupId:artifactId")
         ImmutableList<String> versionlessCoordinatesInPath =
             dependencyPath.getPath().stream().map(Artifacts::makeKey).collect(toImmutableList());
-        if (commonVersionlessCoordinates == null) {
+        if (versionlessCoordinatesIntersection == null) {
           // For 1st iteration, initializes the intersection set with LinkedHashSet, which keeps
           // the order of the common artifacts.
-          commonVersionlessCoordinates = Sets.newLinkedHashSet(versionlessCoordinatesInPath);
+          versionlessCoordinatesIntersection = Sets.newLinkedHashSet(versionlessCoordinatesInPath);
         } else {
           // intersection of elements in DependencyPaths
-          commonVersionlessCoordinates.retainAll(versionlessCoordinatesInPath);
+          versionlessCoordinatesIntersection.retainAll(versionlessCoordinatesInPath);
         }
       }
 
       // When dependencyPaths is not empty, versionlessCoordinates is not null
       if (dependencyPaths.size() > SUMMARIZING_DEPENDENCY_PATH_SIZE_THRESHOLD
-          && commonVersionlessCoordinates.size() > 1) { // The last paths elements are always same
+          && versionlessCoordinatesIntersection.size() > 1) { // The last paths elements are always same
         StringBuilder messageBuilder = new StringBuilder();
         messageBuilder.append("Artifacts '");
-        messageBuilder.append(Joiner.on(" > ").join(commonVersionlessCoordinates));
+        messageBuilder.append(Joiner.on(" > ").join(versionlessCoordinatesIntersection));
         messageBuilder.append("' exist in all " + dependencyPaths.size() + " dependency paths. ");
         messageBuilder.append("Example path: ");
         messageBuilder.append(dependencyPaths.get(0));

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -307,7 +307,6 @@ public class DashboardMain {
       templateData.put("dependencyRootNode", Iterables.getFirst(dependencyTree.values(), null));
       templateData.put("jarLinkageReports", staticLinkageCheckReports);
       templateData.put("jarToDependencyPaths", jarToDependencyPathsForArtifact);
-      templateData.put("jarToSimplifiedPathMessage", Maps.newHashMap());
       templateData.put("totalLinkageErrorCount", totalLinkageErrorCount);
       report.process(templateData, out);
 
@@ -370,8 +369,7 @@ public class DashboardMain {
       templateData.put("latestArtifacts", latestArtifacts);
       templateData.put("jarLinkageReports", classpathCheckReport.getJarLinkageReports());
       templateData.put("jarToDependencyPaths", jarToDependencyPaths);
-      templateData.put(
-          "jarToSimplifiedPathMessage", jarToDependencyPathSummary(jarToDependencyPaths));
+      templateData.put("dependencyPathRootCauses", findRootCauses(jarToDependencyPaths));
 
       // Accessing Static method 'countFailures' from Freemarker template
       // https://freemarker.apache.org/docs/pgui_misc_beanwrapper.html#autoid_60
@@ -427,7 +425,7 @@ public class DashboardMain {
    * example, {@code commons-logging:commons-logging}, {@code
    * com.google.http-client:google-http-client} and {@code log4j:log4j}.
    */
-  private static ImmutableMap<String, String> jarToDependencyPathSummary(
+  private static ImmutableMap<String, String> findRootCauses(
       ListMultimap<Path, DependencyPath> jarToDependencyPaths) {
     // Freemarker is not good at handling non-string key. Path object in .ftl is automatically
     // converted to String. https://freemarker.apache.org/docs/app_faq.html#faq_nonstring_keys
@@ -455,10 +453,10 @@ public class DashboardMain {
       if (dependencyPaths.size() > SUMMARIZING_DEPENDENCY_PATH_SIZE_THRESHOLD
           && versionlessCoordinates.size() > 1) { // The last elements are always same among paths
         StringBuilder messageBuilder = new StringBuilder();
-        messageBuilder.append("There are " + dependencyPaths.size() + " paths to the artifact. ");
-        messageBuilder.append("All of them have the same artifacts: ");
+        messageBuilder.append("Artifacts '");
         messageBuilder.append(Joiner.on(" > ").join(versionlessCoordinates));
-        messageBuilder.append(". Example path: ");
+        messageBuilder.append("' exist in all " + dependencyPaths.size() + " dependency paths. ");
+        messageBuilder.append("Example path: ");
         messageBuilder.append(dependencyPaths.get(0));
         builder.put(jar.toString(), messageBuilder.toString());
       }

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -432,7 +432,7 @@ public class DashboardMain {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 
     for (Path jar : jarToDependencyPaths.keySet()) {
-      LinkedHashSet<String> versionlessCoordinatesIntersection = null; // null for 1st iteration
+      Set<String> versionlessCoordinatesIntersection = null; // null for 1st iteration
       List<DependencyPath> dependencyPaths = jarToDependencyPaths.get(jar);
 
       for (DependencyPath dependencyPath : dependencyPaths) {

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -432,13 +432,13 @@ public class DashboardMain {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 
     for (Path jar : jarToDependencyPaths.keySet()) {
-      // To keep order of the common artifact
+      // To keep order of the common artifact when shown in dashboard
       LinkedHashSet<String> versionlessCoordinates = null; // null for 1st iteration
       boolean firstIteration = true;
       ImmutableList<DependencyPath> dependencyPaths = ImmutableList
           .copyOf(jarToDependencyPaths.get(jar));
       for (DependencyPath dependencyPath : dependencyPaths) {
-        // Set of versionless coordinates ("groupId:artifactId")
+        // List of versionless coordinates ("groupId:artifactId")
         ImmutableList<String> versionlessCoordinatesInPath =
             dependencyPath.getPath().stream().map(Artifacts::makeKey).collect(toImmutableList());
         if (firstIteration) {

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -437,7 +437,7 @@ public class DashboardMain {
     for (Path jar : jarToDependencyPaths.keySet()) {
       List<DependencyPath> dependencyPaths = jarToDependencyPaths.get(jar);
 
-      LinkedHashSet<String> commonVersionlessArtifacts =
+      ImmutableList<String> commonVersionlessArtifacts =
           commonVersionlessArtifacts(dependencyPaths);
 
       if (dependencyPaths.size() > MINIMUM_NUMBER_DEPENDENCY_PATHS
@@ -451,7 +451,7 @@ public class DashboardMain {
     return builder.build();
   }
 
-  private static LinkedHashSet<String> commonVersionlessArtifacts(
+  private static ImmutableList<String> commonVersionlessArtifacts(
       List<DependencyPath> dependencyPaths) {
     ImmutableList<String> initialVersionlessCoordinates =
         versionlessCoordinates(dependencyPaths.get(0));
@@ -464,8 +464,8 @@ public class DashboardMain {
       // intersection of elements in DependencyPaths
       versionlessCoordinatesIntersection.retainAll(versionlessCoordinatesInPath);
     }
-    // Because dependencyPaths is not empty, always returns non-null
-    return versionlessCoordinatesIntersection;
+
+    return ImmutableList.copyOf(versionlessCoordinatesIntersection);
   }
 
   private static ImmutableList<String> versionlessCoordinates(DependencyPath dependencyPath) {
@@ -473,7 +473,7 @@ public class DashboardMain {
   }
 
   private static String summaryMessage(
-      int dependencyPathCount, Set<String> coordinates, DependencyPath examplePath) {
+      int dependencyPathCount, List<String> coordinates, DependencyPath examplePath) {
     StringBuilder messageBuilder = new StringBuilder();
     messageBuilder.append("Artifacts '");
     messageBuilder.append(Joiner.on(" > ").join(coordinates));

--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -115,7 +115,7 @@
 
     <p id="static-linkage-errors-total">${totalLinkageErrorCount} static linkage error(s)</p>
     <#list jarLinkageReports as jarLinkageReport>
-      <@formatJarLinkageReport jarLinkageReport jarToDependencyPaths/>
+      <@formatJarLinkageReport jarLinkageReport jarToDependencyPaths jarToSimplifiedPathMessage />
     </#list>
 
     <h2>Dependencies</h2>

--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -115,7 +115,7 @@
 
     <p id="static-linkage-errors-total">${totalLinkageErrorCount} static linkage error(s)</p>
     <#list jarLinkageReports as jarLinkageReport>
-      <@formatJarLinkageReport jarLinkageReport jarToDependencyPaths jarToSimplifiedPathMessage />
+      <@formatJarLinkageReport jarLinkageReport jarToDependencyPaths {} />
     </#list>
 
     <h2>Dependencies</h2>

--- a/dashboard/src/main/resources/templates/dashboard.ftl
+++ b/dashboard/src/main/resources/templates/dashboard.ftl
@@ -70,7 +70,7 @@
     <h2>Static Linkage Errors</h2>
 
     <#list jarLinkageReports as jarLinkageReport>
-      <@formatJarLinkageReport jarLinkageReport jarToDependencyPaths/>
+      <@formatJarLinkageReport jarLinkageReport jarToDependencyPaths jarToSimplifiedPathMessage/>
     </#list>
 
     <hr />      

--- a/dashboard/src/main/resources/templates/dashboard.ftl
+++ b/dashboard/src/main/resources/templates/dashboard.ftl
@@ -70,7 +70,7 @@
     <h2>Static Linkage Errors</h2>
 
     <#list jarLinkageReports as jarLinkageReport>
-      <@formatJarLinkageReport jarLinkageReport jarToDependencyPaths jarToSimplifiedPathMessage/>
+      <@formatJarLinkageReport jarLinkageReport jarToDependencyPaths dependencyPathRootCauses/>
     </#list>
 
     <hr />      

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -3,9 +3,10 @@
   <#return number + " " + plural?string(pluralNoun, singlarNoun)>
 </#function>
 
-<#macro formatJarLinkageReport jarLinkageReport jarToDependencyPaths>
+<#macro formatJarLinkageReport jarLinkageReport jarToDependencyPaths jarToSimplifiedPathMessage>
   <#if jarLinkageReport.getCauseToSourceClassesSize() gt 0>
-    <h3>${jarLinkageReport.getJarPath().getFileName()?html}</h3>
+    <#assign jarPath = jarLinkageReport.getJarPath() />
+    <h3>${jarPath.getFileName()?html}</h3>
 
     <#assign causeToSourceClasses = jarLinkageReport.getCauseToSourceClasses() />
     <#assign linkageErrors = pluralize(jarLinkageReport.getCauseToSourceClassesSize(),
@@ -25,11 +26,16 @@
     <p class="static-linkage-check-dependency-paths">
       The following paths to the jar file from BOM are found in the dependency tree.
     </p>
-    <ul class="static-linkage-check-dependency-paths">
-      <#list jarToDependencyPaths.get(jarLinkageReport.getJarPath()) as dependencyPath >
-        <li>${dependencyPath}</li>
-      </#list>
-    </ul>
+    <#if jarToSimplifiedPathMessage[jarPath]?? >
+      <p class="static-linkage-check-dependency-paths">${jarToSimplifiedPathMessage[jarPath]?html}
+      </p>
+    <#else>
+      <ul class="static-linkage-check-dependency-paths">
+          <#list jarToDependencyPaths.get(jarPath) as dependencyPath >
+            <li>${dependencyPath}</li>
+          </#list>
+      </ul>
+    </#if>
   </#if>
 </#macro>
 

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -3,7 +3,7 @@
   <#return number + " " + plural?string(pluralNoun, singlarNoun)>
 </#function>
 
-<#macro formatJarLinkageReport jarLinkageReport jarToDependencyPaths jarToSimplifiedPathMessage>
+<#macro formatJarLinkageReport jarLinkageReport jarToDependencyPaths dependencyPathRootCauses>
   <#if jarLinkageReport.getCauseToSourceClassesSize() gt 0>
     <#assign jarPath = jarLinkageReport.getJarPath() />
     <h3>${jarPath.getFileName()?html}</h3>
@@ -26,8 +26,8 @@
     <p class="static-linkage-check-dependency-paths">
       The following paths to the jar file from BOM are found in the dependency tree.
     </p>
-    <#if jarToSimplifiedPathMessage[jarPath]?? >
-      <p class="static-linkage-check-dependency-paths">${jarToSimplifiedPathMessage[jarPath]?html}
+    <#if dependencyPathRootCauses[jarPath]?? >
+      <p class="static-linkage-check-dependency-paths">${dependencyPathRootCauses[jarPath]?html}
       </p>
     <#else>
       <ul class="static-linkage-check-dependency-paths">

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -163,7 +163,9 @@ public class DashboardTest {
       Node log4jDependencyPathMessage = dependencyPaths.get(dependencyPaths.size() - 1);
       // There are 994 paths to log4j. These should be summarized.
       Truth.assertThat(log4jDependencyPathMessage.getValue())
-          .startsWith("There are 994 paths to the artifact.");
+          .startsWith(
+              "Artifacts 'com.google.http-client:google-http-client >"
+                  + " commons-logging:commons-logging > log4j:log4j' exist in all");
       int dependencyPathListSize =
           document.query("//ul[@class='static-linkage-check-dependency-paths']/li").size();
       Truth.assertWithMessage("The dashboard should not show repetitive dependency paths")

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -161,7 +161,7 @@ public class DashboardTest {
       ImmutableList<Node> dependencyPaths = toList(
           document.query("//p[@class='static-linkage-check-dependency-paths']"));
       Node log4jDependencyPathMessage = dependencyPaths.get(dependencyPaths.size() - 1);
-      // log4j dependency paths, which would have 994 lines, should be shown as summarized
+      // There are 994 paths to log4j. These should be summarized.
       Truth.assertThat(log4jDependencyPathMessage.getValue())
           .startsWith("There are 994 paths to the artifact.");
       int dependencyPathListSize =

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -161,7 +161,7 @@ public class DashboardTest {
       ImmutableList<Node> dependencyPaths = toList(
           document.query("//p[@class='static-linkage-check-dependency-paths']"));
       Node log4jDependencyPathMessage = dependencyPaths.get(dependencyPaths.size() - 1);
-      // Not to show all 900 dependency paths to log4j in the dashboard
+      // log4j dependency paths, which would have 994 lines, should be shown as summarized
       Truth.assertThat(log4jDependencyPathMessage.getValue())
           .startsWith("There are 994 paths to the artifact.");
       int dependencyPathListSize =

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -162,8 +162,8 @@ public class DashboardTest {
           document.query("//p[@class='static-linkage-check-dependency-paths']"));
       Node log4jDependencyPathMessage = dependencyPaths.get(dependencyPaths.size() - 1);
       // Not to show all 900 dependency paths to log4j in the dashboard
-      Truth.assertThat(log4jDependencyPathMessage.getValue()).contains(
-          "and other 993 dependency paths to the jar file. All of them have the same artifacts:");
+      Truth.assertThat(log4jDependencyPathMessage.getValue())
+          .startsWith("There are 994 paths to the artifact.");
       int dependencyPathListSize =
           document.query("//ul[@class='static-linkage-check-dependency-paths']/li").size();
       Truth.assertWithMessage("The dashboard should not show repetitive dependency paths")

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -158,6 +158,18 @@ public class DashboardTest {
       // grpc-testing-1.17.1, shown as first item in linkage errors, has these errors
       Assert.assertTrue(linkage.getValue().contains("3 linkage errors in 3 classes"));
 
+      ImmutableList<Node> dependencyPaths = toList(
+          document.query("//p[@class='static-linkage-check-dependency-paths']"));
+      Node log4jDependencyPathMessage = dependencyPaths.get(dependencyPaths.size() - 1);
+      // Not to show all 900 dependency paths to log4j in the dashboard
+      Truth.assertThat(log4jDependencyPathMessage.getValue()).contains(
+          "and other 993 dependency paths to the jar file. All of them have the same artifacts:");
+      int dependencyPathListSize =
+          document.query("//ul[@class='static-linkage-check-dependency-paths']/li").size();
+      Truth.assertWithMessage("The dashboard should not show repetitive dependency paths")
+          .that(dependencyPathListSize)
+          .isLessThan(100);
+
       Nodes li = document.query("//ul[@id='recommended']/li");
       Assert.assertTrue(li.size() > 100);
 

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -34,7 +34,7 @@ import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
 import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.Multimap;
+import com.google.common.collect.ListMultimap;
 import com.google.common.truth.Truth;
 
 import freemarker.template.Configuration;
@@ -81,7 +81,7 @@ public class FreemarkerTest {
     
     List<ArtifactResults> table = ImmutableList.of(results1, results2);
     List<DependencyGraph> globalDependencies = ImmutableList.of();
-    Multimap<Path, DependencyPath> jarToDependencyPaths = LinkedListMultimap.create();
+    ListMultimap<Path, DependencyPath> jarToDependencyPaths = LinkedListMultimap.create();
     DashboardMain.generateDashboard(configuration, outputDirectory, table, globalDependencies,
         classpathCheckReport, jarToDependencyPaths);
     


### PR DESCRIPTION
Fixes #430. (as part of #395 )

![image](https://user-images.githubusercontent.com/28604/52612680-c80ff700-2e58-11e9-9ce6-a8fb58d18880.png)

@elharo As discussed last week, here is a simplified message for the same cause to avoid listing 900 dependency paths to log4j.