### PR TITLE
To include transitive dependencies in mock test

### DIFF
--- a/enforcer-rules/src/test/java/com/google/cloud/tools/opensource/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/opensource/enforcer/LinkageCheckerRuleTest.java
@@ -89,8 +89,7 @@ public class LinkageCheckerRuleTest {
   }
 
   /**
-   * Returns a list of {@link Dependency}s resolved from {@link Artifact} of {@code coordinates}
-   * with the file in local Maven repository.
+   * Returns a list of {@link Dependency}s resolved from {@link Artifact} of {@code coordinates}.
    */
   private ImmutableList<Dependency> createResolvedDependency(String coordinates)
       throws RepositoryException {


### PR DESCRIPTION
Fixes #469.

Previously `LinkageCheckerRuleTest.createResolvedDependency` was not returning transitive dependencies. This change is to populate transitive dependencies in the mock objects.

This bug was hidden in guava-26 as guava-26 does not require transitive dependencies. Since Guava 27, guava requires transitive dependency to `failureaccess` artifact.