### PR TITLE
Reverting the removal of ALLOW_INSECURE

### DIFF
--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -93,7 +93,7 @@ public class DashboardTest {
   @AfterClass
   public static void cleanUp() {
     try {
-      MoreFiles.deleteRecursively(outputDirectory);
+      MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
     } catch (IOException ex) {
       // no big deal
     }

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -93,6 +93,8 @@ public class DashboardTest {
   @AfterClass
   public static void cleanUp() {
     try {
+      // Mac's APFS fails with InsecureRecursiveDeleteException without ALLOW_INSECURE.
+      // Still safe as this test does not use symbolic links
       MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
     } catch (IOException ex) {
       // no big deal

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -16,31 +16,6 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
-import freemarker.template.Configuration;
-import freemarker.template.TemplateException;
-import nu.xom.Builder;
-import nu.xom.Document;
-import nu.xom.Element;
-import nu.xom.Nodes;
-import nu.xom.ParsingException;
-
-import org.eclipse.aether.RepositoryException;
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.DefaultArtifact;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.google.cloud.tools.opensource.classpath.JarLinkageReport;
 import com.google.cloud.tools.opensource.classpath.LinkageCheckReport;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
@@ -50,6 +25,28 @@ import com.google.common.collect.LinkedListMultimap;
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
 import com.google.common.truth.Truth;
+import freemarker.template.Configuration;
+import freemarker.template.TemplateException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import nu.xom.Builder;
+import nu.xom.Document;
+import nu.xom.Element;
+import nu.xom.Nodes;
+import nu.xom.ParsingException;
+import org.eclipse.aether.RepositoryException;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 
 public class DashboardUnavailableArtifactTest {
@@ -64,6 +61,8 @@ public class DashboardUnavailableArtifactTest {
 
   @AfterClass
   public static void cleanUp() throws IOException {
+    // Mac's APFS fails with InsecureRecursiveDeleteException without ALLOW_INSECURE.
+    // Still safe as this test does not use symbolic links
     MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
   }
 

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
-import com.google.cloud.tools.opensource.classpath.LinkageCheckReport;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -43,11 +42,13 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.cloud.tools.opensource.classpath.JarLinkageReport;
+import com.google.cloud.tools.opensource.classpath.LinkageCheckReport;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.io.MoreFiles;
+import com.google.common.io.RecursiveDeleteOption;
 import com.google.common.truth.Truth;
 
 
@@ -63,7 +64,7 @@ public class DashboardUnavailableArtifactTest {
 
   @AfterClass
   public static void cleanUp() throws IOException {
-    MoreFiles.deleteRecursively(outputDirectory);
+    MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
   }
 
   @Test

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -64,6 +64,7 @@ public class FreemarkerTest {
   @AfterClass
   public static void cleanUp() throws IOException {
     // Mac's APFS fails with InsecureRecursiveDeleteException without ALLOW_INSECURE.
+    // Still safe as this test does not use symbolic links
     MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
   }
 

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.io.MoreFiles;
+import com.google.common.io.RecursiveDeleteOption;
 import com.google.common.truth.Truth;
 
 import freemarker.template.Configuration;
@@ -62,7 +63,8 @@ public class FreemarkerTest {
 
   @AfterClass
   public static void cleanUp() throws IOException {
-    MoreFiles.deleteRecursively(outputDirectory);
+    // Mac's APFS fails with InsecureRecursiveDeleteException without ALLOW_INSECURE.
+    MoreFiles.deleteRecursively(outputDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
   }
 
   @Test


### PR DESCRIPTION
Fixes #472. The test is failing in Mac.