### PR TITLE
(not for merge) BOM Behavior to control transitive dependency

### DIFF
--- a/example-problems/no-such-method-error-signature-mismatch/pom.xml
+++ b/example-problems/no-such-method-error-signature-mismatch/pom.xml
@@ -16,6 +16,18 @@
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>cloud-oss-bom</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.google.api-client</groupId>


### PR DESCRIPTION
@elharo 

This PR explains the behavior of Maven BOM where a _BOM controls versions; when a node in the graph has the same artifact ID and group ID as a BOM member, the BOM overrides the version of the node with the version of the BOM member._

In Maven's documentation it's 

>Dependency management - this allows project authors to directly specify the versions of artifacts to be used when they are encountered in transitive dependencies 
https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management

By adding Cloud OSS BOM in pom.xml, this PR demonstrates the problem of "no-such-method-error" caused by Guava version 20.0 disappears:

```
suztomo@suxtomo24:~/cloud-opensource-java/example-problems/no-such-method-error-signature-mismatch$ mvn exec:java
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building no-such-method-error-example 1.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- exec-maven-plugin:1.6.0:java (default-cli) @ no-such-method-error-example ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.616 s
[INFO] Finished at: 2019-03-13T12:13:00-04:00
[INFO] Final Memory: 22M/970M
[INFO] ------------------------------------------------------------------------
```

Without the BOM, the "mvn exec:java" would throw `NoSuchMethodError` as explained in the [README](https://github.com/GoogleCloudPlatform/cloud-opensource-java/tree/master/example-problems/no-such-method-error-signature-mismatch).

# Dependency Tree without the BOM

Maven picks up Guava version 20.0.

```
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ no-such-method-error-example ---
[INFO] com.google.cloud.tools.opensource:no-such-method-error-example:jar:1.0-SNAPSHOT
[INFO] +- com.google.api-client:google-api-client:jar:1.27.0:compile
[INFO] |  +- com.google.oauth-client:google-oauth-client:jar:1.27.0:compile
[INFO] |  |  +- com.google.http-client:google-http-client:jar:1.27.0:compile
[INFO] |  |  |  +- (com.google.code.findbugs:jsr305:jar:3.0.2:compile - omitted for duplicate)
[INFO] |  |  |  +- (com.google.guava:guava:jar:20.0:compile - omitted for duplicate)
[INFO] |  |  |  +- org.apache.httpcomponents:httpclient:jar:4.5.5:compile
[INFO] |  |  |  |  +- org.apache.httpcomponents:httpcore:jar:4.4.9:compile
[INFO] |  |  |  |  +- commons-logging:commons-logging:jar:1.2:compile
[INFO] |  |  |  |  \- commons-codec:commons-codec:jar:1.10:compile
[INFO] |  |  |  \- com.google.j2objc:j2objc-annotations:jar:1.1:compile
[INFO] |  |  +- (com.google.code.findbugs:jsr305:jar:3.0.2:compile - omitted for duplicate)
[INFO] |  |  \- (com.google.guava:guava:jar:20.0:compile - omitted for duplicate)
[INFO] |  +- com.google.http-client:google-http-client-jackson2:jar:1.27.0:compile
[INFO] |  |  +- (com.google.http-client:google-http-client:jar:1.27.0:compile - omitted for duplicate)
[INFO] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.9.6:compile
[INFO] |  \- com.google.guava:guava:jar:20.0:compile                       <============ This causes NoSuchMethodError
[INFO] \- io.grpc:grpc-core:jar:1.17.1:compile
[INFO]    +- io.grpc:grpc-context:jar:1.17.1:compile
[INFO]    +- com.google.code.gson:gson:jar:2.7:compile
[INFO]    +- com.google.errorprone:error_prone_annotations:jar:2.2.0:compile
[INFO]    +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO]    +- org.codehaus.mojo:animal-sniffer-annotations:jar:1.17:compile
[INFO]    +- (com.google.guava:guava:jar:26.0-android:compile - omitted for conflict with 20.0)
[INFO]    +- io.opencensus:opencensus-api:jar:0.17.0:compile
[INFO]    \- io.opencensus:opencensus-contrib-grpc-metrics:jar:0.17.0:compile
[INFO]       \- (io.opencensus:opencensus-api:jar:0.17.0:compile - omitted for duplicate)

```

# Dependency Tree with the BOM

Maven picks up Guava version 26.0-android.

```
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ no-such-method-error-example ---
[INFO] com.google.cloud.tools.opensource:no-such-method-error-example:jar:1.0-SNAPSHOT
[INFO] +- com.google.api-client:google-api-client:jar:1.27.0:compile
[INFO] |  +- com.google.oauth-client:google-oauth-client:jar:1.27.0:compile
[INFO] |  |  +- com.google.http-client:google-http-client:jar:1.27.0:compile
[INFO] |  |  |  +- (com.google.code.findbugs:jsr305:jar:3.0.2:compile - omitted for duplicate)
[INFO] |  |  |  +- (com.google.guava:guava:jar:26.0-android:compile - version managed from 20.0; omitted for duplicate)
[INFO] |  |  |  +- org.apache.httpcomponents:httpclient:jar:4.5.5:compile
[INFO] |  |  |  |  +- org.apache.httpcomponents:httpcore:jar:4.4.9:compile
[INFO] |  |  |  |  +- commons-logging:commons-logging:jar:1.2:compile
[INFO] |  |  |  |  \- commons-codec:commons-codec:jar:1.10:compile
[INFO] |  |  |  \- (com.google.j2objc:j2objc-annotations:jar:1.1:compile - omitted for duplicate)
[INFO] |  |  +- (com.google.code.findbugs:jsr305:jar:3.0.2:compile - omitted for duplicate)
[INFO] |  |  \- (com.google.guava:guava:jar:26.0-android:compile - version managed from 20.0; omitted for duplicate)
[INFO] |  +- com.google.http-client:google-http-client-jackson2:jar:1.27.0:compile
[INFO] |  |  +- (com.google.http-client:google-http-client:jar:1.27.0:compile - omitted for duplicate)
[INFO] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.9.6:compile
[INFO] |  \- com.google.guava:guava:jar:26.0-android:compile                   <============ This does not cause the error!
[INFO] |     +- (com.google.code.findbugs:jsr305:jar:3.0.2:compile - omitted for duplicate)
[INFO] |     +- org.checkerframework:checker-compat-qual:jar:2.5.2:compile
[INFO] |     +- (com.google.errorprone:error_prone_annotations:jar:2.1.3:compile - omitted for conflict with 2.2.0)
[INFO] |     +- com.google.j2objc:j2objc-annotations:jar:1.1:compile
[INFO] |     \- (org.codehaus.mojo:animal-sniffer-annotations:jar:1.14:compile - omitted for conflict with 1.17)
[INFO] \- io.grpc:grpc-core:jar:1.17.1:compile
[INFO]    +- io.grpc:grpc-context:jar:1.18.0:compile (version managed from 1.17.1)
[INFO]    +- com.google.code.gson:gson:jar:2.7:compile
[INFO]    +- com.google.errorprone:error_prone_annotations:jar:2.2.0:compile
[INFO]    +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO]    +- org.codehaus.mojo:animal-sniffer-annotations:jar:1.17:compile
[INFO]    +- (com.google.guava:guava:jar:26.0-android:compile - version managed from 20.0; omitted for duplicate)
[INFO]    +- io.opencensus:opencensus-api:jar:0.17.0:compile
[INFO]    \- io.opencensus:opencensus-contrib-grpc-metrics:jar:0.17.0:compile
[INFO]       \- (io.opencensus:opencensus-api:jar:0.17.0:compile - omitted for duplicate)
```

io.grpc:grpc-core:jar:1.17.1 specifies io.grpc:grpc-context:1.17.1 as dependency, but the BOM overrides the version to 1.18.0. 

![image](https://user-images.githubusercontent.com/28604/54307287-a615ab80-45a1-11e9-9021-0a3e5cec6100.png)

com.google.api-client:google-api-client:jar:1.27.0 does not specify the version (it relies on parent pom's dependency management)

![image](https://user-images.githubusercontent.com/28604/54301625-b58ef780-4595-11e9-9b7e-a75a2807b20f.png)
