### PR TITLE
Preparing BOM v1.0.0 release

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Previous v1.0.0 tag had the old artifact ID [cloud-oss-bom](https://github.com/GoogleCloudPlatform/cloud-opensource-java/blob/1.0.0/boms/cloud-oss-bom/pom.xml#L9). This PR is to set a new 1.0.0 that uses new artifact ID "libraries-bom".