### PR TITLE
Uncomment FreemarkerTest cleanup code

### DIFF
--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -93,7 +93,7 @@ public class DashboardTest {
   @AfterClass
   public static void cleanUp() {
     try {
-      MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
+      MoreFiles.deleteRecursively(outputDirectory);
     } catch (IOException ex) {
       // no big deal
     }

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -64,7 +64,7 @@ public class DashboardUnavailableArtifactTest {
 
   @AfterClass
   public static void cleanUp() throws IOException {
-    MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
+    MoreFiles.deleteRecursively(outputDirectory);
   }
 
   @Test

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -35,6 +35,8 @@ import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
+import com.google.common.io.MoreFiles;
+import com.google.common.io.RecursiveDeleteOption;
 import com.google.common.truth.Truth;
 
 import freemarker.template.Configuration;
@@ -61,7 +63,7 @@ public class FreemarkerTest {
 
   @AfterClass
   public static void cleanUp() throws IOException {
-    // MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
+    MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
   }
 
   @Test

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -63,7 +63,7 @@ public class FreemarkerTest {
 
   @AfterClass
   public static void cleanUp() throws IOException {
-    MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
+    MoreFiles.deleteRecursively(outputDirectory);
   }
 
   @Test


### PR DESCRIPTION
Fixes #448 . It was accidentally commented out when I was checking the output html.

- uncomment the directory cleanup
- removed ALLOW_INSECURE option when the tests do cleanup. As per [Javadoc](https://google.github.io/guava/releases/21.0/api/docs/com/google/common/io/RecursiveDeleteOption.html#ALLOW_INSECURE), ALLOW_INSECURE is for symbolic links on (insecure) file systems. 
This test does not use symbolic links.