### PR TITLE
LinkageCheckerRule not to use readBom which uses LocalRepository

### DIFF
--- a/enforcer-rules/src/main/java/com/google/cloud/tools/opensource/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/opensource/enforcer/LinkageCheckerRule.java
@@ -165,11 +165,10 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
 
     ArtifactTypeRegistry artifactTypeRegistry = repositorySystemSession.getArtifactTypeRegistry();
     try {
-
       ImmutableList<Artifact> artifacts =
           bomProject.getDependencyManagement().getDependencies().stream()
               .map(dependency -> RepositoryUtils.toDependency(dependency, artifactTypeRegistry))
-              .map(dependency -> dependency.getArtifact())
+              .map(Dependency::getArtifact)
               .filter(artifact -> !shouldSkipBomMember(artifact))
               .collect(toImmutableList());
       return ClassPathBuilder.artifactsToClasspath(artifacts);

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/opensource/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/opensource/enforcer/LinkageCheckerRuleTest.java
@@ -89,8 +89,7 @@ public class LinkageCheckerRuleTest {
   }
 
   /**
-   * Returns a list of {@link Dependency}s resolved from {@link Artifact} of {@code coordinates}
-   * with the file in local Maven repository.
+   * Returns a list of {@link Dependency}s resolved from {@link Artifact} of {@code coordinates}.
    */
   private ImmutableList<Dependency> createResolvedDependency(String coordinates)
       throws RepositoryException {


### PR DESCRIPTION
Fixes #457 . With the following change, now we have non-trivial test cases for LinkageCheckerRule checking a BOM.

Before this commit, LinkageCheckerRule was using `RepositoryUtility.readBom` to get the content of BOM project, which in turn asks a local repository. This required that the BOM is installed in local repository. This was unnecessary and was preventing from writing simple unit tests.

With this commit, LinkageCheckerRule reads BOM content through `MavenProject.getDependencyManagement()` without asking a repository. `RepositoryUtility.readBom` has special logic to skip artifacts, which now available as a public method `shouldSkipBomMember`.