### PR TITLE
Convert lambda to for loop so breakpoints can be set and single stepped

### DIFF
--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -26,15 +26,11 @@ import com.google.cloud.tools.opensource.classpath.LinkageCheckReport;
 import com.google.cloud.tools.opensource.classpath.LinkageChecker;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.graph.Traverser;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Objects;
-import java.util.Spliterator;
-import java.util.stream.StreamSupport;
 import javax.annotation.Nonnull;
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
@@ -191,7 +187,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
       DependencyNode dependencyGraph = resolutionResult.getDependencyGraph();
       Iterable<DependencyNode> breadthFirst = traverser.breadthFirst(dependencyGraph);
       
-      Builder<Path> builder = ImmutableList.builder();
+      ImmutableList.Builder<Path> builder = ImmutableList.builder();
       for (DependencyNode node : breadthFirst) {
         // the very first one is the pom.xml where this rule appears
         Artifact artifact = node.getArtifact();

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -183,13 +183,11 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
       DependencyResolutionResult resolutionResult =
           projectDependenciesResolver.resolve(dependencyResolutionRequest);
 
-      Traverser<DependencyNode> traverser = Traverser.forTree(DependencyNode::getChildren);
-
-      Iterable<DependencyNode> breadthFirst =
-          traverser.breadthFirst(resolutionResult.getDependencyGraph());
+      Iterable<DependencyNode> dependencies = Traverser.forTree(DependencyNode::getChildren)
+          .breadthFirst(resolutionResult.getDependencyGraph());
       
       ImmutableList.Builder<Path> builder = ImmutableList.builder();
-      for (DependencyNode node : breadthFirst) {
+      for (DependencyNode node : dependencies) {
         // the very first one is the pom.xml where this rule appears
         Artifact artifact = node.getArtifact();
         if (artifact != null) { // why is this possible?
@@ -199,7 +197,8 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
           // the classpath but what we really need for this one is a classes directory
           if (file == null) {
             throw new EnforcerRuleException(
-                "Artifact " + Artifacts.toCoordinates(artifact) + " is not associated with a file");
+                "Artifact " + Artifacts.toCoordinates(artifact) + " is not associated with a file."
+                    + " The linkage checker enforcer rule should be bound to the verify phase.");
           }
           Path path = file.toPath();
           builder.add(path);


### PR DESCRIPTION
@netdpb also catches a NullPointerException should one arise again. It's still possible to get one if the user binds this to the wrong phase. It's also worth noting that when the NullPointerException arose the lambda obscured the source of the problem. 

fix #524