### PR TITLE
Example project for google-api-client compatibility

### DIFF
--- a/example-problems/class-removed-from-google-http-client/README.md
+++ b/example-problems/class-removed-from-google-http-client/README.md
@@ -12,7 +12,8 @@ However, when the `pom.xml` uses `com.google.api-client:google-api-client:1.27.0
 `com.google.cloud:google-cloud-bigtable:0.81.0-alpha` together in this order, Maven picks up 
 `com.google.http-client:google-http-client:1.28.0` in the transitive dependencies.
 This version of the google-http-client artifact does not have `ApacheHttpTransport` any more.
-Because of the missing class for the returned value, the compilation fails.
+Because of the missing class for the returned value (not `GoogleApacheHttpTransport`), the
+compilation fails.
 
 ```
 $ mvn clean compile

--- a/example-problems/class-removed-from-google-http-client/README.md
+++ b/example-problems/class-removed-from-google-http-client/README.md
@@ -12,7 +12,7 @@ However, when the `pom.xml` uses `com.google.api-client:google-api-client:1.27.0
 `com.google.cloud:google-cloud-bigtable:0.81.0-alpha` together, Maven picks up 
 `com.google.http-client:google-http-client:1.28.0` in transitive dependencies.
 `com.google.http-client:google-http-client:1.28.0` does not have `ApacheHttpTransport` any more.
-Because of the missing class, the compilation fails.
+Because of the missing class for the returned value, the compilation fails.
 
 ```
 $ mvn clean compile

--- a/example-problems/class-removed-from-google-http-client/README.md
+++ b/example-problems/class-removed-from-google-http-client/README.md
@@ -1,0 +1,29 @@
+This project is to demonstrate a hidden incompatibility between
+`com.google.api-client:google-api-client:1.27.0` and
+`com.google.cloud:google-cloud-bigtable:0.81.0-alpha`.
+
+Maven artifact `com.google.api-client:google-api-client:1.27.0` contains `GoogleApacheHttpTransport`
+class.
+`GoogleApacheHttpTransport.newTrustedTransport()` returns `ApacheHttpTransport` class.
+This class is available `com.google.http-client:google-http-client:1.27.0`, which is one of the
+transitive dependencies of the google-api-client artifact.
+
+However, when the `pom.xml` uses `com.google.api-client:google-api-client:1.27.0` and
+`com.google.cloud:google-cloud-bigtable:0.81.0-alpha` together, Maven picks up 
+`com.google.http-client:google-http-client:1.28.0` in transitive dependencies.
+`com.google.http-client:google-http-client:1.28.0` does not have `ApacheHttpTransport` any more.
+Because of the missing class, the compilation fails.
+
+```
+$ mvn clean compile
+[INFO] Scanning for projects...
+...
+[ERROR] COMPILATION ERROR : 
+[INFO] -------------------------------------------------------------
+[ERROR] /usr/local/google/home/suztomo/cloud-opensource-java/example-problems/class-removed-from-google-http-client/src/main/java/com/google/cloud/tools/examples/HelloTransport.java:[31,50] cannot access com.google.api.client.http.apache.ApacheHttpTransport
+  class file for com.google.api.client.http.apache.ApacheHttpTransport not found
+[INFO] 1 error
+[INFO] -------------------------------------------------------------
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD FAILURE
+```

--- a/example-problems/class-removed-from-google-http-client/README.md
+++ b/example-problems/class-removed-from-google-http-client/README.md
@@ -5,7 +5,7 @@ This project is to demonstrate a hidden incompatibility between
 Maven artifact `com.google.api-client:google-api-client:1.27.0` contains `GoogleApacheHttpTransport`
 class.
 `GoogleApacheHttpTransport.newTrustedTransport()` returns `ApacheHttpTransport` class.
-This class is available `com.google.http-client:google-http-client:1.27.0` available in the
+This class is available in `com.google.http-client:google-http-client:1.27.0`, which is one of the
 transitive dependencies of the google-api-client artifact.
 
 However, when the `pom.xml` uses `com.google.api-client:google-api-client:1.27.0` and

--- a/example-problems/class-removed-from-google-http-client/README.md
+++ b/example-problems/class-removed-from-google-http-client/README.md
@@ -21,8 +21,8 @@ $ mvn clean compile
 
 Maven artifact `com.google.api-client:google-api-client:1.27.0` contains `GoogleApacheHttpTransport`
 class.
-In `HelloTransport` tries to call `GoogleApacheHttpTransport.newTrustedTransport()`. This method
-returns `ApacheHttpTransport` class.
+In this project, `HelloTransport` class tries to call
+`GoogleApacheHttpTransport.newTrustedTransport()`. This method returns `ApacheHttpTransport` class.
 This class is available in `com.google.http-client:google-http-client:1.27.0`, which is one of the
 transitive dependencies of the google-__api__-client artifact. The google-__api__-client version
 1.27.0 and the google-__http__-client version 1.27.0 work fine without any problems.

--- a/example-problems/class-removed-from-google-http-client/README.md
+++ b/example-problems/class-removed-from-google-http-client/README.md
@@ -5,11 +5,11 @@ This project is to demonstrate a hidden incompatibility between
 Maven artifact `com.google.api-client:google-api-client:1.27.0` contains `GoogleApacheHttpTransport`
 class.
 `GoogleApacheHttpTransport.newTrustedTransport()` returns `ApacheHttpTransport` class.
-This class is available `com.google.http-client:google-http-client:1.27.0`, which is one of the
+This class is available `com.google.http-client:google-http-client:1.27.0` available in the
 transitive dependencies of the google-api-client artifact.
 
 However, when the `pom.xml` uses `com.google.api-client:google-api-client:1.27.0` and
-`com.google.cloud:google-cloud-bigtable:0.81.0-alpha` together, Maven picks up 
+`com.google.cloud:google-cloud-bigtable:0.81.0-alpha` together in this order, Maven picks up 
 `com.google.http-client:google-http-client:1.28.0` in transitive dependencies.
 `com.google.http-client:google-http-client:1.28.0` does not have `ApacheHttpTransport` any more.
 Because of the missing class for the returned value, the compilation fails.

--- a/example-problems/class-removed-from-google-http-client/README.md
+++ b/example-problems/class-removed-from-google-http-client/README.md
@@ -1,4 +1,4 @@
-This project is to demonstrate a hidden incompatibility between
+This project demonstrates a hidden incompatibility between
 `com.google.api-client:google-api-client:1.27.0` and
 `com.google.cloud:google-cloud-bigtable:0.81.0-alpha`. The compilation fails due to the
 incompatibility.

--- a/example-problems/class-removed-from-google-http-client/README.md
+++ b/example-problems/class-removed-from-google-http-client/README.md
@@ -1,21 +1,6 @@
 This project demonstrates a hidden incompatibility between
 `com.google.api-client:google-api-client:1.27.0` and
-`com.google.cloud:google-cloud-bigtable:0.81.0-alpha`. The compilation fails due to the
-incompatibility.
-
-```
-$ mvn clean compile
- Scanning for projects...
-...
-[ERROR] COMPILATION ERROR : 
- -------------------------------------------------------------
-[ERROR] /usr/local/google/home/suztomo/cloud-opensource-java/example-problems/class-removed-from-google-http-client/src/main/java/com/google/cloud/tools/examples/HelloTransport.java:[31,50] cannot access com.google.api.client.http.apache.ApacheHttpTransport
-  class file for com.google.api.client.http.apache.ApacheHttpTransport not found
- 1 error
- -------------------------------------------------------------
- ------------------------------------------------------------------------
- BUILD FAILURE
-```
+`com.google.cloud:google-cloud-bigtable:0.81.0-alpha`.
 
 # Diagnosis
 
@@ -37,7 +22,21 @@ This version of the google-__http__-client artifact does not have `ApacheHttpTra
 https://github.com/googleapis/google-http-java-client/commit/bf4a8dad3f44772504f0223544ab7b92c9bea3be#diff-a2171533e9e559802ade0026c92d3bdf)).
 
 Because of the missing `ApacheHttpTransport` class for the return value (not
-`GoogleApacheHttpTransport`), the compilation fails.
+`GoogleApacheHttpTransport`), the compilation of this project fails.
+
+```
+$ mvn clean compile
+ Scanning for projects...
+...
+[ERROR] COMPILATION ERROR : 
+ -------------------------------------------------------------
+[ERROR] /usr/local/google/home/suztomo/cloud-opensource-java/example-problems/class-removed-from-google-http-client/src/main/java/com/google/cloud/tools/examples/HelloTransport.java:[31,50] cannot access com.google.api.client.http.apache.ApacheHttpTransport
+  class file for com.google.api.client.http.apache.ApacheHttpTransport not found
+ 1 error
+ -------------------------------------------------------------
+ ------------------------------------------------------------------------
+ BUILD FAILURE
+```
 
 # Changes in Dependency Tree
 

--- a/example-problems/class-removed-from-google-http-client/README.md
+++ b/example-problems/class-removed-from-google-http-client/README.md
@@ -36,7 +36,7 @@ This version of the google-__http__-client artifact does not have `ApacheHttpTra
 ([PR #543: Split http apache artifact](
 https://github.com/googleapis/google-http-java-client/commit/bf4a8dad3f44772504f0223544ab7b92c9bea3be#diff-a2171533e9e559802ade0026c92d3bdf)).
 
-Because of the missing `ApacheHttpTransport` class for the returned value (not
+Because of the missing `ApacheHttpTransport` class for the return value (not
 `GoogleApacheHttpTransport`), the compilation fails.
 
 # Changes in Dependency Tree

--- a/example-problems/class-removed-from-google-http-client/README.md
+++ b/example-problems/class-removed-from-google-http-client/README.md
@@ -42,7 +42,7 @@ Because of the missing `ApacheHttpTransport` class for the return value (not
 # Changes in Dependency Tree
 
 The google-api-client:1.__27__.0 artifact used `ApacheHttpTransport` through
-`com.google.http-client:google-http-client:1.27.0`.
+`com.google.http-client:google-http-client:1.27.0`:
 
 ```
 com.google.api-client:google-api-client:jar:1.27.0:compile
@@ -84,13 +84,15 @@ com.google.api-client:google-api-client:jar:1.28.0:compile
    \- org.codehaus.mojo:animal-sniffer-annotations:jar:1.14:compile
 ```
 
-Dependency tree of this project:
+Dependency tree of this project shows that Maven picks up
+`com.google.http-client:google-http-client:1.28.0` and
+`com.google.api-client:google-api-client:1.27.0`:
 
 ```
 com.google.cloud.tools.opensource:class-removed-from-google-http-client:jar:1.0-SNAPSHOT
  +- com.google.cloud:google-cloud-bigtable:jar:0.81.0-alpha:compile
  |  +- com.google.cloud:google-cloud-core:jar:1.63.0:compile
- |  |  +- com.google.http-client:google-http-client:jar:1.28.0:compile   <-- No ApacheHttpTransport any more. 
+ |  |  +- com.google.http-client:google-http-client:jar:1.28.0:compile     <-- No ApacheHttpTransport any more. 
  |  |  |  +- com.google.j2objc:j2objc-annotations:jar:1.1:compile
  |  |  |  +- io.opencensus:opencensus-api:jar:0.18.0:compile
  |  |  |  \- io.opencensus:opencensus-contrib-http-util:jar:0.18.0:compile
@@ -124,7 +126,7 @@ com.google.cloud.tools.opensource:class-removed-from-google-http-client:jar:1.0-
  |  +- io.grpc:grpc-stub:jar:1.18.0:compile
  |  +- io.grpc:grpc-auth:jar:1.18.0:compile
  |  \- javax.annotation:javax.annotation-api:jar:1.2:compile
- \- com.google.api-client:google-api-client:jar:1.27.0:compile     <-- Uses com.google.api.client.http.apache.ApacheHttpTransport
+ \- com.google.api-client:google-api-client:jar:1.27.0:compile       <-- Uses com.google.api.client.http.apache.ApacheHttpTransport
     +- com.google.oauth-client:google-oauth-client:jar:1.27.0:compile
     +- com.google.http-client:google-http-client-jackson2:jar:1.27.0:compile
     |  \- com.fasterxml.jackson.core:jackson-core:jar:2.9.6:compile

--- a/example-problems/class-removed-from-google-http-client/README.md
+++ b/example-problems/class-removed-from-google-http-client/README.md
@@ -10,8 +10,8 @@ transitive dependencies of the google-api-client artifact.
 
 However, when the `pom.xml` uses `com.google.api-client:google-api-client:1.27.0` and
 `com.google.cloud:google-cloud-bigtable:0.81.0-alpha` together in this order, Maven picks up 
-`com.google.http-client:google-http-client:1.28.0` in transitive dependencies.
-`com.google.http-client:google-http-client:1.28.0` does not have `ApacheHttpTransport` any more.
+`com.google.http-client:google-http-client:1.28.0` in the transitive dependencies.
+This version of the google-http-client artifact does not have `ApacheHttpTransport` any more.
 Because of the missing class for the returned value, the compilation fails.
 
 ```

--- a/example-problems/class-removed-from-google-http-client/README.md
+++ b/example-problems/class-removed-from-google-http-client/README.md
@@ -1,30 +1,132 @@
 This project is to demonstrate a hidden incompatibility between
 `com.google.api-client:google-api-client:1.27.0` and
-`com.google.cloud:google-cloud-bigtable:0.81.0-alpha`.
-
-Maven artifact `com.google.api-client:google-api-client:1.27.0` contains `GoogleApacheHttpTransport`
-class.
-`GoogleApacheHttpTransport.newTrustedTransport()` returns `ApacheHttpTransport` class.
-This class is available in `com.google.http-client:google-http-client:1.27.0`, which is one of the
-transitive dependencies of the google-api-client artifact.
-
-However, when the `pom.xml` uses `com.google.api-client:google-api-client:1.27.0` and
-`com.google.cloud:google-cloud-bigtable:0.81.0-alpha` together in this order, Maven picks up 
-`com.google.http-client:google-http-client:1.28.0` in the transitive dependencies.
-This version of the google-http-client artifact does not have `ApacheHttpTransport` any more.
-Because of the missing class for the returned value (not `GoogleApacheHttpTransport`), the
-compilation fails.
+`com.google.cloud:google-cloud-bigtable:0.81.0-alpha`. The compilation fails due to the
+incompatibility.
 
 ```
 $ mvn clean compile
-[INFO] Scanning for projects...
+ Scanning for projects...
 ...
 [ERROR] COMPILATION ERROR : 
-[INFO] -------------------------------------------------------------
+ -------------------------------------------------------------
 [ERROR] /usr/local/google/home/suztomo/cloud-opensource-java/example-problems/class-removed-from-google-http-client/src/main/java/com/google/cloud/tools/examples/HelloTransport.java:[31,50] cannot access com.google.api.client.http.apache.ApacheHttpTransport
   class file for com.google.api.client.http.apache.ApacheHttpTransport not found
-[INFO] 1 error
-[INFO] -------------------------------------------------------------
-[INFO] ------------------------------------------------------------------------
-[INFO] BUILD FAILURE
+ 1 error
+ -------------------------------------------------------------
+ ------------------------------------------------------------------------
+ BUILD FAILURE
+```
+
+# Diagnosis
+
+Maven artifact `com.google.api-client:google-api-client:1.27.0` contains `GoogleApacheHttpTransport`
+class.
+In `HelloTransport` tries to call `GoogleApacheHttpTransport.newTrustedTransport()`. This method
+returns `ApacheHttpTransport` class.
+This class is available in `com.google.http-client:google-http-client:1.27.0`, which is one of the
+transitive dependencies of the google-__api__-client artifact. The google-__api__-client version
+1.27.0 and the google-__http__-client version 1.27.0 work fine without any problems.
+
+However, the google-__api__-client version 1.__27__.0 and the google-__http__-client version
+1.__28__.0 has a linkage error.
+When the `pom.xml` uses `com.google.api-client:google-api-client:1.27.0` and
+`com.google.cloud:google-cloud-bigtable:0.81.0-alpha` together in this order, Maven picks up 
+`com.google.http-client:google-http-client:1.28.0` in the transitive dependencies.
+This version of the google-__http__-client artifact does not have `ApacheHttpTransport` any more
+([PR #543: Split http apache artifact](
+https://github.com/googleapis/google-http-java-client/commit/bf4a8dad3f44772504f0223544ab7b92c9bea3be#diff-a2171533e9e559802ade0026c92d3bdf)).
+
+Because of the missing `ApacheHttpTransport` class for the returned value (not
+`GoogleApacheHttpTransport`), the compilation fails.
+
+# Changes in Dependency Tree
+
+The google-api-client:1.__27__.0 artifact used `ApacheHttpTransport` through
+`com.google.http-client:google-http-client:1.27.0`.
+
+```
+com.google.api-client:google-api-client:jar:1.27.0:compile
++- com.google.oauth-client:google-oauth-client:jar:1.27.0:compile
+|  +- com.google.http-client:google-http-client:jar:1.27.0:compile  <-- com.google.api.client.http.apache.ApacheHttpTransport was here
+|  |  +- org.apache.httpcomponents:httpclient:jar:4.5.5:compile
+|  |  |  +- org.apache.httpcomponents:httpcore:jar:4.4.9:compile
+|  |  |  +- commons-logging:commons-logging:jar:1.2:compile
+|  |  |  \- commons-codec:commons-codec:jar:1.10:compile
+|  |  \- com.google.j2objc:j2objc-annotations:jar:1.1:compile
+|  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
++- com.google.http-client:google-http-client-jackson2:jar:1.27.0:compile
+|  \- com.fasterxml.jackson.core:jackson-core:jar:2.9.6:compile
+\- com.google.guava:guava:jar:20.0:compile
+```
+
+The google-api-client:1.__28__.0 artifact (This example project does not use this artifact) depends
+on google-http-client-__apache__ artifact that has `ApacheHttpTransport` class:
+
+```
+com.google.api-client:google-api-client:jar:1.28.0:compile
++- com.google.oauth-client:google-oauth-client:jar:1.28.0:compile
+|  +- com.google.http-client:google-http-client:jar:1.28.0:compile  <-- No ApacheHttpTransport any more.
+|  |  +- io.opencensus:opencensus-api:jar:0.18.0:compile
+|  |  |  \- io.grpc:grpc-context:jar:1.14.0:compile
+|  |  \- io.opencensus:opencensus-contrib-http-util:jar:0.18.0:compile
+|  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
++- com.google.http-client:google-http-client-jackson2:jar:1.28.0:compile
+|  \- com.fasterxml.jackson.core:jackson-core:jar:2.9.6:compile
++- com.google.http-client:google-http-client-apache:jar:2.0.0:compile   <-- New artifact! com.google.api.client.http.apache.ApacheHttpTransport is here
+|  \- org.apache.httpcomponents:httpclient:jar:4.5.5:compile
+|     +- org.apache.httpcomponents:httpcore:jar:4.4.9:compile
+|     +- commons-logging:commons-logging:jar:1.2:compile
+|     \- commons-codec:commons-codec:jar:1.10:compile
+\- com.google.guava:guava:jar:26.0-android:compile
+   +- org.checkerframework:checker-compat-qual:jar:2.5.2:compile
+   +- com.google.errorprone:error_prone_annotations:jar:2.1.3:compile
+   +- com.google.j2objc:j2objc-annotations:jar:1.1:compile
+   \- org.codehaus.mojo:animal-sniffer-annotations:jar:1.14:compile
+```
+
+Dependency tree of this project:
+
+```
+com.google.cloud.tools.opensource:class-removed-from-google-http-client:jar:1.0-SNAPSHOT
+ +- com.google.cloud:google-cloud-bigtable:jar:0.81.0-alpha:compile
+ |  +- com.google.cloud:google-cloud-core:jar:1.63.0:compile
+ |  |  +- com.google.http-client:google-http-client:jar:1.28.0:compile   <-- No ApacheHttpTransport any more. 
+ |  |  |  +- com.google.j2objc:j2objc-annotations:jar:1.1:compile
+ |  |  |  +- io.opencensus:opencensus-api:jar:0.18.0:compile
+ |  |  |  \- io.opencensus:opencensus-contrib-http-util:jar:0.18.0:compile
+ |  |  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
+ |  |  +- com.google.api:api-common:jar:1.7.0:compile
+ |  |  +- com.google.api:gax:jar:1.40.0:compile
+ |  |  |  +- org.threeten:threetenbp:jar:1.3.3:compile
+ |  |  |  \- com.google.auth:google-auth-library-oauth2-http:jar:0.13.0:compile
+ |  |  +- com.google.protobuf:protobuf-java-util:jar:3.6.1:compile
+ |  |  |  \- com.google.code.gson:gson:jar:2.7:compile
+ |  |  +- com.google.api.grpc:proto-google-common-protos:jar:1.14.0:compile
+ |  |  \- com.google.api.grpc:proto-google-iam-v1:jar:0.12.0:compile
+ |  +- com.google.cloud:google-cloud-core-grpc:jar:1.63.0:compile
+ |  |  +- com.google.auth:google-auth-library-credentials:jar:0.13.0:compile
+ |  |  +- com.google.protobuf:protobuf-java:jar:3.6.1:compile
+ |  |  +- io.grpc:grpc-protobuf:jar:1.18.0:compile
+ |  |  |  +- org.checkerframework:checker-compat-qual:jar:2.5.2:compile
+ |  |  |  \- io.grpc:grpc-protobuf-lite:jar:1.18.0:compile
+ |  |  +- io.grpc:grpc-context:jar:1.18.0:compile
+ |  |  \- com.google.api:gax-grpc:jar:1.40.0:compile
+ |  |     \- io.grpc:grpc-alts:jar:1.18.0:compile
+ |  |        +- org.apache.commons:commons-lang3:jar:3.5:compile
+ |  |        \- io.grpc:grpc-grpclb:jar:1.18.0:runtime
+ |  +- com.google.api.grpc:proto-google-cloud-bigtable-v2:jar:0.46.0:compile
+ |  +- com.google.api.grpc:proto-google-cloud-bigtable-admin-v2:jar:0.46.0:compile
+ |  +- io.grpc:grpc-netty-shaded:jar:1.18.0:compile
+ |  |  \- io.grpc:grpc-core:jar:1.18.0:compile (version selected from constraint [1.18.0,1.18.0])
+ |  |     +- com.google.errorprone:error_prone_annotations:jar:2.2.0:compile
+ |  |     +- org.codehaus.mojo:animal-sniffer-annotations:jar:1.17:compile
+ |  |     \- io.opencensus:opencensus-contrib-grpc-metrics:jar:0.18.0:compile
+ |  +- io.grpc:grpc-stub:jar:1.18.0:compile
+ |  +- io.grpc:grpc-auth:jar:1.18.0:compile
+ |  \- javax.annotation:javax.annotation-api:jar:1.2:compile
+ \- com.google.api-client:google-api-client:jar:1.27.0:compile     <-- Uses com.google.api.client.http.apache.ApacheHttpTransport
+    +- com.google.oauth-client:google-oauth-client:jar:1.27.0:compile
+    +- com.google.http-client:google-http-client-jackson2:jar:1.27.0:compile
+    |  \- com.fasterxml.jackson.core:jackson-core:jar:2.9.6:compile
+    \- com.google.guava:guava:jar:20.0:compile
 ```

--- a/example-problems/class-removed-from-google-http-client/pom.xml
+++ b/example-problems/class-removed-from-google-http-client/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.google.cloud.tools.opensource</groupId>
+  <artifactId>class-removed-from-google-http-client</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>class-removed-from-google-http-client</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigtable</artifactId>
+      <version>0.81.0-alpha</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>1.27.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/example-problems/class-removed-from-google-http-client/src/main/java/com/google/cloud/tools/examples/HelloTransport.java
+++ b/example-problems/class-removed-from-google-http-client/src/main/java/com/google/cloud/tools/examples/HelloTransport.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.examples;
+
+import com.google.api.client.googleapis.apache.GoogleApacheHttpTransport;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+public class HelloTransport {
+  public static void main(String[] arguments) throws GeneralSecurityException, IOException {
+    GoogleApacheHttpTransport.newTrustedTransport();
+  }
+}


### PR DESCRIPTION
For #468.

I could only produce an issue in compilation, not at runtime.

The following artifacts are not using GoogleApacheHttpTransport:
 - com.google.cloud:google-cloud-core-http:1.63.0
 - com.google.apis:google-api-services-bigquery:v2-rev20181104-1.27.0
 - com.google.apis:google-api-services-compute:v1-rev20181022-1.27.0
 - com.google.apis:google-api-services-dns:v1-rev20180813-1.27.0

The [GoogleApacheHttpTransport](https://github.com/googleapis/google-api-java-client/blob/v1.27.0/google-api-client/src/main/java/com/google/api/client/googleapis/apache/GoogleApacheHttpTransport.java#L39) are unreachable by the artifacts above.


An issue is filed in the library repo https://github.com/googleapis/google-cloud-java/issues/4579