### PR TITLE
(Not for merge) Entry points only with "com.google.appengine"

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassReferenceGraph.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassReferenceGraph.java
@@ -66,8 +66,10 @@ class ClassReferenceGraph {
     Set<String> packageNames = Sets.newHashSet();
     for (Path jarPath : entryPointJars) {
       for (JavaClass javaClass : ClassDumper.listClassesInJar(jarPath)) {
-        packageNames.add(javaClass.getPackageName());
-        if (!javaClass.getPackageName().startsWith("com.google.appengine")) {
+        String packageName = javaClass.getPackageName();
+        packageNames.add(packageName);
+        if (!packageName.startsWith("com.google.appengine")
+            || packageName.startsWith("com.google.appengine.repackaged")) {
           continue;
         }
         entryPointClassBuilder.add(javaClass.getClassName());

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassReferenceGraph.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassReferenceGraph.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.opensource.classpath;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.MutableGraph;
 import com.google.common.graph.Traverser;
@@ -61,10 +62,19 @@ class ClassReferenceGraph {
             .collect(toImmutableSet());
 
     ImmutableSet.Builder<String> entryPointClassBuilder = ImmutableSet.builder();
+
+    Set<String> packageNames = Sets.newHashSet();
     for (Path jarPath : entryPointJars) {
       for (JavaClass javaClass : ClassDumper.listClassesInJar(jarPath)) {
+        packageNames.add(javaClass.getPackageName());
+        if (!javaClass.getPackageName().startsWith("com.google.appengine")) {
+          continue;
+        }
         entryPointClassBuilder.add(javaClass.getClassName());
       }
+    }
+    for (String s : packageNames) {
+      System.out.println(s);
     }
 
     return new ClassReferenceGraph(classSymbolReferences, entryPointClassBuilder.build());

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClasspathChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClasspathChecker.java
@@ -170,9 +170,26 @@ public class ClasspathChecker {
             .map(checkFunction)
             .filter(Optional::isPresent)
             .map(Optional::get)
+            .filter(error -> !containsExclusionClass(error.getReference()))
             .collect(toImmutableList());
     return linkageErrors;
   }
+
+  static final ImmutableList<String> excludeWords =
+      ImmutableList.of("Pb", "repackaged", "servlet", "protos");
+
+  private static boolean containsExclusionClass(SymbolReference reference) {
+    for (String excludeWord : excludeWords) {
+      if (reference.getSourceClassName().contains(excludeWord)) {
+        return true;
+      }
+      if (reference.getTargetClassName().contains(excludeWord)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
 
   /**
    * Returns an {@code Optional} describing the linkage error for the method reference if the


### PR DESCRIPTION
For #441.

Some errors are now marked as unreachable.

```  
com.google.appengine.tools.appstats
appengine-api-1.0-sdk-1.9.64.jar (680 errors):
...
ClassSymbolReference{sourceClassName=com.google.apphosting.api.logservice.LogServicePb$LogService_3, targetClassName=com.google.net.rpc3.client.RpcStubCreationFilter, subclass=false}, reason: CLASS_NOT_FOUND, target class location not found, isReachable: true
ClassSymbolReference{sourceClassName=com.google.apphosting.api.logservice.LogServicePb$LogService_3, targetClassName=com.google.appengine.repackaged.com.google.common.inject.Providers, subclass=false}, reason: CLASS_NOT_FOUND, target class location not found, isReachable: true
ClassSymbolReference{sourceClassName=com.google.apphosting.client.serviceapp.BaseApiServlet, targetClassName=javax.servlet.http.HttpServlet, subclass=true}, reason: CLASS_NOT_FOUND, target class location not found, isReachable: false
ClassSymbolReference{sourceClassName=com.google.apphosting.client.serviceapp.BaseApiServlet, targetClassName=javax.servlet.http.HttpServletRequest, subclass=false}, reason: CLASS_NOT_FOUND, target class location not found, isReachable: false
ClassSymbolReference{sourceClassName=com.google.apphosting.client.serviceapp.BaseApiServlet, targetClassName=javax.servlet.http.HttpServletResponse, subclass=false}, reason: CLASS_NOT_FOUND, target class location not found, isReachable: false
ClassSymbolReference{sourceClassName=com.google.apphosting.client.serviceapp.BaseApiServlet, targetClassName=javax.servlet.ServletOutputStream, subclass=false}, reason: CLASS_NOT_FOUND, target class location not found, isReachable: false
ClassSymbolReference{sourceClassName=com.google.apphosting.datastore.DatastoreV4$DatastoreV4Service$1, targetClassName=com.google.net.rpc3.client.RpcStubDescriptor, subclass=true}, reason: CLASS_NOT_FOUND, target class location not found, isReachable: false
```
