### PR TITLE
Move main method of DependencyTreeFormatter to DependencyTreeFormatterMain

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
@@ -23,11 +23,10 @@ import java.util.Collection;
 import java.util.List;
 import org.eclipse.aether.artifact.Artifact;
 
-/** Formats artifact dependency tree represented by a list of {@link DependencyPath}s. */
+/** Formats Maven artifact dependency tree. */
 public class DependencyTreeFormatter {
   /**
-   * Formats dependencies expressed in dependency paths in tree in similar way to {@code mvn
-   * dependency:tree}.
+   * Formats dependencies as a tree in a similar way to {@code mvn dependency:tree}.
    *
    * @param dependencyPaths dependency paths from @{@link
    *     DependencyGraphBuilder#getCompleteDependencies(Artifact)}. Each element must have its

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
@@ -28,7 +28,7 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 /**
  * Formats and prints artifact dependency tree represented by a list of {@link DependencyPath}s.
  */
-public class DependencyTreeFormatter {
+class DependencyTreeFormatter {
 
   public static void main(String[] args) {
     if (args.length < 1) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
@@ -21,52 +21,19 @@ import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import java.util.Collection;
 import java.util.List;
-import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.DefaultArtifact;
 
-/**
- * Formats and prints artifact dependency tree represented by a list of {@link DependencyPath}s.
- */
-class DependencyTreeFormatter {
-
-  public static void main(String[] args) {
-    if (args.length < 1) {
-      System.err.println("Maven coordinate not provided. E.g., 'io.grpc:grpc-auth:1.15.0'");
-      return;
-    }
-    for (String coordinate : args) {
-      try {
-        printDependencyTree(coordinate);
-      } catch (RepositoryException e) {
-        System.err.println(coordinate + " : Failed to retrieve dependency information:"
-            + e.getMessage());
-      }
-    }
-  }
-
+/** Formats artifact dependency tree represented by a list of {@link DependencyPath}s. */
+public class DependencyTreeFormatter {
   /**
-   * Prints dependencies for the coordinate of an artifact
-   *
-   * @param coordinate Maven coordinate of an artifact to print its dependencies
-   */
-  private static void printDependencyTree(String coordinate) throws RepositoryException {
-    DefaultArtifact rootArtifact = new DefaultArtifact(coordinate);
-    DependencyGraph dependencyGraph =
-        DependencyGraphBuilder.getCompleteDependencies(rootArtifact);
-    System.out.println("Dependencies for " + coordinate);
-    System.out.println(formatDependencyPaths(dependencyGraph.list()));
-  }
-
-  /**
-   * Prints dependencies expressed in dependency paths in tree in similar way to
-   * mvn dependency:tree.
+   * Formats dependencies expressed in dependency paths in tree in similar way to {@code mvn
+   * dependency:tree}.
    *
    * @param dependencyPaths dependency paths from @{@link
    *     DependencyGraphBuilder#getCompleteDependencies(Artifact)}. Each element must have its
    *     parent in the list, except the ones at the root.
    */
-  public static String formatDependencyPaths(List<DependencyPath> dependencyPaths) {
+  static String formatDependencyPaths(List<DependencyPath> dependencyPaths) {
     StringBuilder stringBuilder = new StringBuilder();
     // While Maven dependencies are resolved in level-order, printing text representing a tree
     // requires traversing the items in pre-order

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatterMain.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatterMain.java
@@ -21,32 +21,27 @@ import static com.google.cloud.tools.opensource.dependencies.DependencyTreeForma
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.DefaultArtifact;
 
-/** Prints artifact dependency tree represented by a list of {@link DependencyPath}s. */
+/** Prints the dependency tree of Maven artifacts. */
 class DependencyTreeFormatterMain {
   public static void main(String[] args) {
     if (args.length < 1) {
-      System.err.println("Maven coordinate not provided. E.g., 'io.grpc:grpc-auth:1.15.0'");
+      System.err.println("Maven coordinates not provided. E.g., 'io.grpc:grpc-auth:1.15.0'");
       return;
     }
-    for (String coordinate : args) {
+    for (String coordinates : args) {
       try {
-        printDependencyTree(coordinate);
+        printDependencyTree(coordinates);
       } catch (RepositoryException e) {
         System.err.println(
-            coordinate + " : Failed to retrieve dependency information:" + e.getMessage());
+            coordinates + " : Failed to retrieve dependency information:" + e.getMessage());
       }
     }
   }
 
-  /**
-   * Prints dependencies for the coordinate of an artifact
-   *
-   * @param coordinate Maven coordinate of an artifact to print its dependencies
-   */
-  private static void printDependencyTree(String coordinate) throws RepositoryException {
-    DefaultArtifact rootArtifact = new DefaultArtifact(coordinate);
+  private static void printDependencyTree(String coordinates) throws RepositoryException {
+    DefaultArtifact rootArtifact = new DefaultArtifact(coordinates);
     DependencyGraph dependencyGraph = DependencyGraphBuilder.getCompleteDependencies(rootArtifact);
-    System.out.println("Dependencies for " + coordinate);
+    System.out.println("Dependencies for " + coordinates);
     System.out.println(formatDependencyPaths(dependencyGraph.list()));
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatterMain.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatterMain.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.dependencies;
+
+import static com.google.cloud.tools.opensource.dependencies.DependencyTreeFormatter.formatDependencyPaths;
+
+import org.eclipse.aether.RepositoryException;
+import org.eclipse.aether.artifact.DefaultArtifact;
+
+/** Prints artifact dependency tree represented by a list of {@link DependencyPath}s. */
+class DependencyTreeFormatterMain {
+  public static void main(String[] args) {
+    if (args.length < 1) {
+      System.err.println("Maven coordinate not provided. E.g., 'io.grpc:grpc-auth:1.15.0'");
+      return;
+    }
+    for (String coordinate : args) {
+      try {
+        printDependencyTree(coordinate);
+      } catch (RepositoryException e) {
+        System.err.println(
+            coordinate + " : Failed to retrieve dependency information:" + e.getMessage());
+      }
+    }
+  }
+
+  /**
+   * Prints dependencies for the coordinate of an artifact
+   *
+   * @param coordinate Maven coordinate of an artifact to print its dependencies
+   */
+  private static void printDependencyTree(String coordinate) throws RepositoryException {
+    DefaultArtifact rootArtifact = new DefaultArtifact(coordinate);
+    DependencyGraph dependencyGraph = DependencyGraphBuilder.getCompleteDependencies(rootArtifact);
+    System.out.println("Dependencies for " + coordinate);
+    System.out.println(formatDependencyPaths(dependencyGraph.list()));
+  }
+}

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreePrinter.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreePrinter.java
@@ -25,7 +25,7 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 class DependencyTreePrinter {
   public static void main(String[] args) {
     if (args.length < 1) {
-      System.err.println("Maven coordinates not provided. E.g., 'io.grpc:grpc-auth:1.15.0'");
+      System.err.println("Maven coordinates not provided. E.g., 'io.grpc:grpc-auth:1.19.0'");
       return;
     }
     for (String coordinates : args) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreePrinter.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreePrinter.java
@@ -22,7 +22,7 @@ import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.DefaultArtifact;
 
 /** Prints the dependency tree of Maven artifacts. */
-class DependencyTreeFormatterMain {
+class DependencyTreePrinter {
   public static void main(String[] args) {
     if (args.length < 1) {
       System.err.println("Maven coordinates not provided. E.g., 'io.grpc:grpc-auth:1.15.0'");


### PR DESCRIPTION
Fixes #453 .

DependencyTreeFromatter class is the last remaining class that has a main method and is public. As a cleanup, this change moves the main method to a new class `DependencyTreeFormatterMain`.

Note that DependencyTreeFromatter is used by dashboard and thus needs to be public.