### PR TITLE
Skip root project in the enforcer rule

### DIFF
--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -189,9 +189,8 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
       return StreamSupport.stream(
               traverser.breadthFirst(resolutionResult.getDependencyGraph()).spliterator(), false)
           .map(DependencyNode::getArtifact)
-          .filter(Objects::nonNull)
+          .skip(1) // The root project's file is null if it's not installed locally (#524)
           .map(Artifact::getFile)
-          .filter(Objects::nonNull) // The root project's file is null if it's not installed locally
           .map(File::toPath)
           .collect(toImmutableList());
     } catch (ComponentLookupException e) {

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -189,7 +189,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
       return StreamSupport.stream(
               traverser.breadthFirst(resolutionResult.getDependencyGraph()).spliterator(), false)
           .map(DependencyNode::getArtifact)
-          .skip(1) // The root project's file is null if it's not installed locally (#524)
+          .skip(1) // Not to check the root project's jar file; Maven "validate" is before "compile"
           .map(Artifact::getFile)
           .map(File::toPath)
           .collect(toImmutableList());

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -191,7 +191,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
           .map(DependencyNode::getArtifact)
           .filter(Objects::nonNull)
           .map(Artifact::getFile)
-          .filter(Objects::nonNull) // The root artifact is null if 'mvn install' has not run yet
+          .filter(Objects::nonNull) // The root project's file is null if it's not installed locally
           .map(File::toPath)
           .collect(toImmutableList());
     } catch (ComponentLookupException e) {

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -191,6 +191,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
           .map(DependencyNode::getArtifact)
           .filter(Objects::nonNull)
           .map(Artifact::getFile)
+          .filter(Objects::nonNull) // The root artifact is null if 'mvn install' has not run yet
           .map(File::toPath)
           .collect(toImmutableList());
     } catch (ComponentLookupException e) {

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -48,6 +48,7 @@ import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.graph.DefaultDependencyNode;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.resolution.DependencyRequest;
@@ -100,6 +101,7 @@ public class LinkageCheckerRuleTest {
       throws RepositoryException {
     CollectRequest collectRequest = new CollectRequest();
     collectRequest.setRepositories(ImmutableList.of(RepositoryUtility.CENTRAL));
+    collectRequest.setRootArtifact(new DefaultArtifact("dummy:mock:0.0.1"));
     collectRequest.setDependencies(
         Arrays.stream(coordinates)
             .map(DefaultArtifact::new)
@@ -143,6 +145,16 @@ public class LinkageCheckerRuleTest {
     // This should not raise an EnforcerRuleException
     rule.execute(mockRuleHelper);
     verify(mockLog).info("No error found");
+  }
+
+  @Test
+  public void testExecute_shouldPassEmptyProject()
+      throws EnforcerRuleException, RepositoryException {
+    // Empty project with no dependency
+    setupMockDependencyResolution();
+
+    // This should not raise a NullPointerException
+    rule.execute(mockRuleHelper);
   }
 
   @Test


### PR DESCRIPTION
Fixes #524.

The root project's file may be null if the project has not run "mvn install" yet. An enforcer rule, which runs "validate" lifecycle, should not depends on it.