### PR TITLE
rename StaticLinkageError

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClasspathChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClasspathChecker.java
@@ -43,7 +43,7 @@ import org.apache.commons.cli.ParseException;
 import org.eclipse.aether.RepositoryException;
 
 /**
- * A tool to find static linkage errors for a class path.
+ * A tool to find linkage errors in a class path.
  */
 public class ClasspathChecker {
 
@@ -160,11 +160,11 @@ public class ClasspathChecker {
   }
 
   private static <R extends SymbolReference>
-      ImmutableList<SymbolNotFound<R>> errorsFromSymbolReferences(
+      ImmutableList<SymbolNotResolvable<R>> errorsFromSymbolReferences(
           Set<R> symbolReferences,
           Set<String> classesDefinedInJar,
-          Function<R, Optional<SymbolNotFound<R>>> checkFunction) {
-    ImmutableList<SymbolNotFound<R>> linkageErrors =
+          Function<R, Optional<SymbolNotResolvable<R>>> checkFunction) {
+    ImmutableList<SymbolNotResolvable<R>> linkageErrors =
         symbolReferences.stream()
             .filter(reference -> !classesDefinedInJar.contains(reference.getTargetClassName()))
             .map(checkFunction)
@@ -185,7 +185,7 @@ public class ClasspathChecker {
    *     Virtual Machine Specification: 5.4.3.4. Interface Method Resolution</a>
    */
   @VisibleForTesting
-  Optional<SymbolNotFound<MethodSymbolReference>> checkLinkageErrorMissingMethodAt(
+  Optional<SymbolNotResolvable<MethodSymbolReference>> checkLinkageErrorMissingMethodAt(
       MethodSymbolReference reference) {
     String targetClassName = reference.getTargetClassName();
     String sourceClassName = reference.getSourceClassName();
@@ -202,13 +202,13 @@ public class ClasspathChecker {
       Path classFileLocation = classDumper.findClassLocation(targetClassName);
       if (!isClassAccessibleFrom(targetJavaClass, sourceClassName)) {
         return Optional.of(
-            SymbolNotFound.errorInaccessibleClass(
+            SymbolNotResolvable.errorInaccessibleClass(
                 reference, classFileLocation, isSourceClassReachable));
       }
 
       if (targetJavaClass.isInterface() != reference.isInterfaceMethod()) {
         return Optional.of(
-            SymbolNotFound.errorIncompatibleClassChange(
+            SymbolNotResolvable.errorIncompatibleClassChange(
                 reference, classFileLocation, isSourceClassReachable));
       }
 
@@ -227,7 +227,7 @@ public class ClasspathChecker {
               && method.getSignature().equals(reference.getDescriptor())) {
             if (!isMemberAccessibleFrom(javaClass, method, sourceClassName)) {
               return Optional.of(
-                  SymbolNotFound.errorInaccessibleMember(
+                  SymbolNotResolvable.errorInaccessibleMember(
                       reference, classFileLocation, isSourceClassReachable));
             }
             // The method is found and accessible. Returning no error.
@@ -238,14 +238,14 @@ public class ClasspathChecker {
 
       // The class is in class path but the symbol is not found
       return Optional.of(
-          SymbolNotFound.errorMissingMember(
+          SymbolNotResolvable.errorMissingMember(
               reference, classFileLocation, isSourceClassReachable));
     } catch (ClassNotFoundException ex) {
       if (classDumper.catchesNoClassDefFoundError(reference)) {
         return Optional.empty();
       }
       return Optional.of(
-          SymbolNotFound.errorMissingTargetClass(reference, isSourceClassReachable));
+          SymbolNotResolvable.errorMissingTargetClass(reference, isSourceClassReachable));
     }
   }
 
@@ -255,7 +255,7 @@ public class ClasspathChecker {
    * Optional}.
    */
   @VisibleForTesting
-  Optional<SymbolNotFound<FieldSymbolReference>> checkLinkageErrorMissingFieldAt(
+  Optional<SymbolNotResolvable<FieldSymbolReference>> checkLinkageErrorMissingFieldAt(
       FieldSymbolReference reference) {
     String targetClassName = reference.getTargetClassName();
     String sourceClassName = reference.getSourceClassName();
@@ -266,7 +266,7 @@ public class ClasspathChecker {
       Path classFileLocation = classDumper.findClassLocation(targetClassName);
       if (!isClassAccessibleFrom(targetJavaClass, sourceClassName)) {
         return Optional.of(
-            SymbolNotFound.errorInaccessibleClass(
+            SymbolNotResolvable.errorInaccessibleClass(
                 reference, classFileLocation, isSourceClassReachable));
       }
 
@@ -275,7 +275,7 @@ public class ClasspathChecker {
           if (field.getName().equals(fieldName)) {
             if (!isMemberAccessibleFrom(javaClass, field, sourceClassName)) {
               return Optional.of(
-                  SymbolNotFound.errorInaccessibleMember(
+                  SymbolNotResolvable.errorInaccessibleMember(
                       reference, classFileLocation, isSourceClassReachable));
             }
             // The field is found and accessible. Returning no error.
@@ -285,14 +285,14 @@ public class ClasspathChecker {
       }
       // The field was not found in the class from the classpath
       return Optional.of(
-          SymbolNotFound.errorMissingMember(
+          SymbolNotResolvable.errorMissingMember(
               reference, classFileLocation, isSourceClassReachable));
     } catch (ClassNotFoundException ex) {
       if (classDumper.catchesNoClassDefFoundError(reference)) {
         return Optional.empty();
       }
       return Optional.of(
-          SymbolNotFound.errorMissingTargetClass(reference, isSourceClassReachable));
+          SymbolNotResolvable.errorMissingTargetClass(reference, isSourceClassReachable));
     }
   }
 
@@ -345,7 +345,7 @@ public class ClasspathChecker {
    * Optional}.
    */
   @VisibleForTesting
-  Optional<SymbolNotFound<ClassSymbolReference>> checkLinkageErrorMissingClassAt(
+  Optional<SymbolNotResolvable<ClassSymbolReference>> checkLinkageErrorMissingClassAt(
       ClassSymbolReference reference) {
     String sourceClassName = reference.getSourceClassName();
     String targetClassName = reference.getTargetClassName();
@@ -358,13 +358,13 @@ public class ClasspathChecker {
           && !classDumper.hasValidSuperclass(
               classDumper.loadJavaClass(sourceClassName), targetClass)) {
         return Optional.of(
-            SymbolNotFound.errorIncompatibleClassChange(
+            SymbolNotResolvable.errorIncompatibleClassChange(
                 reference, classFileLocation, isSourceClassReachable));
       }
 
       if (!isClassAccessibleFrom(targetClass, sourceClassName)) {
         return Optional.of(
-            SymbolNotFound.errorInaccessibleClass(
+            SymbolNotResolvable.errorInaccessibleClass(
                 reference, classFileLocation, isSourceClassReachable));
       }
       return Optional.empty();
@@ -375,7 +375,7 @@ public class ClasspathChecker {
         return Optional.empty();
       }
       return Optional.of(
-          SymbolNotFound.errorMissingTargetClass(reference, isSourceClassReachable));
+          SymbolNotResolvable.errorMissingTargetClass(reference, isSourceClassReachable));
     }
   }
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
@@ -41,11 +41,11 @@ public abstract class JarLinkageReport {
    */
   public abstract Path getJarPath();
 
-  public abstract ImmutableList<StaticLinkageError<ClassSymbolReference>> getMissingClassErrors();
+  public abstract ImmutableList<SymbolNotFound<ClassSymbolReference>> getMissingClassErrors();
 
-  public abstract ImmutableList<StaticLinkageError<MethodSymbolReference>> getMissingMethodErrors();
+  public abstract ImmutableList<SymbolNotFound<MethodSymbolReference>> getMissingMethodErrors();
 
-  public abstract ImmutableList<StaticLinkageError<FieldSymbolReference>> getMissingFieldErrors();
+  public abstract ImmutableList<SymbolNotFound<FieldSymbolReference>> getMissingFieldErrors();
 
   static Builder builder() {
     return new AutoValue_JarLinkageReport.Builder();
@@ -56,13 +56,13 @@ public abstract class JarLinkageReport {
     abstract Builder setJarPath(Path value);
 
     abstract Builder setMissingClassErrors(
-        Iterable<StaticLinkageError<ClassSymbolReference>> errors);
+        Iterable<SymbolNotFound<ClassSymbolReference>> errors);
 
     abstract Builder setMissingMethodErrors(
-        Iterable<StaticLinkageError<MethodSymbolReference>> errors);
+        Iterable<SymbolNotFound<MethodSymbolReference>> errors);
 
     abstract Builder setMissingFieldErrors(
-        Iterable<StaticLinkageError<FieldSymbolReference>> errors);
+        Iterable<SymbolNotFound<FieldSymbolReference>> errors);
 
     abstract JarLinkageReport build();
   }
@@ -74,15 +74,15 @@ public abstract class JarLinkageReport {
     int totalErrors = getCauseToSourceClassesSize();
 
     builder.append(getJarPath().getFileName() + " (" + totalErrors + " errors):\n");
-    for (StaticLinkageError<ClassSymbolReference> missingClass : getMissingClassErrors()) {
+    for (SymbolNotFound<ClassSymbolReference> missingClass : getMissingClassErrors()) {
       builder.append(indent + missingClass);
       builder.append("\n");
     }
-    for (StaticLinkageError<MethodSymbolReference> missingMethod : getMissingMethodErrors()) {
+    for (SymbolNotFound<MethodSymbolReference> missingMethod : getMissingMethodErrors()) {
       builder.append(indent + missingMethod);
       builder.append("\n");
     }
-    for (StaticLinkageError<FieldSymbolReference> missingField : getMissingFieldErrors()) {
+    for (SymbolNotFound<FieldSymbolReference> missingField : getMissingFieldErrors()) {
       builder.append(indent + missingField);
       builder.append("\n");
     }
@@ -91,13 +91,13 @@ public abstract class JarLinkageReport {
 
   /** Returns map from the cause of linkage errors to class names affected by the errors. */
   public ImmutableMultimap<LinkageErrorCause, String> getCauseToSourceClasses() {
-    ImmutableListMultimap<LinkageErrorCause, StaticLinkageError<ClassSymbolReference>>
+    ImmutableListMultimap<LinkageErrorCause, SymbolNotFound<ClassSymbolReference>>
         groupedClassErrors = Multimaps.index(getMissingClassErrors(), LinkageErrorCause::from);
 
-    ImmutableListMultimap<LinkageErrorCause, StaticLinkageError<MethodSymbolReference>>
+    ImmutableListMultimap<LinkageErrorCause, SymbolNotFound<MethodSymbolReference>>
         groupedMethodErrors = Multimaps.index(getMissingMethodErrors(), LinkageErrorCause::from);
 
-    ImmutableListMultimap<LinkageErrorCause, StaticLinkageError<FieldSymbolReference>>
+    ImmutableListMultimap<LinkageErrorCause, SymbolNotFound<FieldSymbolReference>>
         groupedFieldErrors = Multimaps.index(getMissingFieldErrors(), LinkageErrorCause::from);
 
     // ImmutableSet ensures deterministic iteration order
@@ -110,7 +110,7 @@ public abstract class JarLinkageReport {
 
     ImmutableMultimap.Builder<LinkageErrorCause, String> builder = ImmutableMultimap.builder();
     for (LinkageErrorCause key : combinedKeys) {
-      List<StaticLinkageError<? extends SymbolReference>> allErrorsForKey =
+      List<SymbolNotFound<? extends SymbolReference>> allErrorsForKey =
           Lists.newArrayList(
               Iterables.concat(
                   groupedClassErrors.get(key),
@@ -119,7 +119,7 @@ public abstract class JarLinkageReport {
       builder.putAll(
           key,
           allErrorsForKey.stream()
-              .map(StaticLinkageError::getReference)
+              .map(SymbolNotFound::getReference)
               .map(SymbolReference::getSourceClassName)
               .map(className -> className.split("\\$")[0]) // Removing duplicate inner classes
               .collect(toImmutableSet()));

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
@@ -41,11 +41,11 @@ public abstract class JarLinkageReport {
    */
   public abstract Path getJarPath();
 
-  public abstract ImmutableList<SymbolNotFound<ClassSymbolReference>> getMissingClassErrors();
+  public abstract ImmutableList<SymbolNotResolvable<ClassSymbolReference>> getMissingClassErrors();
 
-  public abstract ImmutableList<SymbolNotFound<MethodSymbolReference>> getMissingMethodErrors();
+  public abstract ImmutableList<SymbolNotResolvable<MethodSymbolReference>> getMissingMethodErrors();
 
-  public abstract ImmutableList<SymbolNotFound<FieldSymbolReference>> getMissingFieldErrors();
+  public abstract ImmutableList<SymbolNotResolvable<FieldSymbolReference>> getMissingFieldErrors();
 
   static Builder builder() {
     return new AutoValue_JarLinkageReport.Builder();
@@ -56,13 +56,13 @@ public abstract class JarLinkageReport {
     abstract Builder setJarPath(Path value);
 
     abstract Builder setMissingClassErrors(
-        Iterable<SymbolNotFound<ClassSymbolReference>> errors);
+        Iterable<SymbolNotResolvable<ClassSymbolReference>> errors);
 
     abstract Builder setMissingMethodErrors(
-        Iterable<SymbolNotFound<MethodSymbolReference>> errors);
+        Iterable<SymbolNotResolvable<MethodSymbolReference>> errors);
 
     abstract Builder setMissingFieldErrors(
-        Iterable<SymbolNotFound<FieldSymbolReference>> errors);
+        Iterable<SymbolNotResolvable<FieldSymbolReference>> errors);
 
     abstract JarLinkageReport build();
   }
@@ -74,15 +74,15 @@ public abstract class JarLinkageReport {
     int totalErrors = getCauseToSourceClassesSize();
 
     builder.append(getJarPath().getFileName() + " (" + totalErrors + " errors):\n");
-    for (SymbolNotFound<ClassSymbolReference> missingClass : getMissingClassErrors()) {
+    for (SymbolNotResolvable<ClassSymbolReference> missingClass : getMissingClassErrors()) {
       builder.append(indent + missingClass);
       builder.append("\n");
     }
-    for (SymbolNotFound<MethodSymbolReference> missingMethod : getMissingMethodErrors()) {
+    for (SymbolNotResolvable<MethodSymbolReference> missingMethod : getMissingMethodErrors()) {
       builder.append(indent + missingMethod);
       builder.append("\n");
     }
-    for (SymbolNotFound<FieldSymbolReference> missingField : getMissingFieldErrors()) {
+    for (SymbolNotResolvable<FieldSymbolReference> missingField : getMissingFieldErrors()) {
       builder.append(indent + missingField);
       builder.append("\n");
     }
@@ -91,13 +91,13 @@ public abstract class JarLinkageReport {
 
   /** Returns map from the cause of linkage errors to class names affected by the errors. */
   public ImmutableMultimap<LinkageErrorCause, String> getCauseToSourceClasses() {
-    ImmutableListMultimap<LinkageErrorCause, SymbolNotFound<ClassSymbolReference>>
+    ImmutableListMultimap<LinkageErrorCause, SymbolNotResolvable<ClassSymbolReference>>
         groupedClassErrors = Multimaps.index(getMissingClassErrors(), LinkageErrorCause::from);
 
-    ImmutableListMultimap<LinkageErrorCause, SymbolNotFound<MethodSymbolReference>>
+    ImmutableListMultimap<LinkageErrorCause, SymbolNotResolvable<MethodSymbolReference>>
         groupedMethodErrors = Multimaps.index(getMissingMethodErrors(), LinkageErrorCause::from);
 
-    ImmutableListMultimap<LinkageErrorCause, SymbolNotFound<FieldSymbolReference>>
+    ImmutableListMultimap<LinkageErrorCause, SymbolNotResolvable<FieldSymbolReference>>
         groupedFieldErrors = Multimaps.index(getMissingFieldErrors(), LinkageErrorCause::from);
 
     // ImmutableSet ensures deterministic iteration order
@@ -110,7 +110,7 @@ public abstract class JarLinkageReport {
 
     ImmutableMultimap.Builder<LinkageErrorCause, String> builder = ImmutableMultimap.builder();
     for (LinkageErrorCause key : combinedKeys) {
-      List<SymbolNotFound<? extends SymbolReference>> allErrorsForKey =
+      List<SymbolNotResolvable<? extends SymbolReference>> allErrorsForKey =
           Lists.newArrayList(
               Iterables.concat(
                   groupedClassErrors.get(key),
@@ -119,7 +119,7 @@ public abstract class JarLinkageReport {
       builder.putAll(
           key,
           allErrorsForKey.stream()
-              .map(SymbolNotFound::getReference)
+              .map(SymbolNotResolvable::getReference)
               .map(SymbolReference::getSourceClassName)
               .map(className -> className.split("\\$")[0]) // Removing duplicate inner classes
               .collect(toImmutableSet()));

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorCause.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorCause.java
@@ -23,19 +23,19 @@ import com.google.auto.value.AutoValue;
 abstract class LinkageErrorCause {
 
   /** Returns the reason for the error */
-  abstract SymbolNotFound.Reason getReason();
+  abstract SymbolNotResolvable.Reason getReason();
 
   /** Returns the symbol causing the error. It's either class name, field name, or method name. */
   abstract String getSymbol();
 
   static <T extends SymbolReference> LinkageErrorCause from(
-      SymbolNotFound<T> staticLinkageError) {
+      SymbolNotResolvable<T> staticLinkageError) {
     String symbolName = symbolNameFrom(staticLinkageError);
     return new AutoValue_LinkageErrorCause(staticLinkageError.getReason(), symbolName);
   }
 
   private static <T extends SymbolReference> String symbolNameFrom(
-      SymbolNotFound<T> staticLinkageError) {
+      SymbolNotResolvable<T> staticLinkageError) {
     T reference = staticLinkageError.getReference();
     switch (staticLinkageError.getReason()) {
       case INACCESSIBLE_MEMBER:

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorCause.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorCause.java
@@ -23,19 +23,19 @@ import com.google.auto.value.AutoValue;
 abstract class LinkageErrorCause {
 
   /** Returns the reason for the error */
-  abstract StaticLinkageError.Reason getReason();
+  abstract SymbolNotFound.Reason getReason();
 
   /** Returns the symbol causing the error. It's either class name, field name, or method name. */
   abstract String getSymbol();
 
   static <T extends SymbolReference> LinkageErrorCause from(
-      StaticLinkageError<T> staticLinkageError) {
+      SymbolNotFound<T> staticLinkageError) {
     String symbolName = symbolNameFrom(staticLinkageError);
     return new AutoValue_LinkageErrorCause(staticLinkageError.getReason(), symbolName);
   }
 
   private static <T extends SymbolReference> String symbolNameFrom(
-      StaticLinkageError<T> staticLinkageError) {
+      SymbolNotFound<T> staticLinkageError) {
     T reference = staticLinkageError.getReference();
     switch (staticLinkageError.getReason()) {
       case INACCESSIBLE_MEMBER:

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolNotFound.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolNotFound.java
@@ -21,22 +21,23 @@ import java.nio.file.Path;
 import javax.annotation.Nullable;
 
 /**
- * Static linkage error caused by a symbol reference.
+ * Linkage error caused by a symbol reference that cannot be resolved.
  *
- * @param <T> type of symbol reference that caused the linkage error
+ * @param <T> symbol reference that caused the linkage error
  * @see <a
- *     href="https://github.com/GoogleCloudPlatform/cloud-opensource-java/blob/master/library-best-practices/glossary.md#static-linkage-error">
- *     Java Dependency Glossary: Static linkage error</a>
+ *     href="https://github.com/GoogleCloudPlatform/cloud-opensource-java/blob/master/library-best-practices/glossary.md#linkage-error">
+ *     Java Dependency Glossary: Linkage Error</a>
  */
 @AutoValue
-abstract class StaticLinkageError<T extends SymbolReference> {
+abstract class SymbolNotFound<T extends SymbolReference> {
 
-  /** Returns the symbol reference on which this linkage error occurred. */
+  /** Returns the symbol reference that could not be resolved. */
   abstract T getReference();
 
   /**
-   * Returns the location of the target class in the symbol reference; null if the target class is
-   * not found in the class path or the source location is unavailable.
+   * Returns the path to the class where symbol reference was expected to be found.
+   * This is null if the target class is not found in the class path or the source
+   * location is unavailable.
    */
   @Nullable
   abstract Path getTargetClassLocation();
@@ -68,8 +69,8 @@ abstract class StaticLinkageError<T extends SymbolReference> {
     return builder.toString();
   }
 
-  /** Returns a linkage error caused by {@link Reason#CLASS_NOT_FOUND}. */
-  static <U extends SymbolReference> StaticLinkageError<U> errorMissingTargetClass(
+  /** Returns a SymbolNotFound caused by {@link Reason#CLASS_NOT_FOUND}. */
+  static <U extends SymbolReference> SymbolNotFound<U> errorMissingTargetClass(
       U reference, boolean isReachable) {
     return builderFor(reference)
         .setReason(Reason.CLASS_NOT_FOUND)
@@ -77,8 +78,8 @@ abstract class StaticLinkageError<T extends SymbolReference> {
         .build();
   }
 
-  /** Returns a linkage error caused by {@link Reason#INCOMPATIBLE_CLASS_CHANGE}. */
-  static <U extends SymbolReference> StaticLinkageError<U> errorIncompatibleClassChange(
+  /** Returns a SymbolNotFound caused by {@link Reason#INCOMPATIBLE_CLASS_CHANGE}. */
+  static <U extends SymbolReference> SymbolNotFound<U> errorIncompatibleClassChange(
       U reference, Path targetClassLocation, boolean isReachable) {
     return builderFor(reference)
         .setReason(Reason.INCOMPATIBLE_CLASS_CHANGE)
@@ -87,8 +88,8 @@ abstract class StaticLinkageError<T extends SymbolReference> {
         .build();
   }
 
-  /** Returns a linkage error caused by {@link Reason#SYMBOL_NOT_FOUND}. */
-  static <U extends SymbolReference> StaticLinkageError<U> errorMissingMember(
+  /** Returns a SymbolNotFound caused by {@link Reason#SYMBOL_NOT_FOUND}. */
+  static <U extends SymbolReference> SymbolNotFound<U> errorMissingMember(
       U reference, Path targetClassLocation, boolean isReachable) {
     return builderFor(reference)
         .setReason(Reason.SYMBOL_NOT_FOUND)
@@ -97,8 +98,8 @@ abstract class StaticLinkageError<T extends SymbolReference> {
         .build();
   }
 
-  /** Returns a linkage error caused by {@link Reason#INACCESSIBLE_CLASS}. */
-  static <U extends SymbolReference> StaticLinkageError<U> errorInaccessibleClass(
+  /** Returns a SymbolNotFound caused by {@link Reason#INACCESSIBLE_CLASS}. */
+  static <U extends SymbolReference> SymbolNotFound<U> errorInaccessibleClass(
       U reference, Path targetClassLocation, boolean isReachable) {
     return builderFor(reference)
         .setReason(Reason.INACCESSIBLE_CLASS)
@@ -107,8 +108,8 @@ abstract class StaticLinkageError<T extends SymbolReference> {
         .build();
   }
 
-  /** Returns a linkage error caused by {@link Reason#INACCESSIBLE_MEMBER}. */
-  static <U extends SymbolReference> StaticLinkageError<U> errorInaccessibleMember(
+  /** Returns a SymbolNotFound caused by {@link Reason#INACCESSIBLE_MEMBER}. */
+  static <U extends SymbolReference> SymbolNotFound<U> errorInaccessibleMember(
       U reference, Path targetClassLocation, boolean isReachable) {
     return builderFor(reference)
         .setReason(Reason.INACCESSIBLE_MEMBER)
@@ -117,10 +118,13 @@ abstract class StaticLinkageError<T extends SymbolReference> {
         .build();
   }
 
-  /** Returns {@code Builder} for a linkage error that occurred at the symbol reference. */
+  /**
+   * Returns a {@code SymbolNotFound.Builder} for a linkage error that occurred at the symbol
+   * reference.
+   */
   private static <U extends SymbolReference> Builder<U> builderFor(U reference) {
     // This method gives type-safety compared with normal builder() method.
-    Builder<U> builder = new AutoValue_StaticLinkageError.Builder<>();
+    Builder<U> builder = new AutoValue_SymbolNotFound.Builder<>();
     builder.setReference(reference);
     return builder;
   }
@@ -128,18 +132,18 @@ abstract class StaticLinkageError<T extends SymbolReference> {
   @AutoValue.Builder
   abstract static class Builder<T extends SymbolReference> {
 
-    abstract StaticLinkageError.Builder<T> setTargetClassLocation(Path targetClassLocation);
+    abstract SymbolNotFound.Builder<T> setTargetClassLocation(Path targetClassLocation);
 
-    abstract StaticLinkageError.Builder<T> setReason(Reason reason);
+    abstract SymbolNotFound.Builder<T> setReason(Reason reason);
 
-    abstract StaticLinkageError.Builder<T> setReference(T reference);
+    abstract SymbolNotFound.Builder<T> setReference(T reference);
 
-    abstract StaticLinkageError.Builder<T> setReachable(boolean reachable);
+    abstract SymbolNotFound.Builder<T> setReachable(boolean reachable);
 
-    abstract StaticLinkageError<T> build();
+    abstract SymbolNotFound<T> build();
   }
 
-  /** Reason to distinguish the cause of a static linkage error against a symbol reference. */
+  /** The kind of static linkage error against a symbol reference. */
   enum Reason {
     /** The target class of the symbol reference is not found in the class path. */
     CLASS_NOT_FOUND,

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolNotResolvable.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolNotResolvable.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
  *     Java Dependency Glossary: Linkage Error</a>
  */
 @AutoValue
-abstract class SymbolNotFound<T extends SymbolReference> {
+abstract class SymbolNotResolvable<T extends SymbolReference> {
 
   /** Returns the symbol reference that could not be resolved. */
   abstract T getReference();
@@ -70,7 +70,7 @@ abstract class SymbolNotFound<T extends SymbolReference> {
   }
 
   /** Returns a SymbolNotFound caused by {@link Reason#CLASS_NOT_FOUND}. */
-  static <U extends SymbolReference> SymbolNotFound<U> errorMissingTargetClass(
+  static <U extends SymbolReference> SymbolNotResolvable<U> errorMissingTargetClass(
       U reference, boolean isReachable) {
     return builderFor(reference)
         .setReason(Reason.CLASS_NOT_FOUND)
@@ -79,7 +79,7 @@ abstract class SymbolNotFound<T extends SymbolReference> {
   }
 
   /** Returns a SymbolNotFound caused by {@link Reason#INCOMPATIBLE_CLASS_CHANGE}. */
-  static <U extends SymbolReference> SymbolNotFound<U> errorIncompatibleClassChange(
+  static <U extends SymbolReference> SymbolNotResolvable<U> errorIncompatibleClassChange(
       U reference, Path targetClassLocation, boolean isReachable) {
     return builderFor(reference)
         .setReason(Reason.INCOMPATIBLE_CLASS_CHANGE)
@@ -89,7 +89,7 @@ abstract class SymbolNotFound<T extends SymbolReference> {
   }
 
   /** Returns a SymbolNotFound caused by {@link Reason#SYMBOL_NOT_FOUND}. */
-  static <U extends SymbolReference> SymbolNotFound<U> errorMissingMember(
+  static <U extends SymbolReference> SymbolNotResolvable<U> errorMissingMember(
       U reference, Path targetClassLocation, boolean isReachable) {
     return builderFor(reference)
         .setReason(Reason.SYMBOL_NOT_FOUND)
@@ -99,7 +99,7 @@ abstract class SymbolNotFound<T extends SymbolReference> {
   }
 
   /** Returns a SymbolNotFound caused by {@link Reason#INACCESSIBLE_CLASS}. */
-  static <U extends SymbolReference> SymbolNotFound<U> errorInaccessibleClass(
+  static <U extends SymbolReference> SymbolNotResolvable<U> errorInaccessibleClass(
       U reference, Path targetClassLocation, boolean isReachable) {
     return builderFor(reference)
         .setReason(Reason.INACCESSIBLE_CLASS)
@@ -109,7 +109,7 @@ abstract class SymbolNotFound<T extends SymbolReference> {
   }
 
   /** Returns a SymbolNotFound caused by {@link Reason#INACCESSIBLE_MEMBER}. */
-  static <U extends SymbolReference> SymbolNotFound<U> errorInaccessibleMember(
+  static <U extends SymbolReference> SymbolNotResolvable<U> errorInaccessibleMember(
       U reference, Path targetClassLocation, boolean isReachable) {
     return builderFor(reference)
         .setReason(Reason.INACCESSIBLE_MEMBER)
@@ -124,7 +124,7 @@ abstract class SymbolNotFound<T extends SymbolReference> {
    */
   private static <U extends SymbolReference> Builder<U> builderFor(U reference) {
     // This method gives type-safety compared with normal builder() method.
-    Builder<U> builder = new AutoValue_SymbolNotFound.Builder<>();
+    Builder<U> builder = new AutoValue_SymbolNotResolvable.Builder<>();
     builder.setReference(reference);
     return builder;
   }
@@ -132,18 +132,18 @@ abstract class SymbolNotFound<T extends SymbolReference> {
   @AutoValue.Builder
   abstract static class Builder<T extends SymbolReference> {
 
-    abstract SymbolNotFound.Builder<T> setTargetClassLocation(Path targetClassLocation);
+    abstract SymbolNotResolvable.Builder<T> setTargetClassLocation(Path targetClassLocation);
 
-    abstract SymbolNotFound.Builder<T> setReason(Reason reason);
+    abstract SymbolNotResolvable.Builder<T> setReason(Reason reason);
 
-    abstract SymbolNotFound.Builder<T> setReference(T reference);
+    abstract SymbolNotResolvable.Builder<T> setReference(T reference);
 
-    abstract SymbolNotFound.Builder<T> setReachable(boolean reachable);
+    abstract SymbolNotResolvable.Builder<T> setReachable(boolean reachable);
 
-    abstract SymbolNotFound<T> build();
+    abstract SymbolNotResolvable<T> build();
   }
 
-  /** The kind of static linkage error against a symbol reference. */
+  /** The kind of linkage error against a symbol reference. */
   enum Reason {
     /** The target class of the symbol reference is not found in the class path. */
     CLASS_NOT_FOUND,

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckReportTest.java
@@ -40,9 +40,9 @@ public class ClasspathCheckReportTest {
             .setSubclass(false)
             .setSourceClassName("ClassB")
             .build();
-    SymbolNotFound<ClassSymbolReference> linkageErrorMissingClass =
-        SymbolNotFound.errorMissingTargetClass(classSymbolReference, true);
-    ImmutableList<SymbolNotFound<ClassSymbolReference>> missingClassErrors =
+    SymbolNotResolvable<ClassSymbolReference> linkageErrorMissingClass =
+        SymbolNotResolvable.errorMissingTargetClass(classSymbolReference, true);
+    ImmutableList<SymbolNotResolvable<ClassSymbolReference>> missingClassErrors =
         ImmutableList.of(linkageErrorMissingClass);
 
     MethodSymbolReference methodSymbolReference =
@@ -53,9 +53,9 @@ public class ClasspathCheckReportTest {
             .setDescriptor("java.lang.String")
             .setSourceClassName("ClassB")
             .build();
-    SymbolNotFound<MethodSymbolReference> linkageErrorMissingMethod =
-        SymbolNotFound.errorMissingMember(methodSymbolReference, null, true);
-    ImmutableList<SymbolNotFound<MethodSymbolReference>> missingMethodErrors =
+    SymbolNotResolvable<MethodSymbolReference> linkageErrorMissingMethod =
+        SymbolNotResolvable.errorMissingMember(methodSymbolReference, null, true);
+    ImmutableList<SymbolNotResolvable<MethodSymbolReference>> missingMethodErrors =
         ImmutableList.of(linkageErrorMissingMethod);
 
     FieldSymbolReference fieldSymbolReference =
@@ -64,9 +64,9 @@ public class ClasspathCheckReportTest {
             .setFieldName("fieldX")
             .setSourceClassName("ClassD")
             .build();
-    SymbolNotFound<FieldSymbolReference> linkageErrorMissingField =
-        SymbolNotFound.errorMissingMember(fieldSymbolReference, null, true);
-    ImmutableList<SymbolNotFound<FieldSymbolReference>> missingFieldErrors =
+    SymbolNotResolvable<FieldSymbolReference> linkageErrorMissingField =
+        SymbolNotResolvable.errorMissingMember(fieldSymbolReference, null, true);
+    ImmutableList<SymbolNotResolvable<FieldSymbolReference>> missingFieldErrors =
         ImmutableList.of(linkageErrorMissingField);
 
     jarLinkageReport =

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckReportTest.java
@@ -40,9 +40,9 @@ public class ClasspathCheckReportTest {
             .setSubclass(false)
             .setSourceClassName("ClassB")
             .build();
-    StaticLinkageError<ClassSymbolReference> linkageErrorMissingClass =
-        StaticLinkageError.errorMissingTargetClass(classSymbolReference, true);
-    ImmutableList<StaticLinkageError<ClassSymbolReference>> missingClassErrors =
+    SymbolNotFound<ClassSymbolReference> linkageErrorMissingClass =
+        SymbolNotFound.errorMissingTargetClass(classSymbolReference, true);
+    ImmutableList<SymbolNotFound<ClassSymbolReference>> missingClassErrors =
         ImmutableList.of(linkageErrorMissingClass);
 
     MethodSymbolReference methodSymbolReference =
@@ -53,9 +53,9 @@ public class ClasspathCheckReportTest {
             .setDescriptor("java.lang.String")
             .setSourceClassName("ClassB")
             .build();
-    StaticLinkageError<MethodSymbolReference> linkageErrorMissingMethod =
-        StaticLinkageError.errorMissingMember(methodSymbolReference, null, true);
-    ImmutableList<StaticLinkageError<MethodSymbolReference>> missingMethodErrors =
+    SymbolNotFound<MethodSymbolReference> linkageErrorMissingMethod =
+        SymbolNotFound.errorMissingMember(methodSymbolReference, null, true);
+    ImmutableList<SymbolNotFound<MethodSymbolReference>> missingMethodErrors =
         ImmutableList.of(linkageErrorMissingMethod);
 
     FieldSymbolReference fieldSymbolReference =
@@ -64,9 +64,9 @@ public class ClasspathCheckReportTest {
             .setFieldName("fieldX")
             .setSourceClassName("ClassD")
             .build();
-    StaticLinkageError<FieldSymbolReference> linkageErrorMissingField =
-        StaticLinkageError.errorMissingMember(fieldSymbolReference, null, true);
-    ImmutableList<StaticLinkageError<FieldSymbolReference>> missingFieldErrors =
+    SymbolNotFound<FieldSymbolReference> linkageErrorMissingField =
+        SymbolNotFound.errorMissingMember(fieldSymbolReference, null, true);
+    ImmutableList<SymbolNotFound<FieldSymbolReference>> missingFieldErrors =
         ImmutableList.of(linkageErrorMissingField);
 
     jarLinkageReport =

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckerTest.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.opensource.classpath;
 import static com.google.cloud.tools.opensource.classpath.ClassPathBuilderTest.PATH_FILE_NAMES;
 import static com.google.cloud.tools.opensource.classpath.TestHelper.absolutePathOfResource;
 
-import com.google.cloud.tools.opensource.classpath.SymbolNotFound.Reason;
+import com.google.cloud.tools.opensource.classpath.SymbolNotResolvable.Reason;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -120,7 +120,7 @@ public class ClasspathCheckerTest {
             .setDescriptor("(I)Ljava/lang/Object;")
             .build();
     // When it's verified against interfaces, it should generate an error
-    Optional<SymbolNotFound<MethodSymbolReference>> errorFound =
+    Optional<SymbolNotResolvable<MethodSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isPresent();
@@ -143,7 +143,7 @@ public class ClasspathCheckerTest {
             .setDescriptor("(Ljava/lang/Class;)Ljava/lang/Object;")
             .build();
     // When it's verified against classes, it should generate an error
-    Optional<SymbolNotFound<MethodSymbolReference>> errorFound =
+    Optional<SymbolNotResolvable<MethodSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isPresent();
@@ -166,7 +166,7 @@ public class ClasspathCheckerTest {
             .setDescriptor("(Ljava/lang/Class;)Ljava/lang/Object;")
             .build();
     // There is no such method on ClassToInstanceMap
-    Optional<SymbolNotFound<MethodSymbolReference>> errorFound =
+    Optional<SymbolNotResolvable<MethodSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isPresent();
@@ -188,7 +188,7 @@ public class ClasspathCheckerTest {
             .setMethodName("get")
             .setDescriptor("(I)Ljava/lang/Object;")
             .build();
-    Optional<SymbolNotFound<MethodSymbolReference>> errorFound =
+    Optional<SymbolNotResolvable<MethodSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isEmpty();
@@ -211,7 +211,7 @@ public class ClasspathCheckerTest {
             .setDescriptor("()V")
             .build();
 
-    Optional<SymbolNotFound<MethodSymbolReference>> errorFound =
+    Optional<SymbolNotResolvable<MethodSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isPresent();
@@ -238,7 +238,7 @@ public class ClasspathCheckerTest {
             .setDescriptor("()V")
             .build();
 
-    Optional<SymbolNotFound<MethodSymbolReference>> errorFound =
+    Optional<SymbolNotResolvable<MethodSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     // JLS 6.6.2.2 says
@@ -264,7 +264,7 @@ public class ClasspathCheckerTest {
             .setDescriptor("()Ljava/lang/Object;")
             .build();
 
-    Optional<SymbolNotFound<MethodSymbolReference>> errorFound =
+    Optional<SymbolNotResolvable<MethodSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isPresent();
@@ -288,7 +288,7 @@ public class ClasspathCheckerTest {
             .setDescriptor("(C)I") // private static int getAlphaIndex(char);
             .build();
 
-    Optional<SymbolNotFound<MethodSymbolReference>> errorFound =
+    Optional<SymbolNotResolvable<MethodSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingMethodAt(privateStaticReference);
 
     Truth8.assertThat(errorFound).isPresent();
@@ -369,7 +369,7 @@ public class ClasspathCheckerTest {
             .build();
 
     // There should be an error reported for the reference
-    Optional<SymbolNotFound<ClassSymbolReference>> classSymbolError =
+    Optional<SymbolNotResolvable<ClassSymbolReference>> classSymbolError =
         classpathChecker.checkLinkageErrorMissingClassAt(invalidClassReference);
     Truth8.assertThat(classSymbolError).isPresent();
     Truth.assertThat(classSymbolError.get().getReference()).isEqualTo(invalidClassReference);
@@ -392,7 +392,7 @@ public class ClasspathCheckerTest {
             .build();
 
     // There should not be an error reported for the reference
-    Optional<SymbolNotFound<ClassSymbolReference>> classSymbolError =
+    Optional<SymbolNotResolvable<ClassSymbolReference>> classSymbolError =
         classpathChecker.checkLinkageErrorMissingClassAt(invalidClassReference);
     Truth8.assertThat(classSymbolError).isEmpty();
   }
@@ -412,7 +412,7 @@ public class ClasspathCheckerTest {
             .setTargetClassName("com.google.firestore.v1beta1.FirestoreGrpc")
             .build();
 
-    Optional<SymbolNotFound<ClassSymbolReference>> classSymbolError =
+    Optional<SymbolNotResolvable<ClassSymbolReference>> classSymbolError =
         classpathChecker.checkLinkageErrorMissingClassAt(invalidClassReference);
     Truth8.assertThat(classSymbolError).isPresent();
     Truth.assertThat(classSymbolError.get().getReason())
@@ -439,7 +439,7 @@ public class ClasspathCheckerTest {
             .setTargetClassName("org.objectweb.asm.ClassWriter")
             .build();
 
-    Optional<SymbolNotFound<ClassSymbolReference>> classSymbolError =
+    Optional<SymbolNotResolvable<ClassSymbolReference>> classSymbolError =
         classpathChecker.checkLinkageErrorMissingClassAt(invalidClassReference);
     Truth8.assertThat(classSymbolError).isPresent();
     Truth.assertWithMessage(
@@ -460,7 +460,7 @@ public class ClasspathCheckerTest {
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/api-common-1.7.0.jar"));
     ClasspathChecker classpathChecker = ClasspathChecker.create(paths, paths);
 
-    Optional<SymbolNotFound<FieldSymbolReference>> errorFound =
+    Optional<SymbolNotResolvable<FieldSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingFieldAt(privateFieldReference);
 
     Truth8.assertThat(errorFound).isPresent();
@@ -491,11 +491,11 @@ public class ClasspathCheckerTest {
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/guava-23.5-jre.jar"));
     ClasspathChecker classpathChecker = ClasspathChecker.create(paths, paths);
 
-    Optional<SymbolNotFound<FieldSymbolReference>> errorOnSamePackage =
+    Optional<SymbolNotResolvable<FieldSymbolReference>> errorOnSamePackage =
         classpathChecker.checkLinkageErrorMissingFieldAt(accessFromSamePackage);
     Truth8.assertThat(errorOnSamePackage).isEmpty();
 
-    Optional<SymbolNotFound<FieldSymbolReference>> errorOnDifferentPackage =
+    Optional<SymbolNotResolvable<FieldSymbolReference>> errorOnDifferentPackage =
         classpathChecker.checkLinkageErrorMissingFieldAt(accessFromDifferentPackage);
     Truth8.assertThat(errorOnDifferentPackage).isPresent();
 
@@ -522,7 +522,7 @@ public class ClasspathCheckerTest {
 
     // Because StringCharSource is in the same package, the source class is not suitable
     // for this class.
-    Optional<SymbolNotFound<FieldSymbolReference>> errorFound =
+    Optional<SymbolNotResolvable<FieldSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingFieldAt(referenceFromSubclass);
     Truth8.assertThat(errorFound).isEmpty();
   }
@@ -610,7 +610,7 @@ public class ClasspathCheckerTest {
             symbolReferenceSet);
 
     Truth.assertThat(jarLinkageReport.getMissingClassErrors()).hasSize(1);
-    SymbolNotFound<ClassSymbolReference> classReferenceError =
+    SymbolNotResolvable<ClassSymbolReference> classReferenceError =
         jarLinkageReport.getMissingClassErrors().get(0);
     Truth.assertThat(classReferenceError.getReason()).isEqualTo(Reason.INACCESSIBLE_CLASS);
     Truth.assertWithMessage(

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClasspathCheckerTest.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.opensource.classpath;
 import static com.google.cloud.tools.opensource.classpath.ClassPathBuilderTest.PATH_FILE_NAMES;
 import static com.google.cloud.tools.opensource.classpath.TestHelper.absolutePathOfResource;
 
-import com.google.cloud.tools.opensource.classpath.StaticLinkageError.Reason;
+import com.google.cloud.tools.opensource.classpath.SymbolNotFound.Reason;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -120,7 +120,7 @@ public class ClasspathCheckerTest {
             .setDescriptor("(I)Ljava/lang/Object;")
             .build();
     // When it's verified against interfaces, it should generate an error
-    Optional<StaticLinkageError<MethodSymbolReference>> errorFound =
+    Optional<SymbolNotFound<MethodSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isPresent();
@@ -143,7 +143,7 @@ public class ClasspathCheckerTest {
             .setDescriptor("(Ljava/lang/Class;)Ljava/lang/Object;")
             .build();
     // When it's verified against classes, it should generate an error
-    Optional<StaticLinkageError<MethodSymbolReference>> errorFound =
+    Optional<SymbolNotFound<MethodSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isPresent();
@@ -166,7 +166,7 @@ public class ClasspathCheckerTest {
             .setDescriptor("(Ljava/lang/Class;)Ljava/lang/Object;")
             .build();
     // There is no such method on ClassToInstanceMap
-    Optional<StaticLinkageError<MethodSymbolReference>> errorFound =
+    Optional<SymbolNotFound<MethodSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isPresent();
@@ -188,7 +188,7 @@ public class ClasspathCheckerTest {
             .setMethodName("get")
             .setDescriptor("(I)Ljava/lang/Object;")
             .build();
-    Optional<StaticLinkageError<MethodSymbolReference>> errorFound =
+    Optional<SymbolNotFound<MethodSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isEmpty();
@@ -211,7 +211,7 @@ public class ClasspathCheckerTest {
             .setDescriptor("()V")
             .build();
 
-    Optional<StaticLinkageError<MethodSymbolReference>> errorFound =
+    Optional<SymbolNotFound<MethodSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isPresent();
@@ -238,7 +238,7 @@ public class ClasspathCheckerTest {
             .setDescriptor("()V")
             .build();
 
-    Optional<StaticLinkageError<MethodSymbolReference>> errorFound =
+    Optional<SymbolNotFound<MethodSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     // JLS 6.6.2.2 says
@@ -264,7 +264,7 @@ public class ClasspathCheckerTest {
             .setDescriptor("()Ljava/lang/Object;")
             .build();
 
-    Optional<StaticLinkageError<MethodSymbolReference>> errorFound =
+    Optional<SymbolNotFound<MethodSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingMethodAt(methodSymbolReference);
 
     Truth8.assertThat(errorFound).isPresent();
@@ -288,7 +288,7 @@ public class ClasspathCheckerTest {
             .setDescriptor("(C)I") // private static int getAlphaIndex(char);
             .build();
 
-    Optional<StaticLinkageError<MethodSymbolReference>> errorFound =
+    Optional<SymbolNotFound<MethodSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingMethodAt(privateStaticReference);
 
     Truth8.assertThat(errorFound).isPresent();
@@ -369,7 +369,7 @@ public class ClasspathCheckerTest {
             .build();
 
     // There should be an error reported for the reference
-    Optional<StaticLinkageError<ClassSymbolReference>> classSymbolError =
+    Optional<SymbolNotFound<ClassSymbolReference>> classSymbolError =
         classpathChecker.checkLinkageErrorMissingClassAt(invalidClassReference);
     Truth8.assertThat(classSymbolError).isPresent();
     Truth.assertThat(classSymbolError.get().getReference()).isEqualTo(invalidClassReference);
@@ -392,7 +392,7 @@ public class ClasspathCheckerTest {
             .build();
 
     // There should not be an error reported for the reference
-    Optional<StaticLinkageError<ClassSymbolReference>> classSymbolError =
+    Optional<SymbolNotFound<ClassSymbolReference>> classSymbolError =
         classpathChecker.checkLinkageErrorMissingClassAt(invalidClassReference);
     Truth8.assertThat(classSymbolError).isEmpty();
   }
@@ -412,7 +412,7 @@ public class ClasspathCheckerTest {
             .setTargetClassName("com.google.firestore.v1beta1.FirestoreGrpc")
             .build();
 
-    Optional<StaticLinkageError<ClassSymbolReference>> classSymbolError =
+    Optional<SymbolNotFound<ClassSymbolReference>> classSymbolError =
         classpathChecker.checkLinkageErrorMissingClassAt(invalidClassReference);
     Truth8.assertThat(classSymbolError).isPresent();
     Truth.assertThat(classSymbolError.get().getReason())
@@ -439,7 +439,7 @@ public class ClasspathCheckerTest {
             .setTargetClassName("org.objectweb.asm.ClassWriter")
             .build();
 
-    Optional<StaticLinkageError<ClassSymbolReference>> classSymbolError =
+    Optional<SymbolNotFound<ClassSymbolReference>> classSymbolError =
         classpathChecker.checkLinkageErrorMissingClassAt(invalidClassReference);
     Truth8.assertThat(classSymbolError).isPresent();
     Truth.assertWithMessage(
@@ -460,7 +460,7 @@ public class ClasspathCheckerTest {
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/api-common-1.7.0.jar"));
     ClasspathChecker classpathChecker = ClasspathChecker.create(paths, paths);
 
-    Optional<StaticLinkageError<FieldSymbolReference>> errorFound =
+    Optional<SymbolNotFound<FieldSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingFieldAt(privateFieldReference);
 
     Truth8.assertThat(errorFound).isPresent();
@@ -491,11 +491,11 @@ public class ClasspathCheckerTest {
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/guava-23.5-jre.jar"));
     ClasspathChecker classpathChecker = ClasspathChecker.create(paths, paths);
 
-    Optional<StaticLinkageError<FieldSymbolReference>> errorOnSamePackage =
+    Optional<SymbolNotFound<FieldSymbolReference>> errorOnSamePackage =
         classpathChecker.checkLinkageErrorMissingFieldAt(accessFromSamePackage);
     Truth8.assertThat(errorOnSamePackage).isEmpty();
 
-    Optional<StaticLinkageError<FieldSymbolReference>> errorOnDifferentPackage =
+    Optional<SymbolNotFound<FieldSymbolReference>> errorOnDifferentPackage =
         classpathChecker.checkLinkageErrorMissingFieldAt(accessFromDifferentPackage);
     Truth8.assertThat(errorOnDifferentPackage).isPresent();
 
@@ -522,7 +522,7 @@ public class ClasspathCheckerTest {
 
     // Because StringCharSource is in the same package, the source class is not suitable
     // for this class.
-    Optional<StaticLinkageError<FieldSymbolReference>> errorFound =
+    Optional<SymbolNotFound<FieldSymbolReference>> errorFound =
         classpathChecker.checkLinkageErrorMissingFieldAt(referenceFromSubclass);
     Truth8.assertThat(errorFound).isEmpty();
   }
@@ -610,7 +610,7 @@ public class ClasspathCheckerTest {
             symbolReferenceSet);
 
     Truth.assertThat(jarLinkageReport.getMissingClassErrors()).hasSize(1);
-    StaticLinkageError<ClassSymbolReference> classReferenceError =
+    SymbolNotFound<ClassSymbolReference> classReferenceError =
         jarLinkageReport.getMissingClassErrors().get(0);
     Truth.assertThat(classReferenceError.getReason()).isEqualTo(Reason.INACCESSIBLE_CLASS);
     Truth.assertWithMessage(

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
@@ -30,10 +30,10 @@ import org.junit.Test;
 public class JarLinkageReportTest {
 
   private JarLinkageReport jarLinkageReport;
-  private ImmutableList<SymbolNotFound<FieldSymbolReference>> missingFieldErrors;
-  private ImmutableList<SymbolNotFound<MethodSymbolReference>> missingMethodErrors;
-  private ImmutableList<SymbolNotFound<ClassSymbolReference>> missingClassErrors;
-  private SymbolNotFound<MethodSymbolReference> linkageErrorMissingMethod;
+  private ImmutableList<SymbolNotResolvable<FieldSymbolReference>> missingFieldErrors;
+  private ImmutableList<SymbolNotResolvable<MethodSymbolReference>> missingMethodErrors;
+  private ImmutableList<SymbolNotResolvable<ClassSymbolReference>> missingClassErrors;
+  private SymbolNotResolvable<MethodSymbolReference> linkageErrorMissingMethod;
 
   @Before
   public void setUp() {
@@ -45,8 +45,8 @@ public class JarLinkageReportTest {
             .setSourceClassName("ClassB")
             .build();
 
-    SymbolNotFound<ClassSymbolReference> linkageErrorMissingClass =
-        SymbolNotFound.errorMissingTargetClass(classSymbolReference, true);
+    SymbolNotResolvable<ClassSymbolReference> linkageErrorMissingClass =
+        SymbolNotResolvable.errorMissingTargetClass(classSymbolReference, true);
     missingClassErrors = ImmutableList.of(linkageErrorMissingClass);
 
     MethodSymbolReference methodSymbolReference =
@@ -59,7 +59,7 @@ public class JarLinkageReportTest {
             .build();
     Path targetClassLocation = Paths.get("dummy.jar");
     linkageErrorMissingMethod =
-        SymbolNotFound.errorMissingMember(methodSymbolReference, targetClassLocation, true);
+        SymbolNotResolvable.errorMissingMember(methodSymbolReference, targetClassLocation, true);
 
     MethodSymbolReference methodSymbolReferenceDueToMissingClass =
         MethodSymbolReference.builder()
@@ -69,8 +69,8 @@ public class JarLinkageReportTest {
             .setDescriptor("java.lang.String")
             .setSourceClassName("ClassC$InnerC")
             .build();
-    SymbolNotFound<MethodSymbolReference> linkageErrorMissingMethodByClass =
-        SymbolNotFound.errorMissingTargetClass(methodSymbolReferenceDueToMissingClass, false);
+    SymbolNotResolvable<MethodSymbolReference> linkageErrorMissingMethodByClass =
+        SymbolNotResolvable.errorMissingTargetClass(methodSymbolReferenceDueToMissingClass, false);
 
     missingMethodErrors =
         ImmutableList.of(linkageErrorMissingMethod, linkageErrorMissingMethodByClass);
@@ -81,8 +81,8 @@ public class JarLinkageReportTest {
             .setFieldName("fieldX")
             .setSourceClassName("ClassD")
             .build();
-    SymbolNotFound<FieldSymbolReference> linkageErrorMissingField =
-        SymbolNotFound.errorMissingTargetClass(fieldSymbolReference, true);
+    SymbolNotResolvable<FieldSymbolReference> linkageErrorMissingField =
+        SymbolNotResolvable.errorMissingTargetClass(fieldSymbolReference, true);
     missingFieldErrors = ImmutableList.of(linkageErrorMissingField);
     jarLinkageReport =
         JarLinkageReport.builder()

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
@@ -30,10 +30,10 @@ import org.junit.Test;
 public class JarLinkageReportTest {
 
   private JarLinkageReport jarLinkageReport;
-  private ImmutableList<StaticLinkageError<FieldSymbolReference>> missingFieldErrors;
-  private ImmutableList<StaticLinkageError<MethodSymbolReference>> missingMethodErrors;
-  private ImmutableList<StaticLinkageError<ClassSymbolReference>> missingClassErrors;
-  private StaticLinkageError<MethodSymbolReference> linkageErrorMissingMethod;
+  private ImmutableList<SymbolNotFound<FieldSymbolReference>> missingFieldErrors;
+  private ImmutableList<SymbolNotFound<MethodSymbolReference>> missingMethodErrors;
+  private ImmutableList<SymbolNotFound<ClassSymbolReference>> missingClassErrors;
+  private SymbolNotFound<MethodSymbolReference> linkageErrorMissingMethod;
 
   @Before
   public void setUp() {
@@ -45,8 +45,8 @@ public class JarLinkageReportTest {
             .setSourceClassName("ClassB")
             .build();
 
-    StaticLinkageError<ClassSymbolReference> linkageErrorMissingClass =
-        StaticLinkageError.errorMissingTargetClass(classSymbolReference, true);
+    SymbolNotFound<ClassSymbolReference> linkageErrorMissingClass =
+        SymbolNotFound.errorMissingTargetClass(classSymbolReference, true);
     missingClassErrors = ImmutableList.of(linkageErrorMissingClass);
 
     MethodSymbolReference methodSymbolReference =
@@ -59,7 +59,7 @@ public class JarLinkageReportTest {
             .build();
     Path targetClassLocation = Paths.get("dummy.jar");
     linkageErrorMissingMethod =
-        StaticLinkageError.errorMissingMember(methodSymbolReference, targetClassLocation, true);
+        SymbolNotFound.errorMissingMember(methodSymbolReference, targetClassLocation, true);
 
     MethodSymbolReference methodSymbolReferenceDueToMissingClass =
         MethodSymbolReference.builder()
@@ -69,8 +69,8 @@ public class JarLinkageReportTest {
             .setDescriptor("java.lang.String")
             .setSourceClassName("ClassC$InnerC")
             .build();
-    StaticLinkageError<MethodSymbolReference> linkageErrorMissingMethodByClass =
-        StaticLinkageError.errorMissingTargetClass(methodSymbolReferenceDueToMissingClass, false);
+    SymbolNotFound<MethodSymbolReference> linkageErrorMissingMethodByClass =
+        SymbolNotFound.errorMissingTargetClass(methodSymbolReferenceDueToMissingClass, false);
 
     missingMethodErrors =
         ImmutableList.of(linkageErrorMissingMethod, linkageErrorMissingMethodByClass);
@@ -81,8 +81,8 @@ public class JarLinkageReportTest {
             .setFieldName("fieldX")
             .setSourceClassName("ClassD")
             .build();
-    StaticLinkageError<FieldSymbolReference> linkageErrorMissingField =
-        StaticLinkageError.errorMissingTargetClass(fieldSymbolReference, true);
+    SymbolNotFound<FieldSymbolReference> linkageErrorMissingField =
+        SymbolNotFound.errorMissingTargetClass(fieldSymbolReference, true);
     missingFieldErrors = ImmutableList.of(linkageErrorMissingField);
     jarLinkageReport =
         JarLinkageReport.builder()

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageErrorCauseTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageErrorCauseTest.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-import com.google.cloud.tools.opensource.classpath.SymbolNotFound.Reason;
+import com.google.cloud.tools.opensource.classpath.SymbolNotResolvable.Reason;
 import com.google.common.truth.Truth;
 import org.junit.Test;
 
@@ -31,8 +31,8 @@ public class LinkageErrorCauseTest {
             .setSourceClassName("ClassD")
             .build();
 
-    SymbolNotFound<FieldSymbolReference> fieldError =
-        SymbolNotFound.errorMissingTargetClass(fieldSymbolReference, true);
+    SymbolNotResolvable<FieldSymbolReference> fieldError =
+        SymbolNotResolvable.errorMissingTargetClass(fieldSymbolReference, true);
 
     LinkageErrorCause groupKey = LinkageErrorCause.from(fieldError);
     Truth.assertThat(groupKey.getReason()).isEqualTo(Reason.CLASS_NOT_FOUND);

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageErrorCauseTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageErrorCauseTest.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-import com.google.cloud.tools.opensource.classpath.StaticLinkageError.Reason;
+import com.google.cloud.tools.opensource.classpath.SymbolNotFound.Reason;
 import com.google.common.truth.Truth;
 import org.junit.Test;
 
@@ -31,8 +31,8 @@ public class LinkageErrorCauseTest {
             .setSourceClassName("ClassD")
             .build();
 
-    StaticLinkageError<FieldSymbolReference> fieldError =
-        StaticLinkageError.errorMissingTargetClass(fieldSymbolReference, true);
+    SymbolNotFound<FieldSymbolReference> fieldError =
+        SymbolNotFound.errorMissingTargetClass(fieldSymbolReference, true);
 
     LinkageErrorCause groupKey = LinkageErrorCause.from(fieldError);
     Truth.assertThat(groupKey.getReason()).isEqualTo(Reason.CLASS_NOT_FOUND);

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolNotFoundTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolNotFoundTest.java
@@ -16,13 +16,13 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-import com.google.cloud.tools.opensource.classpath.StaticLinkageError.Reason;
+import com.google.cloud.tools.opensource.classpath.SymbolNotFound.Reason;
 import com.google.common.truth.Truth;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Test;
 
-public class StaticLinkageErrorTest {
+public class SymbolNotFoundTest {
 
   @Test
   public void testLinkageErrorCreation() {
@@ -33,8 +33,8 @@ public class StaticLinkageErrorTest {
             .setSourceClassName("ClassD")
             .build();
 
-    StaticLinkageError<FieldSymbolReference> fieldError =
-        StaticLinkageError.errorMissingTargetClass(fieldSymbolReference, true);
+    SymbolNotFound<FieldSymbolReference> fieldError =
+        SymbolNotFound.errorMissingTargetClass(fieldSymbolReference, true);
     Truth.assertThat(fieldError.getReference()).isEqualTo(fieldSymbolReference);
 
     MethodSymbolReference methodSymbolReference =
@@ -47,8 +47,8 @@ public class StaticLinkageErrorTest {
             .build();
 
     Path targetClassLocation = Paths.get("foo", "bar");
-    StaticLinkageError<MethodSymbolReference> methodError =
-        StaticLinkageError.errorMissingMember(methodSymbolReference, targetClassLocation, true);
+    SymbolNotFound<MethodSymbolReference> methodError =
+        SymbolNotFound.errorMissingMember(methodSymbolReference, targetClassLocation, true);
     Truth.assertThat((Object) methodError.getTargetClassLocation()).isEqualTo(targetClassLocation);
 
     ClassSymbolReference classSymbolReference =
@@ -57,8 +57,8 @@ public class StaticLinkageErrorTest {
             .setSubclass(false)
             .setSourceClassName("ClassB")
             .build();
-    StaticLinkageError<ClassSymbolReference> classError =
-        StaticLinkageError.errorInaccessibleClass(classSymbolReference, targetClassLocation, true);
+    SymbolNotFound<ClassSymbolReference> classError =
+        SymbolNotFound.errorInaccessibleClass(classSymbolReference, targetClassLocation, true);
     Truth.assertThat(classError.getReason()).isEqualTo(Reason.INACCESSIBLE_CLASS);
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolNotFoundTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolNotFoundTest.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-import com.google.cloud.tools.opensource.classpath.SymbolNotFound.Reason;
+import com.google.cloud.tools.opensource.classpath.SymbolNotResolvable.Reason;
 import com.google.common.truth.Truth;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -33,8 +33,8 @@ public class SymbolNotFoundTest {
             .setSourceClassName("ClassD")
             .build();
 
-    SymbolNotFound<FieldSymbolReference> fieldError =
-        SymbolNotFound.errorMissingTargetClass(fieldSymbolReference, true);
+    SymbolNotResolvable<FieldSymbolReference> fieldError =
+        SymbolNotResolvable.errorMissingTargetClass(fieldSymbolReference, true);
     Truth.assertThat(fieldError.getReference()).isEqualTo(fieldSymbolReference);
 
     MethodSymbolReference methodSymbolReference =
@@ -47,8 +47,8 @@ public class SymbolNotFoundTest {
             .build();
 
     Path targetClassLocation = Paths.get("foo", "bar");
-    SymbolNotFound<MethodSymbolReference> methodError =
-        SymbolNotFound.errorMissingMember(methodSymbolReference, targetClassLocation, true);
+    SymbolNotResolvable<MethodSymbolReference> methodError =
+        SymbolNotResolvable.errorMissingMember(methodSymbolReference, targetClassLocation, true);
     Truth.assertThat((Object) methodError.getTargetClassLocation()).isEqualTo(targetClassLocation);
 
     ClassSymbolReference classSymbolReference =
@@ -57,8 +57,8 @@ public class SymbolNotFoundTest {
             .setSubclass(false)
             .setSourceClassName("ClassB")
             .build();
-    SymbolNotFound<ClassSymbolReference> classError =
-        SymbolNotFound.errorInaccessibleClass(classSymbolReference, targetClassLocation, true);
+    SymbolNotResolvable<ClassSymbolReference> classError =
+        SymbolNotResolvable.errorInaccessibleClass(classSymbolReference, targetClassLocation, true);
     Truth.assertThat(classError.getReason()).isEqualTo(Reason.INACCESSIBLE_CLASS);
   }
 }


### PR DESCRIPTION
@suztomo Rename StaticLinkageError since:

1. This class is not a java.lang.Error, much less a java.lang.LinkageError
2. We're no longer calling this a "static" linkage error. 