### PR TITLE
Add fmt-maven-plugin so users can run fmt:format

### DIFF
--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -74,6 +74,10 @@
           <mainClass>com.google.cloud.tools.opensource.dashboard.DashboardMain</mainClass>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -147,6 +147,10 @@
           </annotationProcessorPaths>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -104,4 +104,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,11 @@
             <argLine>-Xms128m -Xmx2048m</argLine>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>com.coveo</groupId>
+          <artifactId>fmt-maven-plugin</artifactId>
+          <version>2.8</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
- Does NOT automatically enforce formatting rules.
- Will apply directly on source google-java-format.
- Should help users with issues like https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/570/files/5d454478a7f79ca469226f93576951687789497b#r276329495