### PR TITLE
To remove unnecessary argument validation in DashboardMain

### DIFF
--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -95,10 +95,6 @@ public class DashboardMain {
       throws IOException, TemplateException, RepositoryException, URISyntaxException,
           PlexusContainerException, ComponentLookupException, ProjectBuildingException,
           ParseException {
-    if (arguments.length != 1) {
-      System.err.println("Please specify path to pom.xml or Maven coordinates for a BOM.");
-      return;
-    }
     DashboardArguments dashboardArguments = DashboardArguments.readCommandLine(arguments);
     Path output =
         dashboardArguments.hasFile()


### PR DESCRIPTION
Fixes #578 

Without the unnecessary validation, DashboardMain can reject invalid arguments:

![image](https://user-images.githubusercontent.com/28604/56527312-769c7c00-651b-11e9-9771-942840bf9c4c.png)

