### PR TITLE
Format error strings for enforcer rule

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
@@ -26,6 +26,13 @@ abstract class ClassSymbolReference implements SymbolReference {
 
   /** Returns true if the symbol reference is from a class to its superclass. */
   abstract boolean isSubclass();
+  
+  @Override
+  public String getDisplayString() {
+    return this.getTargetClassName()
+        + " is not found, referenced from "
+        + this.getSourceClassName();
+  }
 
   static Builder builder() {
     return new AutoValue_ClassSymbolReference.Builder();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
@@ -28,7 +28,7 @@ abstract class ClassSymbolReference implements SymbolReference {
   abstract boolean isSubclass();
   
   @Override
-  public String getDisplayString() {
+  public String getErrorString() {
     return this.getTargetClassName()
         + " is not found, referenced from "
         + this.getSourceClassName();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
@@ -29,9 +29,7 @@ abstract class ClassSymbolReference implements SymbolReference {
   
   @Override
   public String getErrorString() {
-    return this.getTargetClassName()
-        + " is not found, referenced from "
-        + this.getSourceClassName();
+    return getTargetClassName() + " is not found, referenced from " + getSourceClassName();
   }
 
   static Builder builder() {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
@@ -23,10 +23,18 @@ import com.google.auto.value.AutoValue;
  */
 @AutoValue
 abstract class FieldSymbolReference implements SymbolReference {
+  
   /**
-   * Returns the field name of the reference.
+   * Returns the name of the referenced field.
    */
   abstract String getFieldName();
+  
+  @Override
+  public String getDisplayString() {
+    return this.getTargetClassName()
+        + " is not found, referenced from "
+        + this.getSourceClassName();
+  }
 
   static Builder builder() {
     return new AutoValue_FieldSymbolReference.Builder();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
@@ -31,9 +31,8 @@ abstract class FieldSymbolReference implements SymbolReference {
   
   @Override
   public String getErrorString() {
-    return this.getTargetClassName() + "." + getFieldName()
-        + " is not found, referenced from "
-        + this.getSourceClassName();
+    return getTargetClassName() + "." + getFieldName() + " is not found, referenced from "
+        + getSourceClassName();
   }
 
   static Builder builder() {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
@@ -30,8 +30,8 @@ abstract class FieldSymbolReference implements SymbolReference {
   abstract String getFieldName();
   
   @Override
-  public String getDisplayString() {
-    return this.getTargetClassName()
+  public String getErrorString() {
+    return this.getTargetClassName() + "." + getFieldName()
         + " is not found, referenced from "
         + this.getSourceClassName();
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
@@ -149,7 +149,7 @@ public abstract class JarLinkageReport {
     return builder.build();
   }
 
-  public String getErrorString() {
+  String getErrorString() {
     String indent = "  ";
     StringBuilder builder = new StringBuilder();
     int totalErrors = getCauseToSourceClassesSize();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
@@ -148,4 +148,25 @@ public abstract class JarLinkageReport {
     builder.setJarPath(getJarPath());
     return builder.build();
   }
+
+  public String getErrorString() {
+    String indent = "  ";
+    StringBuilder builder = new StringBuilder();
+    int totalErrors = getCauseToSourceClassesSize();
+
+    builder.append(getJarPath().getFileName() + " (" + totalErrors + " errors):\n");
+    for (SymbolNotResolvable<ClassSymbolReference> missingClass : getMissingClassErrors()) {
+      builder.append(indent + missingClass.getReference().getErrorString());
+      builder.append("\n");
+    }
+    for (SymbolNotResolvable<MethodSymbolReference> missingMethod : getMissingMethodErrors()) {
+      builder.append(indent + missingMethod.getReference().getErrorString());
+      builder.append("\n");
+    }
+    for (SymbolNotResolvable<FieldSymbolReference> missingField : getMissingFieldErrors()) {
+      builder.append(indent + missingField.getReference().getErrorString());
+      builder.append("\n");
+    }
+    return builder.toString();
+  }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckReport.java
@@ -33,12 +33,11 @@ public abstract class LinkageCheckReport {
     return new AutoValue_LinkageCheckReport(ImmutableList.copyOf(jarLinkageReports));
   }
   
-  @Override
-  public String toString() {
+  public String getErrorString() {
     StringBuilder builder = new StringBuilder();
     for (JarLinkageReport jarLinkageReport : getJarLinkageReports()) {
       if (jarLinkageReport.getCauseToSourceClassesSize() > 0) {
-        builder.append(jarLinkageReport.toString());
+        builder.append(jarLinkageReport.getErrorString());
         builder.append('\n');
       }
     }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
@@ -57,7 +57,7 @@ abstract class MethodSymbolReference implements SymbolReference  {
   }
 
   @Override
-  public String getDisplayString() {
+  public String getErrorString() {
     return this.getTargetClassName()
         + "."
         + this.getMethodName()

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
@@ -56,6 +56,7 @@ abstract class MethodSymbolReference implements SymbolReference  {
     abstract MethodSymbolReference build();
   }
 
+  @Override
   public String getDisplayString() {
     return this.getTargetClassName()
         + "."

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
@@ -60,8 +60,8 @@ abstract class MethodSymbolReference implements SymbolReference  {
   public String getErrorString() {
     return this.getTargetClassName()
         + "."
-        + this.getMethodName()
+        + getMethodName()
         + " is not found, referenced from "
-        + this.getSourceClassName();
+        + getSourceClassName();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
@@ -55,4 +55,12 @@ abstract class MethodSymbolReference implements SymbolReference  {
     abstract Builder setSourceClassName(String className);
     abstract MethodSymbolReference build();
   }
+
+  public String getDisplayString() {
+    return this.getTargetClassName()
+        + "."
+        + this.getMethodName()
+        + " is not found, referenced from "
+        + this.getSourceClassName();
+  }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
@@ -58,7 +58,7 @@ abstract class MethodSymbolReference implements SymbolReference  {
 
   @Override
   public String getErrorString() {
-    return this.getTargetClassName()
+    return getTargetClassName()
         + "."
         + getMethodName()
         + " is not found, referenced from "

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
@@ -35,10 +35,9 @@ interface SymbolReference {
    * reference.
    */
   String getTargetClassName();
-  
 
   /**
-   * Returns a string describing the reference for display to an end user.
+   * Returns a string describing the missing reference for display to an end user.
    */
-  String getDisplayString();
+  String getErrorString();
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
@@ -35,4 +35,10 @@ interface SymbolReference {
    * reference.
    */
   String getTargetClassName();
+  
+
+  /**
+   * Returns a string describing the reference for display to an end user.
+   */
+  String getDisplayString();
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
@@ -140,6 +140,17 @@ public class JarLinkageReportTest {
   }
 
   @Test
+  public void testGetErrorString() {
+    Assert.assertEquals(
+        "c (4 errors):\n"
+            + "  ClassA is not found, referenced from ClassB\n"
+            + "  ClassA.methodX is not found, referenced from ClassB\n"
+            + "  ClassA.methodX is not found, referenced from ClassC$InnerC\n"
+            + "  ClassC.fieldX is not found, referenced from ClassD\n",
+        jarLinkageReport.getErrorString());
+  }  
+  
+  @Test
   public void testGetCauseToSourceClasses() {
     ImmutableMultimap<LinkageErrorCause, String> causeToSourceClasses =
         jarLinkageReport.getCauseToSourceClasses();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckReportTest.java
@@ -82,19 +82,19 @@ public class LinkageCheckReportTest {
   }
 
   @Test
-  public void testJarLinkageReportToString() {
-    Truth.assertThat(linkageCheckReport.toString()).startsWith("c (3 errors)");
+  public void testGetErrorString() {
+    Truth.assertThat(linkageCheckReport.getErrorString()).startsWith("c (3 errors)");
   }
   
   @Test
-  public void testToString() {
-    Truth.assertThat(linkageCheckReport.toString()).contains(jarLinkageReport.toString());
+  public void testGetErrorString_contents() {
+    Truth.assertThat(linkageCheckReport.getErrorString()).contains(jarLinkageReport.getErrorString());
   }
   
   @Test
-  public void testToStringNoErrors() {
+  public void testGetErrorString_noErrors() {
     linkageCheckReport = LinkageCheckReport.create(Collections.emptyList());
-    Assert.assertEquals("No linkage errors\n", linkageCheckReport.toString());
+    Assert.assertEquals("No linkage errors\n", linkageCheckReport.getErrorString());
   }
   
   @Test

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReferenceTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReferenceTest.java
@@ -39,7 +39,7 @@ public class MethodSymbolReferenceTest {
   }
 
   @Test
-  public void testDisplayString() {
+  public void testGetErrorString() {
     Assert.assertEquals(
         "ClassA.methodX is not found, referenced from ClassB",
         methodSymbolReference.getErrorString());

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReferenceTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReferenceTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 
 public class MethodSymbolReferenceTest {
   
-  private MethodSymbolReference methodSymbolReference =
+  private static final MethodSymbolReference REFERENCE =
       MethodSymbolReference.builder()
           .setTargetClassName("ClassA")
           .setInterfaceMethod(false)
@@ -32,17 +32,17 @@ public class MethodSymbolReferenceTest {
 
   @Test
   public void testCreation() {
-    Assert.assertEquals("ClassA", methodSymbolReference.getTargetClassName());
-    Assert.assertEquals("methodX", methodSymbolReference.getMethodName());
-    Assert.assertEquals("java.lang.String", methodSymbolReference.getDescriptor());
-    Assert.assertEquals("ClassB", methodSymbolReference.getSourceClassName());
+    Assert.assertEquals("ClassA", REFERENCE.getTargetClassName());
+    Assert.assertEquals("methodX", REFERENCE.getMethodName());
+    Assert.assertEquals("java.lang.String", REFERENCE.getDescriptor());
+    Assert.assertEquals("ClassB", REFERENCE.getSourceClassName());
   }
 
   @Test
   public void testGetErrorString() {
     Assert.assertEquals(
         "ClassA.methodX is not found, referenced from ClassB",
-        methodSymbolReference.getErrorString());
+        REFERENCE.getErrorString());
   }
 
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReferenceTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReferenceTest.java
@@ -20,20 +20,29 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class MethodSymbolReferenceTest {
+  
+  private MethodSymbolReference methodSymbolReference =
+      MethodSymbolReference.builder()
+          .setTargetClassName("ClassA")
+          .setInterfaceMethod(false)
+          .setMethodName("methodX")
+          .setDescriptor("java.lang.String")
+          .setSourceClassName("ClassB")
+          .build();
+
   @Test
   public void testCreation() {
-    MethodSymbolReference methodSymbolReference =
-        MethodSymbolReference.builder()
-            .setTargetClassName("ClassA")
-            .setInterfaceMethod(false)
-            .setMethodName("methodX")
-            .setDescriptor("java.lang.String")
-            .setSourceClassName("ClassB")
-            .build();
-
     Assert.assertEquals("ClassA", methodSymbolReference.getTargetClassName());
     Assert.assertEquals("methodX", methodSymbolReference.getMethodName());
     Assert.assertEquals("java.lang.String", methodSymbolReference.getDescriptor());
     Assert.assertEquals("ClassB", methodSymbolReference.getSourceClassName());
   }
+
+  @Test
+  public void testDisplayString() {
+    Assert.assertEquals(
+        "ClassA.methodX is not found, referenced from ClassB",
+        methodSymbolReference.getDisplayString());
+  }
+
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReferenceTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReferenceTest.java
@@ -42,7 +42,7 @@ public class MethodSymbolReferenceTest {
   public void testDisplayString() {
     Assert.assertEquals(
         "ClassA.methodX is not found, referenced from ClassB",
-        methodSymbolReference.getDisplayString());
+        methodSymbolReference.getErrorString());
   }
 
 }

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -150,7 +150,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
               "Linkage Checker rule found "
                   + foundError
                   + ". Linkage error report:\n"
-                  + linkageReport;
+                  + linkageReport.getErrorString();
           if (getLevel() == WARN) {
             logger.warn(message);
           } else {

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -67,8 +67,8 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
    * Set to true to suppress linkage errors unreachable from the classes in the direct dependencies.
    * By default, it's {@code false}.
    *
-   * @see <a
-   *     href="https://github.com/GoogleCloudPlatform/cloud-opensource-java/blob/master/library-best-practices/glossary.md#class-reference-graph"
+   * @see <a href=
+   *     "https://github.com/GoogleCloudPlatform/cloud-opensource-java/blob/master/library-best-practices/glossary.md#class-reference-graph"
    *     >Java Dependency Glossary: Class reference graph</a>
    */
   private boolean reportOnlyReachable = false;


### PR DESCRIPTION
@netdpb 
as opposed to simply using the `toString` from AutoValue. 
fixes #560