### PR TITLE
Scanning jar files with new value class

### DIFF
--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -316,7 +316,7 @@ public class DashboardTest {
     Nodes linkageCheckMessages = document.query("//ul[@class='jar-linkage-report-cause']/li");
     Truth.assertThat(linkageCheckMessages.size()).isGreaterThan(0);
     Truth.assertThat(linkageCheckMessages.get(0).getValue())
-        .contains("com.google.appengine.api.appidentity.AppIdentityServicePb");
+        .contains("com.google.appengine.api.taskqueue.TaskQueuePb");
   }
 
   @Test

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -316,7 +316,7 @@ public class DashboardTest {
     Nodes linkageCheckMessages = document.query("//ul[@class='jar-linkage-report-cause']/li");
     Truth.assertThat(linkageCheckMessages.size()).isGreaterThan(0);
     Truth.assertThat(linkageCheckMessages.get(0).getValue())
-        .contains("com.google.appengine.api.taskqueue.TaskQueuePb");
+        .contains("com.google.appengine.api.appidentity.AppIdentityServicePb");
   }
 
   @Test

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -35,7 +35,6 @@ import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Attribute;
@@ -147,10 +146,8 @@ class ClassDumper {
   }
 
   /**
-   * Scans the class path for symbol references from classes to class symbols, method symbols and
-   * field symbols.
-   *
-   * @return the set of symbol references found in the class path.
+   * Returns a set of symbol references (classes to class symbols, method symbols and field symbols)
+   * found in the class path.
    */
   ClassToSymbolReferences scanSymbolReferencesInClassPath() throws IOException {
     ClassToSymbolReferences.Builder builder = new ClassToSymbolReferences.Builder();
@@ -168,8 +165,8 @@ class ClassDumper {
   }
 
   /**
-   * Returns true if {@code javaClass} file format is compatible with this tool. Currently Java 8
-   * and earlier are supported.
+   * Returns true if {@code javaClass} file format is compatible with this tool. Currently
+   * Java 8 and earlier are supported.
    *
    * @see <a href="https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.1">Java
    *     Virtual Machine Specification: The ClassFile Structure: minor_version, major_version</a>
@@ -353,7 +350,9 @@ class ClassDumper {
     com.google.common.reflect.ClassPath classPath =
         com.google.common.reflect.ClassPath.from(classLoaderFromJar);
 
-    return classPath.getAllClasses().stream().map(ClassInfo::getName).collect(toImmutableSet());
+    return classPath.getAllClasses().stream()
+        .map(ClassInfo::getName)
+        .collect(toImmutableSet());
   }
 
   /**
@@ -535,7 +534,7 @@ class ClassDumper {
     try {
       JavaClass sourceJavaClass = loadJavaClass(sourceClassName);
 
-      for (String interfaceName : sourceJavaClass.getInterfaceNames()) {
+      for (String interfaceName: sourceJavaClass.getInterfaceNames()) {
         if (interfaceName.equals(targetClassName)) {
           // The target class is used in interfaces
           return false;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -146,11 +146,11 @@ class ClassDumper {
   }
 
   /**
-   * Returns a set of symbol references (classes to class symbols, method symbols and field symbols)
-   * found in the class path.
+   * Returns a set of symbol references (maps from classes to class symbols, method symbols and
+   * field symbols) found in the class path.
    */
-  ClassToSymbolReferences scanSymbolReferencesInClassPath() throws IOException {
-    ClassToSymbolReferences.Builder builder = new ClassToSymbolReferences.Builder();
+  SymbolReferenceMaps scanSymbolReferencesInClassPath() throws IOException {
+    SymbolReferenceMaps.Builder builder = new SymbolReferenceMaps.Builder();
 
     for (Path jar : inputClassPath) {
       for (JavaClass javaClass : listClassesInJar(jar)) {
@@ -176,9 +176,9 @@ class ClassDumper {
     return 45 <= classFileMajorVersion && classFileMajorVersion <= 52;
   }
 
-  private static ClassToSymbolReferences.Builder scanSymbolReferencesInClass(
+  private static SymbolReferenceMaps.Builder scanSymbolReferencesInClass(
       Path jar, JavaClass javaClass) {
-    ClassToSymbolReferences.Builder builder = new ClassToSymbolReferences.Builder();
+    SymbolReferenceMaps.Builder builder = new SymbolReferenceMaps.Builder();
     ClassFile source = new ClassFile(jar, javaClass.getClassName());
 
     ConstantPool constantPool = javaClass.getConstantPool();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -179,7 +179,7 @@ class ClassDumper {
   private static ClassToSymbolReferences.Builder scanSymbolReferencesInClass(
       Path jar, JavaClass javaClass) {
     ClassToSymbolReferences.Builder builder = new ClassToSymbolReferences.Builder();
-    ClassAndJar source = new ClassAndJar(jar, javaClass.getClassName());
+    ClassFile source = new ClassFile(jar, javaClass.getClassName());
 
     ConstantPool constantPool = javaClass.getConstantPool();
     Constant[] constants = constantPool.getConstantPool();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -146,8 +146,7 @@ class ClassDumper {
   }
 
   /**
-   * Returns symbol references (maps from classes to class symbols, method symbols and field
-   * symbols) found in the class path.
+   * Returns a map from classes to the symbol references they contain.
    */
   SymbolReferenceMaps findSymbolReferences() throws IOException {
     SymbolReferenceMaps.Builder builder = new SymbolReferenceMaps.Builder();
@@ -251,10 +250,10 @@ class ClassDumper {
     // Adjust the internal form to comply with binary names defined in JLS 13.1
     String targetClassName = targetClassNameInternalForm.replace('/', '.');
     String superClassName = sourceClass.getSuperclassName();
-    boolean isInheritance = superClassName.equals(targetClassName);
 
-    if (isInheritance) {
-      // A relationship between a superclass and subclass needs special validation for 'final'.
+    // Relationships between superclass and subclass need special validation for 'final' keyword
+    boolean referenceIsForInheritance = superClassName.equals(targetClassName);
+    if (referenceIsForInheritance) {
       return new SuperClassSymbol(targetClassName);
     }
     return new ClassSymbol(targetClassName);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
@@ -35,7 +35,7 @@ final class ClassFile {
     this.className = checkNotNull(className);
   }
 
-  /** Returns jar file containing the class. */
+  /** Returns the path to the JAR file containing the class. */
   Path getJar() {
     return jar;
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.opensource.classpath;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.MoreObjects;
 import java.nio.file.Path;
 import java.util.Objects;
 
@@ -25,11 +26,11 @@ import java.util.Objects;
  * A tuple of a class name and a jar file to uniquely locate the class implementation in a class
  * path.
  */
-final class ClassAndJar {
+final class ClassFile {
   private final Path jar;
   private final String className;
 
-  ClassAndJar(Path jar, String className) {
+  ClassFile(Path jar, String className) {
     this.jar = checkNotNull(jar);
     this.className = checkNotNull(className);
   }
@@ -52,12 +53,20 @@ final class ClassAndJar {
     if (other == null || getClass() != other.getClass()) {
       return false;
     }
-    ClassAndJar that = (ClassAndJar) other;
+    ClassFile that = (ClassFile) other;
     return Objects.equals(jar, that.jar) && Objects.equals(className, that.className);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(jar, className);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("jar", jar)
+        .add("className", className)
+        .toString();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbol.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
+import com.google.common.base.MoreObjects;
+
 /** Symbol for a class. */
 class ClassSymbol extends Symbol {
   ClassSymbol(String className) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
@@ -35,7 +35,7 @@ abstract class ClassSymbolReference implements SymbolReference {
   /**
    * Creates an instance from {@code source} and {@code symbol}.
    */
-  static ClassSymbolReference fromSymbol(ClassAndJar source, ClassSymbol symbol) {
+  static ClassSymbolReference fromSymbol(ClassFile source, ClassSymbol symbol) {
     // This method is for the refactoring (#574).
     return builder()
         .setTargetClassName(symbol.getClassName())

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
@@ -32,6 +32,18 @@ abstract class ClassSymbolReference implements SymbolReference {
     return getTargetClassName() + " is not found, referenced from " + getSourceClassName();
   }
 
+  /**
+   * Creates an instance from {@code source} and {@code symbol}.
+   */
+  static ClassSymbolReference fromSymbol(ClassAndJar source, ClassSymbol symbol) {
+    // This method is for the refactoring (#574).
+    return builder()
+        .setTargetClassName(symbol.getClassName())
+        .setSourceClassName(source.getClassName())
+        .setSubclass(symbol instanceof SuperClassSymbol)
+        .build();
+  }
+
   static Builder builder() {
     return new AutoValue_ClassSymbolReference.Builder();
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbolReference.java
@@ -40,6 +40,7 @@ abstract class ClassSymbolReference implements SymbolReference {
     return builder()
         .setTargetClassName(symbol.getClassName())
         .setSourceClassName(source.getClassName())
+        // Relationships between superclass and subclass need special validation for 'final' keyword
         .setSubclass(symbol instanceof SuperClassSymbol)
         .build();
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassToSymbolReferences.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassToSymbolReferences.java
@@ -27,36 +27,36 @@ import java.util.Objects;
  * symbols).
  */
 class ClassToSymbolReferences {
-  private final ImmutableSetMultimap<ClassAndJar, ClassSymbol> classToClassSymbols;
-  private final ImmutableSetMultimap<ClassAndJar, MethodSymbol> classToMethodSymbols;
-  private final ImmutableSetMultimap<ClassAndJar, FieldSymbol> classToFieldSymbols;
+  private final ImmutableSetMultimap<ClassFile, ClassSymbol> classToClassSymbols;
+  private final ImmutableSetMultimap<ClassFile, MethodSymbol> classToMethodSymbols;
+  private final ImmutableSetMultimap<ClassFile, FieldSymbol> classToFieldSymbols;
 
-  ImmutableSetMultimap<ClassAndJar, ClassSymbol> getClassToClassSymbols() {
+  ImmutableSetMultimap<ClassFile, ClassSymbol> getClassToClassSymbols() {
     return classToClassSymbols;
   }
 
-  ImmutableSetMultimap<ClassAndJar, MethodSymbol> getClassToMethodSymbols() {
+  ImmutableSetMultimap<ClassFile, MethodSymbol> getClassToMethodSymbols() {
     return classToMethodSymbols;
   }
 
-  ImmutableSetMultimap<ClassAndJar, FieldSymbol> getClassToFieldSymbols() {
+  ImmutableSetMultimap<ClassFile, FieldSymbol> getClassToFieldSymbols() {
     return classToFieldSymbols;
   }
 
   @VisibleForTesting
   ClassToSymbolReferences(
-      ImmutableSetMultimap<ClassAndJar, ClassSymbol> classToClassSymbols,
-      ImmutableSetMultimap<ClassAndJar, MethodSymbol> classToMethodSymbols,
-      ImmutableSetMultimap<ClassAndJar, FieldSymbol> classToFieldSymbols) {
+      ImmutableSetMultimap<ClassFile, ClassSymbol> classToClassSymbols,
+      ImmutableSetMultimap<ClassFile, MethodSymbol> classToMethodSymbols,
+      ImmutableSetMultimap<ClassFile, FieldSymbol> classToFieldSymbols) {
     this.classToClassSymbols = checkNotNull(classToClassSymbols);
     this.classToMethodSymbols = checkNotNull(classToMethodSymbols);
     this.classToFieldSymbols = checkNotNull(classToFieldSymbols);
   }
 
   static class Builder {
-    private final ImmutableSetMultimap.Builder<ClassAndJar, ClassSymbol> classToClassSymbols;
-    private final ImmutableSetMultimap.Builder<ClassAndJar, MethodSymbol> classToMethodSymbols;
-    private final ImmutableSetMultimap.Builder<ClassAndJar, FieldSymbol> classToFieldSymbols;
+    private final ImmutableSetMultimap.Builder<ClassFile, ClassSymbol> classToClassSymbols;
+    private final ImmutableSetMultimap.Builder<ClassFile, MethodSymbol> classToMethodSymbols;
+    private final ImmutableSetMultimap.Builder<ClassFile, FieldSymbol> classToFieldSymbols;
 
     Builder() {
       classToClassSymbols = ImmutableSetMultimap.builder();
@@ -64,17 +64,17 @@ class ClassToSymbolReferences {
       classToFieldSymbols = ImmutableSetMultimap.builder();
     }
 
-    Builder addClassReference(ClassAndJar source, ClassSymbol symbol) {
+    Builder addClassReference(ClassFile source, ClassSymbol symbol) {
       classToClassSymbols.put(source, symbol);
       return this;
     }
 
-    Builder addMethodReference(ClassAndJar source, MethodSymbol symbol) {
+    Builder addMethodReference(ClassFile source, MethodSymbol symbol) {
       classToMethodSymbols.put(source, symbol);
       return this;
     }
 
-    Builder addFieldReference(ClassAndJar source, FieldSymbol symbol) {
+    Builder addFieldReference(ClassFile source, FieldSymbol symbol) {
       classToFieldSymbols.put(source, symbol);
       return this;
     }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassToSymbolReferences.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassToSymbolReferences.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.classpath;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableSetMultimap;
+import java.util.Objects;
+
+/**
+ * A set of symbol references from source class to target symbols (class, method, and field
+ * symbols).
+ */
+class ClassToSymbolReferences {
+  private final ImmutableSetMultimap<ClassAndJar, ClassSymbol> classToClassSymbols;
+  private final ImmutableSetMultimap<ClassAndJar, MethodSymbol> classToMethodSymbols;
+  private final ImmutableSetMultimap<ClassAndJar, FieldSymbol> classToFieldSymbols;
+
+  ImmutableSetMultimap<ClassAndJar, ClassSymbol> getClassToClassSymbols() {
+    return classToClassSymbols;
+  }
+
+  ImmutableSetMultimap<ClassAndJar, MethodSymbol> getClassToMethodSymbols() {
+    return classToMethodSymbols;
+  }
+
+  ImmutableSetMultimap<ClassAndJar, FieldSymbol> getClassToFieldSymbols() {
+    return classToFieldSymbols;
+  }
+
+  private ClassToSymbolReferences(
+      ImmutableSetMultimap<ClassAndJar, ClassSymbol> classToClassSymbols,
+      ImmutableSetMultimap<ClassAndJar, MethodSymbol> classToMethodSymbols,
+      ImmutableSetMultimap<ClassAndJar, FieldSymbol> classToFieldSymbols) {
+    this.classToClassSymbols = checkNotNull(classToClassSymbols);
+    this.classToMethodSymbols = checkNotNull(classToMethodSymbols);
+    this.classToFieldSymbols = checkNotNull(classToFieldSymbols);
+  }
+
+  static class Builder {
+    private final ImmutableSetMultimap.Builder<ClassAndJar, ClassSymbol> classToClassSymbols;
+    private final ImmutableSetMultimap.Builder<ClassAndJar, MethodSymbol> classToMethodSymbols;
+    private final ImmutableSetMultimap.Builder<ClassAndJar, FieldSymbol> classToFieldSymbols;
+
+    Builder() {
+      classToClassSymbols = ImmutableSetMultimap.builder();
+      classToMethodSymbols = ImmutableSetMultimap.builder();
+      classToFieldSymbols = ImmutableSetMultimap.builder();
+    }
+
+    Builder addClassReference(ClassAndJar source, ClassSymbol symbol) {
+      classToClassSymbols.put(source, symbol);
+      return this;
+    }
+
+    Builder addMethodReference(ClassAndJar source, MethodSymbol symbol) {
+      classToMethodSymbols.put(source, symbol);
+      return this;
+    }
+
+    Builder addFieldReference(ClassAndJar source, FieldSymbol symbol) {
+      classToFieldSymbols.put(source, symbol);
+      return this;
+    }
+
+    ClassToSymbolReferences build() {
+      return new ClassToSymbolReferences(
+          classToClassSymbols.build(), classToMethodSymbols.build(), classToFieldSymbols.build());
+    }
+
+    Builder addAll(Builder other) {
+      classToClassSymbols.putAll(other.classToClassSymbols.build());
+      classToMethodSymbols.putAll(other.classToMethodSymbols.build());
+      classToFieldSymbols.putAll(other.classToFieldSymbols.build());
+      return this;
+    }
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    ClassToSymbolReferences that = (ClassToSymbolReferences) other;
+    return classToClassSymbols.equals(that.classToClassSymbols)
+        && classToMethodSymbols.equals(that.classToMethodSymbols)
+        && classToFieldSymbols.equals(that.classToFieldSymbols);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(classToClassSymbols, classToMethodSymbols, classToFieldSymbols);
+  }
+}

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassToSymbolReferences.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassToSymbolReferences.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.opensource.classpath;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSetMultimap;
 import java.util.Objects;
 
@@ -42,7 +43,8 @@ class ClassToSymbolReferences {
     return classToFieldSymbols;
   }
 
-  private ClassToSymbolReferences(
+  @VisibleForTesting
+  ClassToSymbolReferences(
       ImmutableSetMultimap<ClassAndJar, ClassSymbol> classToClassSymbols,
       ImmutableSetMultimap<ClassAndJar, MethodSymbol> classToMethodSymbols,
       ImmutableSetMultimap<ClassAndJar, FieldSymbol> classToFieldSymbols) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ErrorType.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ErrorType.java
@@ -17,7 +17,7 @@
 package com.google.cloud.tools.opensource.classpath;
 
 /** The kind of linkage error against a symbol reference. */
-enum Reason {
+enum ErrorType {
   /** The target class of the symbol reference is not found in the class path. */
   CLASS_NOT_FOUND,
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbol.java
@@ -16,6 +16,7 @@ package com.google.cloud.tools.opensource.classpath;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.MoreObjects;
 import java.util.Objects;
 
 /** Symbol for a field of a class. */
@@ -63,5 +64,14 @@ final class FieldSymbol extends Symbol {
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), name, descriptor);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("className", getClassName())
+        .add("name", name)
+        .add("descriptor", descriptor)
+        .toString();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
@@ -35,6 +35,18 @@ abstract class FieldSymbolReference implements SymbolReference {
         + getSourceClassName();
   }
 
+  /**
+   * Creates an instance from {@code source} and {@code symbol}.
+   */
+  static FieldSymbolReference fromSymbol(ClassAndJar source, FieldSymbol symbol) {
+    // This method is for the refactoring (#574).
+    return builder()
+        .setTargetClassName(symbol.getClassName())
+        .setFieldName(symbol.getName())
+        .setSourceClassName(source.getClassName())
+        .build();
+  }
+
   static Builder builder() {
     return new AutoValue_FieldSymbolReference.Builder();
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbolReference.java
@@ -38,7 +38,7 @@ abstract class FieldSymbolReference implements SymbolReference {
   /**
    * Creates an instance from {@code source} and {@code symbol}.
    */
-  static FieldSymbolReference fromSymbol(ClassAndJar source, FieldSymbol symbol) {
+  static FieldSymbolReference fromSymbol(ClassFile source, FieldSymbol symbol) {
     // This method is for the refactoring (#574).
     return builder()
         .setTargetClassName(symbol.getClassName())

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -89,8 +89,8 @@ public class LinkageChecker {
     this.classToSymbols = Preconditions.checkNotNull(symbolReferenceMaps);
   }
 
-  static private ImmutableMap<Path, SymbolReferenceSet> convert(List<Path> inputClassPath,
-      SymbolReferenceMaps classToSymbols) {
+  private static ImmutableMap<Path, SymbolReferenceSet> convert(
+      List<Path> inputClassPath, SymbolReferenceMaps classToSymbols) {
     ImmutableMap.Builder<Path, SymbolReferenceSet> jarToSymbolBuilder = ImmutableMap.builder();
 
     ImmutableSet.Builder<ClassFile> keys = ImmutableSet.builder();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -68,7 +68,7 @@ public class LinkageChecker {
         !jarPaths.isEmpty(),
         "The linkage classpath is empty. Specify input to supply one or more jar files");
     ClassDumper dumper = ClassDumper.create(jarPaths);
-    SymbolReferenceMaps symbolReferenceMaps = dumper.scanSymbolReferencesInClassPath();
+    SymbolReferenceMaps symbolReferenceMaps = dumper.findSymbolReferences();
 
     ImmutableMap<Path, SymbolReferenceSet> jarToSymbols =
         convert(jarPaths, symbolReferenceMaps);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -96,7 +96,7 @@ public class LinkageChecker {
       ClassToSymbolReferences classToSymbols) {
     ImmutableMap.Builder<Path, SymbolReferenceSet> jarToSymbolBuilder = ImmutableMap.builder();
 
-    Set<ClassAndJar> keys = Sets.newHashSet();
+    ImmutableSet.Builder<ClassAndJar> keys = ImmutableSet.builder();
     ImmutableSetMultimap<ClassAndJar, ClassSymbol> classSymbols =
         classToSymbols.getClassToClassSymbols();
     keys.addAll(classSymbols.keys());
@@ -107,7 +107,7 @@ public class LinkageChecker {
         classToSymbols.getClassToFieldSymbols();
     keys.addAll(fieldSymbols.keys());
     ImmutableMultimap<Path, ClassAndJar> pathToClassAndJar =
-        Multimaps.index(keys, ClassAndJar::getJar);
+        Multimaps.index(keys.build(), ClassAndJar::getJar);
 
     // Iterating through inputClassPath, not pathToClassAndJar.keySet(), avoids NullPointerException
     // for jar file containing no class (for example,

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -49,11 +49,11 @@ public class LinkageChecker {
 
   private final ClassDumper classDumper;
   private final ImmutableMap<Path, SymbolReferenceSet> jarToSymbols;
-  private final ClassToSymbolReferences classToSymbols;
+  private final SymbolReferenceMaps classToSymbols;
   private final ClassReferenceGraph classReferenceGraph;
 
   @VisibleForTesting
-  ClassToSymbolReferences getClassToSymbols() {
+  SymbolReferenceMaps getClassToSymbols() {
     return classToSymbols;
   }
 
@@ -68,29 +68,29 @@ public class LinkageChecker {
         !jarPaths.isEmpty(),
         "The linkage classpath is empty. Specify input to supply one or more jar files");
     ClassDumper dumper = ClassDumper.create(jarPaths);
-    ClassToSymbolReferences classToSymbolReferences = dumper.scanSymbolReferencesInClassPath();
+    SymbolReferenceMaps symbolReferenceMaps = dumper.scanSymbolReferencesInClassPath();
 
     ImmutableMap<Path, SymbolReferenceSet> jarToSymbols =
-        convert(jarPaths, classToSymbolReferences);
+        convert(jarPaths, symbolReferenceMaps);
     ClassReferenceGraph classReferenceGraph =
         ClassReferenceGraph.create(jarToSymbols.values(), ImmutableSet.copyOf(entryPoints));
 
-    return new LinkageChecker(dumper, jarToSymbols, classToSymbolReferences, classReferenceGraph);
+    return new LinkageChecker(dumper, jarToSymbols, symbolReferenceMaps, classReferenceGraph);
   }
 
   private LinkageChecker(
       ClassDumper classDumper,
       Map<Path, SymbolReferenceSet> jarToSymbols,
-      ClassToSymbolReferences classToSymbolReferences,
+      SymbolReferenceMaps symbolReferenceMaps,
       ClassReferenceGraph classReferenceGraph) {
     this.classDumper = Preconditions.checkNotNull(classDumper);
     this.jarToSymbols = ImmutableMap.copyOf(jarToSymbols);
     this.classReferenceGraph = Preconditions.checkNotNull(classReferenceGraph);
-    this.classToSymbols = Preconditions.checkNotNull(classToSymbolReferences);
+    this.classToSymbols = Preconditions.checkNotNull(symbolReferenceMaps);
   }
 
   static private ImmutableMap<Path, SymbolReferenceSet> convert(List<Path> inputClassPath,
-      ClassToSymbolReferences classToSymbols) {
+      SymbolReferenceMaps classToSymbols) {
     ImmutableMap.Builder<Path, SymbolReferenceSet> jarToSymbolBuilder = ImmutableMap.builder();
 
     ImmutableSet.Builder<ClassFile> keys = ImmutableSet.builder();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -27,13 +27,10 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Multimaps;
-import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -96,18 +93,18 @@ public class LinkageChecker {
       ClassToSymbolReferences classToSymbols) {
     ImmutableMap.Builder<Path, SymbolReferenceSet> jarToSymbolBuilder = ImmutableMap.builder();
 
-    ImmutableSet.Builder<ClassAndJar> keys = ImmutableSet.builder();
-    ImmutableSetMultimap<ClassAndJar, ClassSymbol> classSymbols =
+    ImmutableSet.Builder<ClassFile> keys = ImmutableSet.builder();
+    ImmutableSetMultimap<ClassFile, ClassSymbol> classSymbols =
         classToSymbols.getClassToClassSymbols();
     keys.addAll(classSymbols.keys());
-    ImmutableSetMultimap<ClassAndJar, MethodSymbol> methodSymbols =
+    ImmutableSetMultimap<ClassFile, MethodSymbol> methodSymbols =
         classToSymbols.getClassToMethodSymbols();
     keys.addAll(methodSymbols.keys());
-    ImmutableSetMultimap<ClassAndJar, FieldSymbol> fieldSymbols =
+    ImmutableSetMultimap<ClassFile, FieldSymbol> fieldSymbols =
         classToSymbols.getClassToFieldSymbols();
     keys.addAll(fieldSymbols.keys());
-    ImmutableMultimap<Path, ClassAndJar> pathToClassAndJar =
-        Multimaps.index(keys.build(), ClassAndJar::getJar);
+    ImmutableMultimap<Path, ClassFile> pathToClassAndJar =
+        Multimaps.index(keys.build(), ClassFile::getJar);
 
     // Iterating through inputClassPath, not pathToClassAndJar.keySet(), avoids NullPointerException
     // for jar file containing no class (for example,
@@ -115,7 +112,7 @@ public class LinkageChecker {
     for (Path jar : inputClassPath) {
       SymbolReferenceSet.Builder symbolReferenceSet = SymbolReferenceSet.builder();
 
-      for (ClassAndJar source : pathToClassAndJar.get(jar)) {
+      for (ClassFile source : pathToClassAndJar.get(jar)) {
         for (ClassSymbol symbol : classSymbols.get(source)) {
           symbolReferenceSet
               .classReferencesBuilder()

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbol.java
@@ -24,11 +24,13 @@ import java.util.Objects;
 final class MethodSymbol extends Symbol {
   private final String name;
   private final String descriptor;
+  private final boolean isInterfaceMethod;
 
-  MethodSymbol(String className, String name, String descriptor) {
+  MethodSymbol(String className, String name, String descriptor, boolean isInterfaceMethod) {
     super(className);
     this.name = checkNotNull(name);
     this.descriptor = checkNotNull(descriptor);
+    this.isInterfaceMethod = isInterfaceMethod;
   }
 
   /** Returns the name of the method. */
@@ -49,6 +51,11 @@ final class MethodSymbol extends Symbol {
     return descriptor;
   }
 
+  /** Returns true if {@link #getClassName()} is an interface. */
+  boolean isInterfaceMethod() {
+    return isInterfaceMethod;
+  }
+
   @Override
   public boolean equals(Object other) {
     if (this == other) {
@@ -61,11 +68,13 @@ final class MethodSymbol extends Symbol {
       return false;
     }
     MethodSymbol that = (MethodSymbol) other;
-    return name.equals(that.name) && descriptor.equals(that.descriptor);
+    return isInterfaceMethod == that.isInterfaceMethod
+        && name.equals(that.name)
+        && descriptor.equals(that.descriptor);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), name, descriptor);
+    return Objects.hash(super.hashCode(), name, descriptor, isInterfaceMethod);
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbol.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.opensource.classpath;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.MoreObjects;
 import java.util.Objects;
 
 /** Symbol for a method of class. */
@@ -76,5 +77,15 @@ final class MethodSymbol extends Symbol {
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), name, descriptor, isInterfaceMethod);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("className", getClassName())
+        .add("name", name)
+        .add("descriptor", descriptor)
+        .add("isInterfaceMethod", isInterfaceMethod)
+        .toString();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
@@ -18,14 +18,10 @@ package com.google.cloud.tools.opensource.classpath;
 
 import com.google.auto.value.AutoValue;
 
-/**
- * A symbol reference to a method of {@code targetClass} referenced from {@code sourceClass}.
- */
+/** A symbol reference to a method of {@code targetClass} referenced from {@code sourceClass}. */
 @AutoValue
-abstract class MethodSymbolReference implements SymbolReference  {
-  /**
-   * Returns the method name of the reference. Example: {@code marshaller}
-   */
+abstract class MethodSymbolReference implements SymbolReference {
+  /** Returns the method name of the reference. Example: {@code marshaller} */
   abstract String getMethodName();
 
   /** Returns true if {@code targetClassName} is an interface. */
@@ -44,6 +40,20 @@ abstract class MethodSymbolReference implements SymbolReference  {
 
   static Builder builder() {
     return new AutoValue_MethodSymbolReference.Builder();
+  }
+
+  /**
+   * Creates an instance from {@code source} and {@code symbol}.
+   */
+  static MethodSymbolReference fromSymbol(ClassAndJar source, MethodSymbol symbol) {
+    // This method is for the refactoring (#574).
+    return builder()
+        .setTargetClassName(symbol.getClassName())
+        .setMethodName(symbol.getName())
+        .setInterfaceMethod(symbol.isInterfaceMethod())
+        .setDescriptor(symbol.getDescriptor())
+        .setSourceClassName(source.getClassName())
+        .build();
   }
 
   @AutoValue.Builder

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbolReference.java
@@ -45,7 +45,7 @@ abstract class MethodSymbolReference implements SymbolReference {
   /**
    * Creates an instance from {@code source} and {@code symbol}.
    */
-  static MethodSymbolReference fromSymbol(ClassAndJar source, MethodSymbol symbol) {
+  static MethodSymbolReference fromSymbol(ClassFile source, MethodSymbol symbol) {
     // This method is for the refactoring (#574).
     return builder()
         .setTargetClassName(symbol.getClassName())

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SuperClassSymbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SuperClassSymbol.java
@@ -19,7 +19,8 @@ package com.google.cloud.tools.opensource.classpath;
 /**
  * Symbol for a super class. This symbol is a special case of {@link ClassSymbol} when it is
  * referenced only from its subclasses. Treating super class symbols apart from {@link ClassSymbol}
- * helps to validate the relationship between a superclass and its subclasses.
+ * helps to validate the relationship between a superclass and its subclasses, with regard to {code
+ * final} keyword.
  *
  * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.10">Java
  *     Virtual Machine Specification: 4.10. Verification of class Files</a>

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SuperClassSymbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SuperClassSymbol.java
@@ -16,9 +16,16 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-/** Symbol for a class. */
-class ClassSymbol extends Symbol {
-  ClassSymbol(String className) {
+/**
+ * Symbol for a super class. This symbol is a special case of {@link ClassSymbol} when it is
+ * referenced only from its subclasses. Treating super class symbols apart from {@link ClassSymbol}
+ * helps to validate the relationship between a superclass and its subclasses.
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.10">Java
+ *     Virtual Machine Specification: 4.10. Verification of class Files</a>
+ */
+final class SuperClassSymbol extends ClassSymbol {
+  SuperClassSymbol(String className) {
     super(className);
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/Symbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/Symbol.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.opensource.classpath;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.MoreObjects;
 import java.util.Objects;
 
 /**
@@ -60,5 +61,12 @@ abstract class Symbol {
   @Override
   public int hashCode() {
     return Objects.hash(className);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("className", className)
+        .toString();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
@@ -32,19 +32,19 @@ import javax.annotation.Nullable;
  */
 final class SymbolProblem {
 
-  private final Reason reason;
+  private final ErrorType errorType;
   private final Symbol symbol;
   private final ClassFile targetClass;
 
-  SymbolProblem(Symbol symbol, Reason reason, @Nullable ClassFile targetClass) {
+  SymbolProblem(Symbol symbol, ErrorType errorType, @Nullable ClassFile targetClass) {
     this.symbol = checkNotNull(symbol);
-    this.reason = checkNotNull(reason);
+    this.errorType = checkNotNull(errorType);
     this.targetClass = targetClass;
   }
 
-  /** Returns the reason why the symbol was not resolved. */
-  Reason getReason() {
-    return reason;
+  /** Returns the errorType why the symbol was not resolved. */
+  ErrorType getErrorType() {
+    return errorType;
   }
 
   /** Returns the target symbol that was not resolved. */
@@ -54,7 +54,7 @@ final class SymbolProblem {
 
   /**
    * Returns the referenced class of the linkage conflict. Null when the target class is not found
-   * in the class path (this is the case if the reason is {@code CLASS_NOT_FOUND} for top-level
+   * in the class path (this is the case if the errorType is {@code CLASS_NOT_FOUND} for top-level
    * classes).
    *
    * <p>In case of an nested class is missing while its outer class is found in the class path, this
@@ -74,20 +74,20 @@ final class SymbolProblem {
       return false;
     }
     SymbolProblem that = (SymbolProblem) other;
-    return reason == that.reason
+    return errorType == that.errorType
         && symbol.equals(that.symbol)
         && Objects.equals(targetClass, that.targetClass);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(reason, symbol, targetClass);
+    return Objects.hash(errorType, symbol, targetClass);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("reason", reason)
+        .add("errorType", errorType)
         .add("symbol", symbol)
         .add("targetClass", targetClass)
         .toString();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
@@ -57,7 +57,7 @@ final class SymbolProblem {
    * in the class path (this is the case if the errorType is {@code CLASS_NOT_FOUND} for top-level
    * classes).
    *
-   * <p>In case of an nested class is missing while its outer class is found in the class path, this
+   * <p>In case of a nested class is missing while its outer class is found in the class path, this
    * method returns the outer class.
    */
   @Nullable

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.opensource.classpath;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.MoreObjects;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
@@ -33,9 +34,9 @@ final class SymbolProblem {
 
   private final Reason reason;
   private final Symbol symbol;
-  private final ClassAndJar targetClass;
+  private final ClassFile targetClass;
 
-  SymbolProblem(Symbol symbol, Reason reason, @Nullable ClassAndJar targetClass) {
+  SymbolProblem(Symbol symbol, Reason reason, @Nullable ClassFile targetClass) {
     this.symbol = checkNotNull(symbol);
     this.reason = checkNotNull(reason);
     this.targetClass = targetClass;
@@ -53,13 +54,14 @@ final class SymbolProblem {
 
   /**
    * Returns the referenced class of the linkage conflict. Null when the target class is not found
-   * in the class path (this is the case if the reason is {@code CLASS_NOT_FOUND}).
+   * in the class path (this is the case if the reason is {@code CLASS_NOT_FOUND} for top-level
+   * classes).
    *
-   * <p>In case of an inner class is missing while its outer class is found in the class path, this
+   * <p>In case of an nested class is missing while its outer class is found in the class path, this
    * method returns the outer class.
    */
   @Nullable
-  ClassAndJar getTargetClass() {
+  ClassFile getTargetClass() {
     return targetClass;
   }
 
@@ -80,5 +82,14 @@ final class SymbolProblem {
   @Override
   public int hashCode() {
     return Objects.hash(reason, symbol, targetClass);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("reason", reason)
+        .add("symbol", symbol)
+        .add("targetClass", targetClass)
+        .toString();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReferenceMaps.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReferenceMaps.java
@@ -23,8 +23,8 @@ import com.google.common.collect.ImmutableSetMultimap;
 import java.util.Objects;
 
 /**
- * A set of symbol references from source class to target symbols (class, method, and field
- * symbols).
+ * A set of symbol references. Symbol references are stored as maps from {@link ClassFile} to {@link
+ * ClassSymbol}s, {@link MethodSymbol}s, and {@link FieldSymbol}s.
  */
 class SymbolReferenceMaps {
   private final ImmutableSetMultimap<ClassFile, ClassSymbol> classToClassSymbols;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReferenceMaps.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolReferenceMaps.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * A set of symbol references from source class to target symbols (class, method, and field
  * symbols).
  */
-class ClassToSymbolReferences {
+class SymbolReferenceMaps {
   private final ImmutableSetMultimap<ClassFile, ClassSymbol> classToClassSymbols;
   private final ImmutableSetMultimap<ClassFile, MethodSymbol> classToMethodSymbols;
   private final ImmutableSetMultimap<ClassFile, FieldSymbol> classToFieldSymbols;
@@ -44,7 +44,7 @@ class ClassToSymbolReferences {
   }
 
   @VisibleForTesting
-  ClassToSymbolReferences(
+  SymbolReferenceMaps(
       ImmutableSetMultimap<ClassFile, ClassSymbol> classToClassSymbols,
       ImmutableSetMultimap<ClassFile, MethodSymbol> classToMethodSymbols,
       ImmutableSetMultimap<ClassFile, FieldSymbol> classToFieldSymbols) {
@@ -79,8 +79,8 @@ class ClassToSymbolReferences {
       return this;
     }
 
-    ClassToSymbolReferences build() {
-      return new ClassToSymbolReferences(
+    SymbolReferenceMaps build() {
+      return new SymbolReferenceMaps(
           classToClassSymbols.build(), classToMethodSymbols.build(), classToFieldSymbols.build());
     }
 
@@ -100,7 +100,7 @@ class ClassToSymbolReferences {
     if (other == null || getClass() != other.getClass()) {
       return false;
     }
-    ClassToSymbolReferences that = (ClassToSymbolReferences) other;
+    SymbolReferenceMaps that = (SymbolReferenceMaps) other;
     return classToClassSymbols.equals(that.classToClassSymbols)
         && classToMethodSymbols.equals(that.classToMethodSymbols)
         && classToFieldSymbols.equals(that.classToFieldSymbols);

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -106,7 +106,7 @@ public class ClassDumperTest {
   public void testScanSymbolTableFromClassPath() throws URISyntaxException, IOException {
     Path path = absolutePathOfResource(GRPC_CLOUD_FIRESTORE_JAR);
     SymbolReferenceMaps symbolReferenceMaps =
-        ClassDumper.create(ImmutableList.of(path)).scanSymbolReferencesInClassPath();
+        ClassDumper.create(ImmutableList.of(path)).findSymbolReferences();
 
     // Class reference
     Truth.assertWithMessage("Class reference should have binary names defined in JLS 13.1")
@@ -149,7 +149,7 @@ public class ClassDumperTest {
 
     Path path = Paths.get(jarUrl.toURI());
     SymbolReferenceMaps symbolReferenceMaps =
-        ClassDumper.create(ImmutableList.of(path)).scanSymbolReferencesInClassPath();
+        ClassDumper.create(ImmutableList.of(path)).findSymbolReferences();
 
     Truth.assertThat(symbolReferenceMaps.getClassToClassSymbols().inverse().keys())
         .comparingElementsUsing(SYMBOL_TARGET_CLASS_NAME)
@@ -161,7 +161,7 @@ public class ClassDumperTest {
       throws URISyntaxException, IOException {
     Path path = absolutePathOfResource("testdata/api-common-1.7.0.jar");
     SymbolReferenceMaps symbolReferenceMaps =
-        ClassDumper.create(ImmutableList.of(path)).scanSymbolReferencesInClassPath();
+        ClassDumper.create(ImmutableList.of(path)).findSymbolReferences();
 
     boolean isInterfaceMethod = true;
     Truth.assertThat(symbolReferenceMaps.getClassToMethodSymbols())

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -105,25 +105,25 @@ public class ClassDumperTest {
   @Test
   public void testScanSymbolTableFromClassPath() throws URISyntaxException, IOException {
     Path path = absolutePathOfResource(GRPC_CLOUD_FIRESTORE_JAR);
-    ClassToSymbolReferences classToSymbolReferences =
+    SymbolReferenceMaps symbolReferenceMaps =
         ClassDumper.create(ImmutableList.of(path)).scanSymbolReferencesInClassPath();
 
     // Class reference
     Truth.assertWithMessage("Class reference should have binary names defined in JLS 13.1")
-        .that(classToSymbolReferences.getClassToClassSymbols())
+        .that(symbolReferenceMaps.getClassToClassSymbols())
         .containsEntry(
             new ClassFile(path, "com.google.firestore.v1beta1.FirestoreGrpc"),
             new ClassSymbol(
                 "com.google.firestore.v1beta1.FirestoreGrpc$FirestoreMethodDescriptorSupplier"));
 
     Truth.assertWithMessage("Reference to superclass should have SuperClassSymbol")
-        .that(classToSymbolReferences.getClassToClassSymbols())
+        .that(symbolReferenceMaps.getClassToClassSymbols())
         .containsEntry(
             new ClassFile(path, "com.google.firestore.v1beta1.FirestoreGrpc$FirestoreFutureStub"),
             new SuperClassSymbol("io.grpc.stub.AbstractStub"));
 
     // Method reference
-    Truth.assertThat(classToSymbolReferences.getClassToMethodSymbols())
+    Truth.assertThat(symbolReferenceMaps.getClassToMethodSymbols())
         .containsEntry(
             new ClassFile(path, "com.google.firestore.v1beta1.FirestoreGrpc"),
             new MethodSymbol(
@@ -133,7 +133,7 @@ public class ClassDumperTest {
                 false));
 
     // Field reference
-    Truth.assertThat(classToSymbolReferences.getClassToFieldSymbols())
+    Truth.assertThat(symbolReferenceMaps.getClassToFieldSymbols())
         .containsEntry(
             new ClassFile(path, "com.google.firestore.v1beta1.FirestoreGrpc"),
             new FieldSymbol(
@@ -148,10 +148,10 @@ public class ClassDumperTest {
     URL jarUrl = URLClassLoader.getSystemResource("testdata/gax-1.32.0.jar");
 
     Path path = Paths.get(jarUrl.toURI());
-    ClassToSymbolReferences classToSymbolReferences =
+    SymbolReferenceMaps symbolReferenceMaps =
         ClassDumper.create(ImmutableList.of(path)).scanSymbolReferencesInClassPath();
 
-    Truth.assertThat(classToSymbolReferences.getClassToClassSymbols().inverse().keys())
+    Truth.assertThat(symbolReferenceMaps.getClassToClassSymbols().inverse().keys())
         .comparingElementsUsing(SYMBOL_TARGET_CLASS_NAME)
         .doesNotContain("[Ljava.lang.Object;");
   }
@@ -160,11 +160,11 @@ public class ClassDumperTest {
   public void testScanSymbolReferencesInClass_shouldPickInterfaceReference()
       throws URISyntaxException, IOException {
     Path path = absolutePathOfResource("testdata/api-common-1.7.0.jar");
-    ClassToSymbolReferences classToSymbolReferences =
+    SymbolReferenceMaps symbolReferenceMaps =
         ClassDumper.create(ImmutableList.of(path)).scanSymbolReferencesInClassPath();
 
     boolean isInterfaceMethod = true;
-    Truth.assertThat(classToSymbolReferences.getClassToMethodSymbols())
+    Truth.assertThat(symbolReferenceMaps.getClassToMethodSymbols())
         .containsEntry(
             new ClassFile(path, "com.google.api.resourcenames.UntypedResourceName"),
             new MethodSymbol(

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -112,20 +112,20 @@ public class ClassDumperTest {
     Truth.assertWithMessage("Class reference should have binary names defined in JLS 13.1")
         .that(classToSymbolReferences.getClassToClassSymbols())
         .containsEntry(
-            new ClassAndJar(path, "com.google.firestore.v1beta1.FirestoreGrpc"),
+            new ClassFile(path, "com.google.firestore.v1beta1.FirestoreGrpc"),
             new ClassSymbol(
                 "com.google.firestore.v1beta1.FirestoreGrpc$FirestoreMethodDescriptorSupplier"));
 
     Truth.assertWithMessage("Reference to superclass should have SuperClassSymbol")
         .that(classToSymbolReferences.getClassToClassSymbols())
         .containsEntry(
-            new ClassAndJar(path, "com.google.firestore.v1beta1.FirestoreGrpc$FirestoreFutureStub"),
+            new ClassFile(path, "com.google.firestore.v1beta1.FirestoreGrpc$FirestoreFutureStub"),
             new SuperClassSymbol("io.grpc.stub.AbstractStub"));
 
     // Method reference
     Truth.assertThat(classToSymbolReferences.getClassToMethodSymbols())
         .containsEntry(
-            new ClassAndJar(path, "com.google.firestore.v1beta1.FirestoreGrpc"),
+            new ClassFile(path, "com.google.firestore.v1beta1.FirestoreGrpc"),
             new MethodSymbol(
                 "io.grpc.protobuf.ProtoUtils",
                 "marshaller",
@@ -135,7 +135,7 @@ public class ClassDumperTest {
     // Field reference
     Truth.assertThat(classToSymbolReferences.getClassToFieldSymbols())
         .containsEntry(
-            new ClassAndJar(path, "com.google.firestore.v1beta1.FirestoreGrpc"),
+            new ClassFile(path, "com.google.firestore.v1beta1.FirestoreGrpc"),
             new FieldSymbol(
                 "io.grpc.MethodDescriptor$MethodType",
                 "BIDI_STREAMING",
@@ -166,7 +166,7 @@ public class ClassDumperTest {
     boolean isInterfaceMethod = true;
     Truth.assertThat(classToSymbolReferences.getClassToMethodSymbols())
         .containsEntry(
-            new ClassAndJar(path, "com.google.api.resourcenames.UntypedResourceName"),
+            new ClassFile(path, "com.google.api.resourcenames.UntypedResourceName"),
             new MethodSymbol(
                 "java.util.Map",
                 "get",

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassInJarTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassInJarTest.java
@@ -27,24 +27,24 @@ import org.junit.Test;
 public class ClassInJarTest {
   @Test
   public void testCreation() {
-    ClassAndJar classInJar = new ClassAndJar(Paths.get("foo", "bar.jar"), "com.test.Foo");
+    ClassFile classInJar = new ClassFile(Paths.get("foo", "bar.jar"), "com.test.Foo");
     assertEquals("com.test.Foo", classInJar.getClassName());
     assertEquals(Paths.get("foo", "bar.jar"), classInJar.getJar());
   }
 
   @Test
   public void testNull() {
-    new NullPointerTester().testConstructors(ClassAndJar.class, Visibility.PACKAGE);
+    new NullPointerTester().testConstructors(ClassFile.class, Visibility.PACKAGE);
   }
 
   @Test
   public void testEquality() {
     new EqualsTester()
         .addEqualityGroup(
-            new ClassAndJar(Paths.get("foo", "bar.jar"), "com.test.Foo"),
-            new ClassAndJar(Paths.get("foo", "bar.jar"), "com.test.Foo"))
-        .addEqualityGroup(new ClassAndJar(Paths.get("abc", "bar.jar"), "com.test.Foo"))
-        .addEqualityGroup(new ClassAndJar(Paths.get("foo", "bar.jar"), "abc.Boo"))
+            new ClassFile(Paths.get("foo", "bar.jar"), "com.test.Foo"),
+            new ClassFile(Paths.get("foo", "bar.jar"), "com.test.Foo"))
+        .addEqualityGroup(new ClassFile(Paths.get("abc", "bar.jar"), "com.test.Foo"))
+        .addEqualityGroup(new ClassFile(Paths.get("foo", "bar.jar"), "abc.Boo"))
         .testEquals();
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -179,7 +179,7 @@ public class ClassPathBuilderTest {
                 + " 4.5.4")
         .that(classToSymbolReferences.getClassToClassSymbols())
         .doesNotContainEntry(
-            new ClassAndJar(
+            new ClassFile(
                 httpClientJar, "org.apache.http.client.protocol.ResponseContentEncoding"),
             new ClassSymbol("org.apache.http.client.entity.GZIPInputStreamFactory"));
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -172,12 +172,12 @@ public class ClassPathBuilderTest {
     // https://github.com/apache/httpcomponents-client/blob/e2cf733c60f910d17dc5cfc0a77797054a2e322e/httpclient/src/main/java/org/apache/http/conn/ssl/AbstractVerifier.java#L153
     ClassDumper dumper = ClassDumper.create(ImmutableList.of(httpClientJar));
 
-    ClassToSymbolReferences classToSymbolReferences = dumper.scanSymbolReferencesInClassPath();
+    SymbolReferenceMaps symbolReferenceMaps = dumper.scanSymbolReferencesInClassPath();
 
     Truth.assertWithMessage(
             "httpclient-4.5.3 shoud not contain GZipInputStreamFactory reference, which is added"
                 + " 4.5.4")
-        .that(classToSymbolReferences.getClassToClassSymbols())
+        .that(symbolReferenceMaps.getClassToClassSymbols())
         .doesNotContainEntry(
             new ClassFile(
                 httpClientJar, "org.apache.http.client.protocol.ResponseContentEncoding"),

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -172,7 +172,7 @@ public class ClassPathBuilderTest {
     // https://github.com/apache/httpcomponents-client/blob/e2cf733c60f910d17dc5cfc0a77797054a2e322e/httpclient/src/main/java/org/apache/http/conn/ssl/AbstractVerifier.java#L153
     ClassDumper dumper = ClassDumper.create(ImmutableList.of(httpClientJar));
 
-    SymbolReferenceMaps symbolReferenceMaps = dumper.scanSymbolReferencesInClassPath();
+    SymbolReferenceMaps symbolReferenceMaps = dumper.findSymbolReferences();
 
     Truth.assertWithMessage(
             "httpclient-4.5.3 shoud not contain GZipInputStreamFactory reference, which is added"

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassSymbolTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassSymbolTest.java
@@ -41,7 +41,8 @@ public class ClassSymbolTest {
     new EqualsTester()
         .addEqualityGroup(new ClassSymbol("java.lang.Object"), new ClassSymbol("java.lang.Object"))
         .addEqualityGroup(new ClassSymbol("java.lang.Long"))
-        .addEqualityGroup(new MethodSymbol("java.lang.Object", "equals", "foo"))
+        .addEqualityGroup(new SuperClassSymbol("java.lang.Object"))
+        .addEqualityGroup(new MethodSymbol("java.lang.Object", "equals", "foo", false))
         .testEquals();
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassToSymbolReferencesTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassToSymbolReferencesTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 public class ClassToSymbolReferencesTest {
   private Path path = Paths.get("foo", "bar.jar");
-  private ClassAndJar sourceClass = new ClassAndJar(path, "com.google.Foo");
+  private ClassFile sourceClass = new ClassFile(path, "com.google.Foo");
   private ClassSymbol classSymbol = new ClassSymbol("java.util.concurrent.TimeoutException");
   private MethodSymbol methodSymbol =
       new MethodSymbol(
@@ -65,7 +65,7 @@ public class ClassToSymbolReferencesTest {
     builder2.addMethodReference(sourceClass, methodSymbol);
     builder2.addFieldReference(sourceClass, fieldSymbol);
 
-    ClassAndJar sourceClass2 = new ClassAndJar(path, "com.google.Bar");
+    ClassFile sourceClass2 = new ClassFile(path, "com.google.Bar");
     ClassToSymbolReferences.Builder builder3 = new ClassToSymbolReferences.Builder();
     builder3.addClassReference(sourceClass2, classSymbol);
     builder3.addMethodReference(sourceClass, methodSymbol);
@@ -103,7 +103,7 @@ public class ClassToSymbolReferencesTest {
     builder1.addMethodReference(sourceClass, methodSymbol);
     builder1.addFieldReference(sourceClass, fieldSymbol);
 
-    ClassAndJar sourceClass2 = new ClassAndJar(path, "com.google.Bar");
+    ClassFile sourceClass2 = new ClassFile(path, "com.google.Bar");
     builder2.addClassReference(sourceClass2, classSymbol);
     builder2.addMethodReference(sourceClass2, methodSymbol);
     builder2.addFieldReference(sourceClass2, fieldSymbol);

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassToSymbolReferencesTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassToSymbolReferencesTest.java
@@ -17,6 +17,8 @@
 package com.google.cloud.tools.opensource.classpath;
 
 import com.google.common.testing.EqualsTester;
+import com.google.common.testing.NullPointerTester;
+import com.google.common.testing.NullPointerTester.Visibility;
 import com.google.common.truth.Truth;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -85,6 +87,11 @@ public class ClassToSymbolReferencesTest {
         .addEqualityGroup(builder4.build())
         .addEqualityGroup(builder5.build())
         .testEquals();
+  }
+
+  @Test
+  public void testNull() {
+    new NullPointerTester().testConstructors(ClassToSymbolReferences.class, Visibility.PACKAGE);
   }
 
   @Test

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassToSymbolReferencesTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassToSymbolReferencesTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.classpath;
+
+import com.google.common.testing.EqualsTester;
+import com.google.common.truth.Truth;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Test;
+
+public class ClassToSymbolReferencesTest {
+  private Path path = Paths.get("foo", "bar.jar");
+  private ClassAndJar sourceClass = new ClassAndJar(path, "com.google.Foo");
+  private ClassSymbol classSymbol = new ClassSymbol("java.util.concurrent.TimeoutException");
+  private MethodSymbol methodSymbol =
+      new MethodSymbol(
+          "com.google.common.base.Preconditions",
+          "checkNotNull",
+          "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+          false);
+
+  private FieldSymbol fieldSymbol =
+      new FieldSymbol("com.google.common.util.concurrent.Monitor$Guard", "waiterCount", "I");
+
+  @Test
+  public void testCreation() {
+    ClassToSymbolReferences.Builder builder = new ClassToSymbolReferences.Builder();
+
+    builder.addClassReference(sourceClass, classSymbol);
+    builder.addMethodReference(sourceClass, methodSymbol);
+    builder.addFieldReference(sourceClass, fieldSymbol);
+
+    ClassToSymbolReferences references = builder.build();
+
+    Truth.assertThat(references.getClassToClassSymbols()).containsEntry(sourceClass, classSymbol);
+    Truth.assertThat(references.getClassToMethodSymbols()).containsEntry(sourceClass, methodSymbol);
+    Truth.assertThat(references.getClassToFieldSymbols()).containsEntry(sourceClass, fieldSymbol);
+  }
+
+  @Test
+  public void testEquality() {
+    ClassToSymbolReferences.Builder builder1 = new ClassToSymbolReferences.Builder();
+    builder1.addClassReference(sourceClass, classSymbol);
+    builder1.addMethodReference(sourceClass, methodSymbol);
+    builder1.addFieldReference(sourceClass, fieldSymbol);
+
+    ClassToSymbolReferences.Builder builder2 = new ClassToSymbolReferences.Builder();
+    builder2.addClassReference(sourceClass, classSymbol);
+    builder2.addMethodReference(sourceClass, methodSymbol);
+    builder2.addFieldReference(sourceClass, fieldSymbol);
+
+    ClassAndJar sourceClass2 = new ClassAndJar(path, "com.google.Bar");
+    ClassToSymbolReferences.Builder builder3 = new ClassToSymbolReferences.Builder();
+    builder3.addClassReference(sourceClass2, classSymbol);
+    builder3.addMethodReference(sourceClass, methodSymbol);
+    builder3.addFieldReference(sourceClass, fieldSymbol);
+
+    ClassToSymbolReferences.Builder builder4 = new ClassToSymbolReferences.Builder();
+    builder4.addClassReference(sourceClass, classSymbol);
+    builder4.addMethodReference(sourceClass2, methodSymbol);
+    builder4.addFieldReference(sourceClass, fieldSymbol);
+
+    ClassToSymbolReferences.Builder builder5 = new ClassToSymbolReferences.Builder();
+    builder5.addClassReference(sourceClass, classSymbol);
+    builder5.addMethodReference(sourceClass, methodSymbol);
+    builder5.addFieldReference(sourceClass2, fieldSymbol);
+
+    new EqualsTester()
+        .addEqualityGroup(builder1.build(), builder2.build())
+        .addEqualityGroup(builder3.build())
+        .addEqualityGroup(builder4.build())
+        .addEqualityGroup(builder5.build())
+        .testEquals();
+  }
+
+  @Test
+  public void testAddAll() {
+    ClassToSymbolReferences.Builder builder1 = new ClassToSymbolReferences.Builder();
+    ClassToSymbolReferences.Builder builder2 = new ClassToSymbolReferences.Builder();
+
+    builder1.addClassReference(sourceClass, classSymbol);
+    builder1.addMethodReference(sourceClass, methodSymbol);
+    builder1.addFieldReference(sourceClass, fieldSymbol);
+
+    ClassAndJar sourceClass2 = new ClassAndJar(path, "com.google.Bar");
+    builder2.addClassReference(sourceClass2, classSymbol);
+    builder2.addMethodReference(sourceClass2, methodSymbol);
+    builder2.addFieldReference(sourceClass2, fieldSymbol);
+
+    builder1.addAll(builder2);
+    ClassToSymbolReferences references = builder1.build();
+
+    Truth.assertThat(references.getClassToClassSymbols()).containsEntry(sourceClass, classSymbol);
+    Truth.assertThat(references.getClassToMethodSymbols()).containsEntry(sourceClass, methodSymbol);
+    Truth.assertThat(references.getClassToFieldSymbols()).containsEntry(sourceClass, fieldSymbol);
+    Truth.assertThat(references.getClassToClassSymbols()).containsEntry(sourceClass2, classSymbol);
+    Truth.assertThat(references.getClassToMethodSymbols())
+        .containsEntry(sourceClass2, methodSymbol);
+    Truth.assertThat(references.getClassToFieldSymbols()).containsEntry(sourceClass2, fieldSymbol);
+  }
+}

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -52,11 +52,11 @@ public class LinkageCheckerTest {
     //   -v com/google/common/util/concurrent/Monitor
     Truth.assertThat(classToSymbols.getClassToClassSymbols())
         .containsEntry(
-            new ClassAndJar(guavaAbsolutePath, "com.google.common.util.concurrent.Service"),
+            new ClassFile(guavaAbsolutePath, "com.google.common.util.concurrent.Service"),
             new ClassSymbol("java.util.concurrent.TimeoutException"));
     Truth.assertThat(classToSymbols.getClassToMethodSymbols())
         .containsEntry(
-            new ClassAndJar(guavaAbsolutePath, "com.google.common.util.concurrent.Monitor"),
+            new ClassFile(guavaAbsolutePath, "com.google.common.util.concurrent.Monitor"),
             new MethodSymbol(
                 "com.google.common.base.Preconditions",
                 "checkNotNull",
@@ -64,7 +64,7 @@ public class LinkageCheckerTest {
                 false));
     Truth.assertThat(classToSymbols.getClassToFieldSymbols())
         .containsEntry(
-            new ClassAndJar(guavaAbsolutePath, "com.google.common.util.concurrent.Monitor"),
+            new ClassFile(guavaAbsolutePath, "com.google.common.util.concurrent.Monitor"),
             new FieldSymbol("com.google.common.util.concurrent.Monitor$Guard", "waiterCount", "I"));
   }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -46,7 +46,7 @@ public class LinkageCheckerTest {
     List<Path> paths = ImmutableList.of(guavaAbsolutePath);
     LinkageChecker linkageChecker = LinkageChecker.create(paths, paths);
 
-    ClassToSymbolReferences classToSymbols = linkageChecker.getClassToSymbols();
+    SymbolReferenceMaps classToSymbols = linkageChecker.getClassToSymbols();
     // These example symbols below are picked up through javap command. For example
     // javap -classpath src/test/resources/testdata/guava-23.5-jre.jar \
     //   -v com/google/common/util/concurrent/Monitor

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/MethodSymbolTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/MethodSymbolTest.java
@@ -31,7 +31,8 @@ public class MethodSymbolTest {
         new MethodSymbol(
             "java.lang.Object",
             "equals",
-            "(Lcom/google/protobuf/Message;)Lio/grpc/MethodDescriptor$Marshaller;");
+            "(Lcom/google/protobuf/Message;)Lio/grpc/MethodDescriptor$Marshaller;",
+            false);
     assertEquals("java.lang.Object", methodSymbol.getClassName());
     assertEquals("equals", methodSymbol.getName());
     assertEquals(
@@ -48,11 +49,12 @@ public class MethodSymbolTest {
   public void testMethodSymbolEquality() {
     new EqualsTester()
         .addEqualityGroup(
-            new MethodSymbol("java.lang.Object", "equals", "foo"),
-            new MethodSymbol("java.lang.Object", "equals", "foo"))
-        .addEqualityGroup(new MethodSymbol("java.lang.Object", "hashCode", "foo"))
-        .addEqualityGroup(new MethodSymbol("Object", "equals", "foo"))
-        .addEqualityGroup(new MethodSymbol("java.lang.Object", "equals", "bar"))
+            new MethodSymbol("java.lang.Object", "equals", "foo", false),
+            new MethodSymbol("java.lang.Object", "equals", "foo", false))
+        .addEqualityGroup(new MethodSymbol("java.lang.Object", "hashCode", "foo", false))
+        .addEqualityGroup(new MethodSymbol("Object", "equals", "foo", false))
+        .addEqualityGroup(new MethodSymbol("java.lang.Object", "equals", "bar", false))
+        .addEqualityGroup(new MethodSymbol("java.lang.Object", "equals", "foo", true))
         .addEqualityGroup(new ClassSymbol("java.lang.Object"))
         .addEqualityGroup(new FieldSymbol("java.lang.Object", "equals", "foo"))
         .testEquals();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SuperClassSymbolTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SuperClassSymbolTest.java
@@ -23,31 +23,27 @@ import com.google.common.testing.NullPointerTester;
 import com.google.common.testing.NullPointerTester.Visibility;
 import org.junit.Test;
 
-public class FieldSymbolTest {
+public class SuperClassSymbolTest {
 
   @Test
-  public void testFieldSymbolCreation() {
-    FieldSymbol fieldSymbol = new FieldSymbol("java.lang.Integer", "MAX_VALUE", "I");
-    assertEquals("java.lang.Integer", fieldSymbol.getClassName());
-    assertEquals("MAX_VALUE", fieldSymbol.getName());
-    assertEquals("I", fieldSymbol.getDescriptor());
+  public void testClassSymbolCreation() {
+    SuperClassSymbol classSymbol = new SuperClassSymbol("java.lang.Object");
+    assertEquals("java.lang.Object", classSymbol.getClassName());
   }
 
   @Test
   public void testNull() {
-    new NullPointerTester().testConstructors(FieldSymbol.class, Visibility.PACKAGE);
+    new NullPointerTester().testConstructors(SuperClassSymbol.class, Visibility.PACKAGE);
   }
 
   @Test
-  public void testFieldSymbolEquality() {
+  public void testClassSymbolEquality() {
     new EqualsTester()
         .addEqualityGroup(
-            new FieldSymbol("java.lang.Integer", "MAX_VALUE", "I"),
-            new FieldSymbol("java.lang.Integer", "MAX_VALUE", "I"))
-        .addEqualityGroup(new FieldSymbol("java.lang.Float", "MAX_VALUE", "I"))
-        .addEqualityGroup(new FieldSymbol("java.lang.Integer", "MIN_VALUE", "I"))
-        .addEqualityGroup(new FieldSymbol("java.lang.Integer", "MAX_VALUE", "F"))
-        .addEqualityGroup(new MethodSymbol("java.lang.Integer", "MAX_VALUE", "I", false))
+            new SuperClassSymbol("java.lang.Object"), new SuperClassSymbol("java.lang.Object"))
+        .addEqualityGroup(new SuperClassSymbol("java.lang.Long"))
+        .addEqualityGroup(new ClassSymbol("java.lang.Object"))
+        .addEqualityGroup(new MethodSymbol("java.lang.Object", "equals", "foo", false))
         .testEquals();
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolProblemTest.java
@@ -32,9 +32,9 @@ public class SymbolProblemTest {
     SymbolProblem symbolProblem =
         new SymbolProblem(
             new ClassSymbol("java.lang.Integer"),
-            Reason.CLASS_NOT_FOUND,
+            ErrorType.CLASS_NOT_FOUND,
             new ClassFile(Paths.get("foo", "bar.jar"), "java.lang.Object"));
-    assertSame(Reason.CLASS_NOT_FOUND, symbolProblem.getReason());
+    assertSame(ErrorType.CLASS_NOT_FOUND, symbolProblem.getErrorType());
     assertEquals(new ClassSymbol("java.lang.Integer"), symbolProblem.getSymbol());
     assertEquals(
         new ClassFile(Paths.get("foo", "bar.jar"), "java.lang.Object"),
@@ -54,29 +54,30 @@ public class SymbolProblemTest {
         .addEqualityGroup(
             new SymbolProblem(
                 new ClassSymbol("java.lang.Integer"),
-                Reason.CLASS_NOT_FOUND,
+                ErrorType.CLASS_NOT_FOUND,
                 new ClassFile(Paths.get("foo", "bar.jar"), "java.lang.Object")),
             new SymbolProblem(
                 new ClassSymbol("java.lang.Integer"),
-                Reason.CLASS_NOT_FOUND,
+                ErrorType.CLASS_NOT_FOUND,
                 new ClassFile(Paths.get("foo", "bar.jar"), "java.lang.Object")))
         .addEqualityGroup(
             new SymbolProblem(
                 new ClassSymbol("java.lang.Long"),
-                Reason.CLASS_NOT_FOUND,
+                ErrorType.CLASS_NOT_FOUND,
                 new ClassFile(Paths.get("foo", "bar.jar"), "java.lang.Object")))
         .addEqualityGroup(
             new SymbolProblem(
                 new ClassSymbol("java.lang.Integer"),
-                Reason.CLASS_NOT_FOUND,
+                ErrorType.CLASS_NOT_FOUND,
                 new ClassFile(Paths.get("abc", "bar.jar"), "java.lang.Object")))
         .addEqualityGroup(
             new SymbolProblem(
                 new ClassSymbol("java.lang.Integer"),
-                Reason.CLASS_NOT_FOUND,
+                ErrorType.CLASS_NOT_FOUND,
                 new ClassFile(Paths.get("foo", "bar.jar"), "java.lang.Long")))
         .addEqualityGroup(
-            new SymbolProblem(new ClassSymbol("java.lang.Integer"), Reason.CLASS_NOT_FOUND, null))
+            new SymbolProblem(
+                new ClassSymbol("java.lang.Integer"), ErrorType.CLASS_NOT_FOUND, null))
         .testEquals();
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolProblemTest.java
@@ -33,11 +33,11 @@ public class SymbolProblemTest {
         new SymbolProblem(
             new ClassSymbol("java.lang.Integer"),
             Reason.CLASS_NOT_FOUND,
-            new ClassAndJar(Paths.get("foo", "bar.jar"), "java.lang.Object"));
+            new ClassFile(Paths.get("foo", "bar.jar"), "java.lang.Object"));
     assertSame(Reason.CLASS_NOT_FOUND, symbolProblem.getReason());
     assertEquals(new ClassSymbol("java.lang.Integer"), symbolProblem.getSymbol());
     assertEquals(
-        new ClassAndJar(Paths.get("foo", "bar.jar"), "java.lang.Object"),
+        new ClassFile(Paths.get("foo", "bar.jar"), "java.lang.Object"),
         symbolProblem.getTargetClass());
   }
 
@@ -55,26 +55,26 @@ public class SymbolProblemTest {
             new SymbolProblem(
                 new ClassSymbol("java.lang.Integer"),
                 Reason.CLASS_NOT_FOUND,
-                new ClassAndJar(Paths.get("foo", "bar.jar"), "java.lang.Object")),
+                new ClassFile(Paths.get("foo", "bar.jar"), "java.lang.Object")),
             new SymbolProblem(
                 new ClassSymbol("java.lang.Integer"),
                 Reason.CLASS_NOT_FOUND,
-                new ClassAndJar(Paths.get("foo", "bar.jar"), "java.lang.Object")))
+                new ClassFile(Paths.get("foo", "bar.jar"), "java.lang.Object")))
         .addEqualityGroup(
             new SymbolProblem(
                 new ClassSymbol("java.lang.Long"),
                 Reason.CLASS_NOT_FOUND,
-                new ClassAndJar(Paths.get("foo", "bar.jar"), "java.lang.Object")))
+                new ClassFile(Paths.get("foo", "bar.jar"), "java.lang.Object")))
         .addEqualityGroup(
             new SymbolProblem(
                 new ClassSymbol("java.lang.Integer"),
                 Reason.CLASS_NOT_FOUND,
-                new ClassAndJar(Paths.get("abc", "bar.jar"), "java.lang.Object")))
+                new ClassFile(Paths.get("abc", "bar.jar"), "java.lang.Object")))
         .addEqualityGroup(
             new SymbolProblem(
                 new ClassSymbol("java.lang.Integer"),
                 Reason.CLASS_NOT_FOUND,
-                new ClassAndJar(Paths.get("foo", "bar.jar"), "java.lang.Long")))
+                new ClassFile(Paths.get("foo", "bar.jar"), "java.lang.Long")))
         .addEqualityGroup(
             new SymbolProblem(new ClassSymbol("java.lang.Integer"), Reason.CLASS_NOT_FOUND, null))
         .testEquals();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolReferenceMapsTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolReferenceMapsTest.java
@@ -24,7 +24,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Test;
 
-public class ClassToSymbolReferencesTest {
+public class SymbolReferenceMapsTest {
   private Path path = Paths.get("foo", "bar.jar");
   private ClassFile sourceClass = new ClassFile(path, "com.google.Foo");
   private ClassSymbol classSymbol = new ClassSymbol("java.util.concurrent.TimeoutException");
@@ -40,13 +40,13 @@ public class ClassToSymbolReferencesTest {
 
   @Test
   public void testCreation() {
-    ClassToSymbolReferences.Builder builder = new ClassToSymbolReferences.Builder();
+    SymbolReferenceMaps.Builder builder = new SymbolReferenceMaps.Builder();
 
     builder.addClassReference(sourceClass, classSymbol);
     builder.addMethodReference(sourceClass, methodSymbol);
     builder.addFieldReference(sourceClass, fieldSymbol);
 
-    ClassToSymbolReferences references = builder.build();
+    SymbolReferenceMaps references = builder.build();
 
     Truth.assertThat(references.getClassToClassSymbols()).containsEntry(sourceClass, classSymbol);
     Truth.assertThat(references.getClassToMethodSymbols()).containsEntry(sourceClass, methodSymbol);
@@ -55,28 +55,28 @@ public class ClassToSymbolReferencesTest {
 
   @Test
   public void testEquality() {
-    ClassToSymbolReferences.Builder builder1 = new ClassToSymbolReferences.Builder();
+    SymbolReferenceMaps.Builder builder1 = new SymbolReferenceMaps.Builder();
     builder1.addClassReference(sourceClass, classSymbol);
     builder1.addMethodReference(sourceClass, methodSymbol);
     builder1.addFieldReference(sourceClass, fieldSymbol);
 
-    ClassToSymbolReferences.Builder builder2 = new ClassToSymbolReferences.Builder();
+    SymbolReferenceMaps.Builder builder2 = new SymbolReferenceMaps.Builder();
     builder2.addClassReference(sourceClass, classSymbol);
     builder2.addMethodReference(sourceClass, methodSymbol);
     builder2.addFieldReference(sourceClass, fieldSymbol);
 
     ClassFile sourceClass2 = new ClassFile(path, "com.google.Bar");
-    ClassToSymbolReferences.Builder builder3 = new ClassToSymbolReferences.Builder();
+    SymbolReferenceMaps.Builder builder3 = new SymbolReferenceMaps.Builder();
     builder3.addClassReference(sourceClass2, classSymbol);
     builder3.addMethodReference(sourceClass, methodSymbol);
     builder3.addFieldReference(sourceClass, fieldSymbol);
 
-    ClassToSymbolReferences.Builder builder4 = new ClassToSymbolReferences.Builder();
+    SymbolReferenceMaps.Builder builder4 = new SymbolReferenceMaps.Builder();
     builder4.addClassReference(sourceClass, classSymbol);
     builder4.addMethodReference(sourceClass2, methodSymbol);
     builder4.addFieldReference(sourceClass, fieldSymbol);
 
-    ClassToSymbolReferences.Builder builder5 = new ClassToSymbolReferences.Builder();
+    SymbolReferenceMaps.Builder builder5 = new SymbolReferenceMaps.Builder();
     builder5.addClassReference(sourceClass, classSymbol);
     builder5.addMethodReference(sourceClass, methodSymbol);
     builder5.addFieldReference(sourceClass2, fieldSymbol);
@@ -91,13 +91,13 @@ public class ClassToSymbolReferencesTest {
 
   @Test
   public void testNull() {
-    new NullPointerTester().testConstructors(ClassToSymbolReferences.class, Visibility.PACKAGE);
+    new NullPointerTester().testConstructors(SymbolReferenceMaps.class, Visibility.PACKAGE);
   }
 
   @Test
   public void testAddAll() {
-    ClassToSymbolReferences.Builder builder1 = new ClassToSymbolReferences.Builder();
-    ClassToSymbolReferences.Builder builder2 = new ClassToSymbolReferences.Builder();
+    SymbolReferenceMaps.Builder builder1 = new SymbolReferenceMaps.Builder();
+    SymbolReferenceMaps.Builder builder2 = new SymbolReferenceMaps.Builder();
 
     builder1.addClassReference(sourceClass, classSymbol);
     builder1.addMethodReference(sourceClass, methodSymbol);
@@ -109,7 +109,7 @@ public class ClassToSymbolReferencesTest {
     builder2.addFieldReference(sourceClass2, fieldSymbol);
 
     builder1.addAll(builder2);
-    ClassToSymbolReferences references = builder1.build();
+    SymbolReferenceMaps references = builder1.build();
 
     Truth.assertThat(references.getClassToClassSymbols()).containsEntry(sourceClass, classSymbol);
     Truth.assertThat(references.getClassToMethodSymbols()).containsEntry(sourceClass, methodSymbol);


### PR DESCRIPTION
Fixes #597. This is part of the entire refactoring (#574).

- `LinkageChecker.create` is the first step to replace old value class with new value class.
  It scans jar files for new value classes and immediately convert them to old value class (`LinkageChecker.convert`). As the refactoring progresses, this conversion gradually moves to the output (the dashboard / enforcer rule)
- New `ClassToSymbolReferences` to hold set of symbol references:
```
  private final ImmutableSetMultimap<ClassAndJar, ClassSymbol> classToClassSymbols;
  private final ImmutableSetMultimap<ClassAndJar, MethodSymbol> classToMethodSymbols;
  private final ImmutableSetMultimap<ClassAndJar, FieldSymbol> classToFieldSymbols;
```

- `SuperClassSymbol` is introduced to distinguish normal class symbol and the one for inheritance.


