### PR TITLE
Replaced deprecated Correspondence constructors

### DIFF
--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -63,9 +63,9 @@ public class DashboardTest {
       Paths.get("..", "boms", "cloud-oss-bom", "pom.xml").toAbsolutePath();
 
   private static final Correspondence<Node, String> NODE_VALUES =
-    Correspondence.from((node, expected) -> 
-    trimAndCollapseWhiteSpace(node.getValue())
-    .equals(expected), "has value equal to");
+    Correspondence.from((node, expected) ->
+        trimAndCollapseWhiteSpace(node.getValue())
+        .equals(expected), "has value equal to");
 
   private static String trimAndCollapseWhiteSpace(String value) {
     return CharMatcher.whitespace().trimAndCollapseFrom(value, ' ');

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -63,9 +63,9 @@ public class DashboardTest {
       Paths.get("..", "boms", "cloud-oss-bom", "pom.xml").toAbsolutePath();
 
   private static final Correspondence<Node, String> NODE_VALUES =
-    Correspondence.from((node, expected) ->
-        trimAndCollapseWhiteSpace(node.getValue())
-        .equals(expected), "has value equal to");
+      Correspondence.from((node, expected) ->
+          trimAndCollapseWhiteSpace(node.getValue())
+          .equals(expected), "has value equal to");
 
   private static String trimAndCollapseWhiteSpace(String value) {
     return CharMatcher.whitespace().trimAndCollapseFrom(value, ' ');

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -63,18 +63,9 @@ public class DashboardTest {
       Paths.get("..", "boms", "cloud-oss-bom", "pom.xml").toAbsolutePath();
 
   private static final Correspondence<Node, String> NODE_VALUES =
-      new Correspondence<Node, String>() {
-        @Override
-        public boolean compare(Node node, String expected) {
-          String trimmedValue = trimAndCollapseWhiteSpace(node.getValue());
-          return trimmedValue.equals(expected);
-        }
-
-        @Override
-        public String toString() {
-          return "has value equal to";
-        }
-      };
+    Correspondence.from((node, expected) -> 
+    trimAndCollapseWhiteSpace(node.getValue())
+    .equals(expected), "has value equal to");
 
   private static String trimAndCollapseWhiteSpace(String value) {
     return CharMatcher.whitespace().trimAndCollapseFrom(value, ' ');

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -53,17 +53,8 @@ public class ClassDumperTest {
       "testdata/grpc-google-cloud-firestore-v1beta1-0.28.0_FirestoreGrpc.class";
 
   private static final Correspondence<SymbolReference, String> SYMBOL_REFERENCE_TARGET_CLASS_NAME =
-      new Correspondence<SymbolReference, String>() {
-        @Override
-        public boolean compare(SymbolReference actual, String expected) {
-          return actual.getTargetClassName().equals(expected);
-        }
-
-        @Override
-        public String toString() {
-          return "has target class name equal to";
-        }
-      };
+    Correspondence.from((actual, expected) -> 
+    actual.getTargetClassName().equals(expected), "has target class name equal to");
 
   private InputStream classFileInputStream;
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -53,8 +53,8 @@ public class ClassDumperTest {
       "testdata/grpc-google-cloud-firestore-v1beta1-0.28.0_FirestoreGrpc.class";
 
   private static final Correspondence<SymbolReference, String> SYMBOL_REFERENCE_TARGET_CLASS_NAME =
-    Correspondence.from((actual, expected) -> 
-    actual.getTargetClassName().equals(expected), "has target class name equal to");
+    Correspondence.from((actual, expected) ->
+        actual.getTargetClassName().equals(expected), "has target class name equal to");
 
   private InputStream classFileInputStream;
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -53,8 +53,8 @@ public class ClassDumperTest {
       "testdata/grpc-google-cloud-firestore-v1beta1-0.28.0_FirestoreGrpc.class";
 
   private static final Correspondence<SymbolReference, String> SYMBOL_REFERENCE_TARGET_CLASS_NAME =
-    Correspondence.from((actual, expected) ->
-        actual.getTargetClassName().equals(expected), "has target class name equal to");
+      Correspondence.from((actual, expected) ->
+          actual.getTargetClassName().equals(expected), "has target class name equal to");
 
   private InputStream classFileInputStream;
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -42,17 +42,8 @@ import org.junit.Test;
 public class ClassPathBuilderTest {
 
   static final Correspondence<Path, String> PATH_FILE_NAMES =
-      new Correspondence<Path, String>() {
-        @Override
-        public boolean compare(Path actual, String expected) {
-          return actual.getFileName().toString().equals(expected);
-        }
-
-        @Override
-        public String toString() {
-          return "has file name equal to";
-        }
-      };
+    Correspondence.from((actual, expected) -> 
+    actual.getFileName().toString().equals(expected), "has file name equal to");
 
   @Test
   public void testArtifactsToPaths_removingDuplicates() throws RepositoryException {

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -42,8 +42,8 @@ import org.junit.Test;
 public class ClassPathBuilderTest {
 
   static final Correspondence<Path, String> PATH_FILE_NAMES =
-    Correspondence.from((actual, expected) -> 
-    actual.getFileName().toString().equals(expected), "has file name equal to");
+      Correspondence.from((actual, expected) ->
+          actual.getFileName().toString().equals(expected), "has file name equal to");
 
   @Test
   public void testArtifactsToPaths_removingDuplicates() throws RepositoryException {


### PR DESCRIPTION
Replaced deprecated Correspondence constructor with Correspondence.from.

fix #565 