### PR TITLE
Split testDashboard into multiple cases

### DIFF
--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -114,8 +114,7 @@ public class DashboardTest {
     Assert.assertTrue("The file is not readable: " + fileName, Files.isReadable(html));
 
     try (InputStream source = Files.newInputStream(html)) {
-      Document document = builder.build(source);
-      return document;
+      return builder.build(source);
     }
   }
 

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -220,11 +220,11 @@ public class DashboardTest {
     assertDocument(
         "dashboard.html",
         document -> {
-          Nodes li = document.query("//ul[@id='recommended']/li");
-          Assert.assertTrue(li.size() > 100);
+          Nodes recommendedListItem = document.query("//ul[@id='recommended']/li");
+          Assert.assertTrue(recommendedListItem.size() > 100);
 
           List<String> coordinateList =
-              toList(li).stream().map(Node::getValue).collect(toImmutableList());
+              toList(recommendedListItem).stream().map(Node::getValue).collect(toImmutableList());
           // fails if these are not valid Maven coordinates
           coordinateList.forEach(DefaultArtifact::new);
 
@@ -237,6 +237,15 @@ public class DashboardTest {
                 "Coordinates are not sorted: ", sorted.get(i), coordinateList.get(i));
           }
         });
+  }
+
+  private static class SortWithoutVersion implements Comparator<String> {
+    @Override
+    public int compare(String s1, String s2) {
+      s1 = s1.substring(0, s1.lastIndexOf(':'));
+      s2 = s2.substring(0, s2.lastIndexOf(':'));
+      return s1.compareTo(s2);
+    }
   }
 
   @Test
@@ -355,17 +364,6 @@ public class DashboardTest {
           Truth.assertThat(staticLinkageTotalMessage.get(0).getValue())
               .contains("0 static linkage error(s)");
         });
-  }
-
-  private static class SortWithoutVersion implements Comparator<String> {
-
-    @Override
-    public int compare(String s1, String s2) {  
-      s1 = s1.substring(0, s1.lastIndexOf(':'));
-      s2 = s2.substring(0, s2.lastIndexOf(':'));
-      return s1.compareTo(s2);
-    }
-
   }
 
   private static ImmutableList<Node> toList(Nodes nodes) {

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -80,19 +80,16 @@ public class DashboardTest {
 
   @BeforeClass
   public static void setUp() throws IOException, ParsingException {
-    // Creates "dashboard.html" in outputDirectory
+    // Creates "dashboard.html" and artifact reports in outputDirectory
     try {
       outputDirectory = DashboardMain.generate();
     } catch (Throwable t) {
       t.printStackTrace();
       Assert.fail("Could not generate dashboard");
     }
-    Path html = outputDirectory.resolve("dashboard.html");
-    Assert.assertTrue("Dashboard.html should be readable", Files.isReadable(html));
-    Assert.assertTrue("Dashboard.html should be a regular file",
-        Files.isRegularFile(html));
 
-    try (InputStream source = Files.newInputStream(html)) {
+    Path dashboardHtml = outputDirectory.resolve("dashboard.html");
+    try (InputStream source = Files.newInputStream(dashboardHtml)) {
       dashboard = builder.build(source);
     }
   }
@@ -128,9 +125,6 @@ public class DashboardTest {
 
   @Test
   public void testDashboard() throws IOException, ArtifactDescriptorException {
-    Assert.assertTrue(Files.exists(outputDirectory));
-    Assert.assertTrue(Files.isDirectory(outputDirectory));
-
     DefaultArtifact bom =
         new DefaultArtifact("com.google.cloud:cloud-oss-bom:pom:1.0.0-SNAPSHOT");
     List<Artifact> artifacts = RepositoryUtility.readBom(bom);


### PR DESCRIPTION
Fixes #439.

- `DashboardTest.testDashboard` is split into multiple test cases for the sections
- New function `assertDocument` abstracts repetitive steps of opening file, asserting its existence, and parsing html document via xom.
- Removed unnecessary `throws` clause