### PR TITLE
cause --> target

### DIFF
--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -15,7 +15,7 @@
       causing linkage errors referenced from
       ${pluralize(sourceClassCount, "source class", "source classes")}.
     </p>
-    <#list jarLinkageReport.getCauses() as cause >
+    <#list jarLinkageReport.getUnresolvableTargets() as cause >
       <#assign sourceClasses = jarLinkageReport.getSourceClasses(cause) />
       <p class="jar-linkage-report-cause">${cause?html}, referenced from ${
         pluralize(sourceClasses?size, "source class", "source classes")?html}

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -15,9 +15,9 @@
       causing linkage errors referenced from
       ${pluralize(sourceClassCount, "source class", "source classes")}.
     </p>
-    <#list jarLinkageReport.getUnresolvableTargets() as cause >
-      <#assign sourceClasses = jarLinkageReport.getSourceClasses(cause) />
-      <p class="jar-linkage-report-cause">${cause?html}, referenced from ${
+    <#list jarLinkageReport.getUnresolvableTargets() as unresolvableTarget >
+      <#assign sourceClasses = jarLinkageReport.getSourceClasses(unresolvableTarget) />
+      <p class="jar-linkage-report-cause">${unresolvableTarget?html}, referenced from ${
         pluralize(sourceClasses?size, "source class", "source classes")?html}
         <button onclick="toggleSourceClassListVisibility(this)"
                 title="Toggle visibility of source class list">▶

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
@@ -40,8 +40,8 @@ import java.util.Set;
 public abstract class JarLinkageReport {
 
   /**
-   * Returns the absolute path of the jar file that was checked. This is where the source classes
-   * were found.
+   * Returns the absolute path of the jar file that was checked. The source classes
+   * of the reported errors are all in this JAR.
    */
   public abstract Path getJarPath();
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/JarLinkageReport.java
@@ -34,13 +34,14 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * The result of checking linkages in one jar file.
+ * Linkage problems found in one jar file given a specific classpath.
  */
 @AutoValue
 public abstract class JarLinkageReport {
 
   /**
-   * Returns the absolute path of the jar file containing source classes of linkage errors
+   * Returns the absolute path of the jar file that was checked. This is where the source classes
+   * were found.
    */
   public abstract Path getJarPath();
 
@@ -92,15 +93,11 @@ public abstract class JarLinkageReport {
     return builder.toString();
   }
 
-  /** Returns map from the cause of linkage errors to class names affected by the errors. */
-  // TODO this is only used by formatJarLinkageReport in macros.ftl. We should be able to
-  // refactor this to make it a lot clearer by removing ImmutableMultimap from the API.
+  /** 
+   * Map missing classes and members to classes that refer to those items.
+   */
   @Memoized
-  ImmutableMultimap<LinkageErrorCause, String> getCauseToSourceClasses() {
-    return mapCauseToSourceClasses();
-  }
-
-  private ImmutableMultimap<LinkageErrorCause, String> mapCauseToSourceClasses() {
+  ImmutableMultimap<LinkageErrorCause, String> getTargetToSources() {
     ImmutableListMultimap<LinkageErrorCause, SymbolNotResolvable<ClassSymbolReference>>
         groupedClassErrors = Multimaps.index(getMissingClassErrors(), LinkageErrorCause::from);
 
@@ -141,29 +138,29 @@ public abstract class JarLinkageReport {
    * @return the total number of classes that refer to missing or inaccessible members
    */
   public int getErrorCount() {
-    return getCauseToSourceClasses().size();
+    return getTargetToSources().size();
   }
   
   /**
-   * @return the total number of missing or inaccessible members
+   * @return the total number of missing or inaccessible targets
    */
   public int getTargetClassCount() {
-    return getCauses().size();
+    return getUnresolvableTargets().size();
   }
   
   /**
-   * @return the references to missing or inaccessible members
+   * @return the references to missing or inaccessible targets
    */
-  public Set<LinkageErrorCause> getCauses() {
-    return getCauseToSourceClasses().keySet();
+  public Set<LinkageErrorCause> getUnresolvableTargets() {
+    return getTargetToSources().keySet();
   }
 
   /**
    * @return the fully qualified names of classes that refer to a
-   *     particular missing or inaccessible members
+   *     particular unresolvable target.
    */
   public ImmutableCollection<String> getSourceClasses(LinkageErrorCause cause) {
-    return getCauseToSourceClasses().get(cause);
+    return getTargetToSources().get(cause);
   }
   
   public JarLinkageReport reachableErrors() {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorCause.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageErrorCause.java
@@ -22,6 +22,8 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 // TODO "cause" is unclear. Is it the target or the source? I don't know.
 // Rename things to remove the word "cause" and use more specific terminology.
+// why do we need this class at all? It's just a wrapper around a SymbolNotResolvable.
+// It has no extra information.
 abstract class LinkageErrorCause {
 
   /** Returns the reason for the error */
@@ -32,7 +34,7 @@ abstract class LinkageErrorCause {
    * This is a class name, field name, or method name. 
    */
   abstract String getSymbol();
-
+  
   static <T extends SymbolReference> LinkageErrorCause from(
       SymbolNotResolvable<T> staticLinkageError) {
     String symbolName = symbolNameFrom(staticLinkageError);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolNotResolvable.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolNotResolvable.java
@@ -35,7 +35,7 @@ abstract class SymbolNotResolvable<T extends SymbolReference> {
   abstract T getReference();
 
   /**
-   * Returns the path to the class where symbol reference was expected to be found.
+   * Returns the path to the class where the target of the reference was expected to be found.
    * This is null if the target class is not found in the class path or the source
    * location is unavailable.
    */
@@ -163,17 +163,16 @@ abstract class SymbolNotResolvable<T extends SymbolReference> {
     INACCESSIBLE_CLASS,
 
     /**
-     * The member (method or field) is inaccessible to the source.
+     * The target member (method or field) is inaccessible to the source.
      *
      * <p>If the source is in a different package, the member is not public. If the source is in the
      * same package, the class is private. If the source is a subclass of the target class, the
-     * member is not protected.
+     * member is not protected or public.
      */
     INACCESSIBLE_MEMBER,
 
     /**
-     * For a method or field reference, the symbol is not found in the target class in the class
-     * path.
+     * For a method or field reference, the symbol is not found in the target class.
      */
     SYMBOL_NOT_FOUND
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReference.java
@@ -18,7 +18,7 @@ package com.google.cloud.tools.opensource.classpath;
 
 /**
  * A reference to a symbol of {@code targetClass} from {@code sourceClass}. The values of the class
- * names are fully-qualified form known as binary names. For example {@code
+ * names are in the fully-qualified form known as binary names. For example, {@code
  * io.grpc.MethodDescriptor$MethodType}.
  *
  * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.1">Java
@@ -35,7 +35,9 @@ interface SymbolReference {
    * reference.
    */
   String getTargetClassName();
-
+  
+  
+  // TODO does this belong in SymbolNotResolvable instead?
   /**
    * Returns a string describing the missing reference for display to an end user.
    */

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
@@ -151,14 +151,13 @@ public class JarLinkageReportTest {
   }  
   
   @Test
-  public void testGetCauseToSourceClasses() {
-    ImmutableMultimap<LinkageErrorCause, String> causeToSourceClasses =
-        jarLinkageReport.getTargetToSources();
+  public void testGetTargetToSources() {
+    ImmutableMultimap<LinkageErrorCause, String> map = jarLinkageReport.getTargetToSources();
 
-    ImmutableSet<LinkageErrorCause> linkageErrorCauses = causeToSourceClasses.keySet();
+    ImmutableSet<LinkageErrorCause> linkageErrorCauses = map.keySet();
     Truth.assertThat(linkageErrorCauses).hasSize(3);
     ImmutableCollection<String> classesForFirstCause =
-        causeToSourceClasses.get(linkageErrorCauses.iterator().next());
+        map.get(linkageErrorCauses.iterator().next());
     // InnerC should not appear here
     Truth.assertThat(classesForFirstCause).containsExactly("ClassB", "ClassC");
   }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/JarLinkageReportTest.java
@@ -153,7 +153,7 @@ public class JarLinkageReportTest {
   @Test
   public void testGetCauseToSourceClasses() {
     ImmutableMultimap<LinkageErrorCause, String> causeToSourceClasses =
-        jarLinkageReport.getCauseToSourceClasses();
+        jarLinkageReport.getTargetToSources();
 
     ImmutableSet<LinkageErrorCause> linkageErrorCauses = causeToSourceClasses.keySet();
     Truth.assertThat(linkageErrorCauses).hasSize(3);


### PR DESCRIPTION
@netdpb This begins removing the confusing terminology "cause" from the code base. I think we can also get rid of the `LinkageErrorCause` class completely since it's jsut a wrapper around a `SymbolNotResolvable` used as a key in the map. However that started to turn into a bigger change, so I thought I should send this out here before the changes get too big to follow.