### PR TITLE
Enforcer rule to use new value class

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
@@ -23,8 +23,8 @@ import java.nio.file.Path;
 import java.util.Objects;
 
 /**
- * A compiled class file of {@code className} in {@code jar} to uniquely locate the class
- * implementation in a class path.
+ * A locator for a compiled class file of {@code className} in {@code jar} to uniquely locate the
+ * class implementation in a class path.
  */
 public final class ClassFile {
   private final Path jar;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
@@ -26,11 +26,11 @@ import java.util.Objects;
  * A tuple of a class name and a jar file to uniquely locate the class implementation in a class
  * path.
  */
-final class ClassFile {
+public final class ClassFile {
   private final Path jar;
   private final String className;
 
-  ClassFile(Path jar, String className) {
+  public ClassFile(Path jar, String className) {
     this.jar = checkNotNull(jar);
     this.className = checkNotNull(className);
   }
@@ -41,7 +41,7 @@ final class ClassFile {
   }
 
   /** Returns class name (binary name as in {@link Symbol#getClassName()}) */
-  String getClassName() {
+  public String getClassName() {
     return className;
   }
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
@@ -23,8 +23,8 @@ import java.nio.file.Path;
 import java.util.Objects;
 
 /**
- * A tuple of a class name and a jar file to uniquely locate the class implementation in a class
- * path.
+ * A compiled class file of {@code className} in {@code jar} to uniquely locate the class
+ * implementation in a class path.
  */
 public final class ClassFile {
   private final Path jar;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassReferenceGraph.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassReferenceGraph.java
@@ -42,7 +42,7 @@ import java.util.Set;
  *     href="https://github.com/GoogleCloudPlatform/cloud-opensource-java/blob/master/library-best-practices/glossary.md#class-reference-graph">
  *     Java Dependency Glossary: Class Reference Graph</a>
  */
-class ClassReferenceGraph {
+public class ClassReferenceGraph {
 
   private final ImmutableSet<String> reachableClasses;
 
@@ -82,7 +82,7 @@ class ClassReferenceGraph {
    * Returns true if {@code className} is reachable from one of classes in {@code entryPointJars}
    * in the graph.
    */
-  boolean isReachable(String className) {
+  public boolean isReachable(String className) {
     return reachableClasses.contains(className);
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbol.java
@@ -16,11 +16,14 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-import com.google.common.base.MoreObjects;
-
 /** Symbol for a class. */
-class ClassSymbol extends Symbol {
-  ClassSymbol(String className) {
+public class ClassSymbol extends Symbol {
+  public ClassSymbol(String className) {
     super(className);
+  }
+
+  @Override
+  public String toString() {
+    return "Class " + getClassName();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ErrorType.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ErrorType.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.opensource.classpath;
 /** The kind of linkage error against a symbol reference. */
 public enum ErrorType {
   /** The target class of the symbol reference is not found in the class path. */
-  CLASS_NOT_FOUND(" is not found"),
+  CLASS_NOT_FOUND("is not found"),
 
   /**
    * The referenced class or interface found in the class path is not binary-compatible with the
@@ -34,7 +34,7 @@ public enum ErrorType {
    * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-5.html#jvms-5.4.3.4>Java
    *     Virtual Machine Specification: 5.4.3.4. Interface Method Resolution</a>
    */
-  INCOMPATIBLE_CLASS_CHANGE(" has changed incompatibly"),
+  INCOMPATIBLE_CLASS_CHANGE("has changed incompatibly"),
 
   /**
    * The target class of the symbol reference is inaccessible to the source class.
@@ -43,7 +43,7 @@ public enum ErrorType {
    * not public. If the source class is in the same package, the class or one of its enclosing types
    * is private.
    */
-  INACCESSIBLE_CLASS(" is not accessible class"),
+  INACCESSIBLE_CLASS("is not accessible class"),
 
   /**
    * The target member (method or field) is inaccessible to the source class.
@@ -52,10 +52,10 @@ public enum ErrorType {
    * the same package, the class is private. If the source is a subclass of the target class, the
    * member is not protected or public.
    */
-  INACCESSIBLE_MEMBER(" is not accessible"),
+  INACCESSIBLE_MEMBER("is not accessible"),
 
   /** For a method or field reference, the symbol is not found in the target class. */
-  SYMBOL_NOT_FOUND(" is not found in the class");
+  SYMBOL_NOT_FOUND("is not found in the class");
 
   private final String message;
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ErrorType.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ErrorType.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.opensource.classpath;
 /** The kind of linkage error against a symbol reference. */
 public enum ErrorType {
   /** The target class of the symbol reference is not found in the class path. */
-  CLASS_NOT_FOUND,
+  CLASS_NOT_FOUND(" is not found"),
 
   /**
    * The referenced class or interface found in the class path is not binary-compatible with the
@@ -34,7 +34,7 @@ public enum ErrorType {
    * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-5.html#jvms-5.4.3.4>Java
    *     Virtual Machine Specification: 5.4.3.4. Interface Method Resolution</a>
    */
-  INCOMPATIBLE_CLASS_CHANGE,
+  INCOMPATIBLE_CLASS_CHANGE(" has changed incompatibly"),
 
   /**
    * The target class of the symbol reference is inaccessible to the source class.
@@ -43,7 +43,7 @@ public enum ErrorType {
    * not public. If the source class is in the same package, the class or one of its enclosing types
    * is private.
    */
-  INACCESSIBLE_CLASS,
+  INACCESSIBLE_CLASS(" is not accessible class"),
 
   /**
    * The target member (method or field) is inaccessible to the source class.
@@ -52,8 +52,21 @@ public enum ErrorType {
    * the same package, the class is private. If the source is a subclass of the target class, the
    * member is not protected or public.
    */
-  INACCESSIBLE_MEMBER,
+  INACCESSIBLE_MEMBER(" is not accessible"),
 
   /** For a method or field reference, the symbol is not found in the target class. */
-  SYMBOL_NOT_FOUND
+  SYMBOL_NOT_FOUND(" is not found in the class");
+
+  private final String message;
+
+  /**
+   * Returns a human-friendly message explaining the error of {@code subject}.
+   */
+  public String getMessage(String subject) {
+    return subject + " " + message;
+  }
+
+  ErrorType(String message) {
+    this.message = message;
+  }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ErrorType.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ErrorType.java
@@ -17,7 +17,7 @@
 package com.google.cloud.tools.opensource.classpath;
 
 /** The kind of linkage error against a symbol reference. */
-enum ErrorType {
+public enum ErrorType {
   /** The target class of the symbol reference is not found in the class path. */
   CLASS_NOT_FOUND,
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ErrorType.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ErrorType.java
@@ -43,7 +43,7 @@ public enum ErrorType {
    * not public. If the source class is in the same package, the class or one of its enclosing types
    * is private.
    */
-  INACCESSIBLE_CLASS("is not accessible class"),
+  INACCESSIBLE_CLASS("is not accessible"),
 
   /**
    * The target member (method or field) is inaccessible to the source class.

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbol.java
@@ -68,10 +68,6 @@ final class FieldSymbol extends Symbol {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("className", getClassName())
-        .add("name", name)
-        .add("descriptor", descriptor)
-        .toString();
+    return getClassName() + "'s field " + name;
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbol.java
@@ -16,7 +16,6 @@ package com.google.cloud.tools.opensource.classpath;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.MoreObjects;
 import java.util.Objects;
 
 /** Symbol for a field of a class. */

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -84,7 +84,6 @@ public class LinkageChecker {
     this.classToSymbols = Preconditions.checkNotNull(symbolReferenceMaps);
   }
 
-  @VisibleForTesting
   public ImmutableSetMultimap<ClassFile, SymbolProblem> findSymbolProblems() {
     // Having Problem in key will dedup SymbolProblems
     ImmutableSetMultimap.Builder<SymbolProblem, ClassFile> problemToClass =

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -50,6 +50,10 @@ public class LinkageChecker {
     return classToSymbols;
   }
 
+  public ClassReferenceGraph getClassReferenceGraph() {
+    return classReferenceGraph;
+  }
+
   public static LinkageChecker create(List<Path> jars, Iterable<Path> entryPoints)
       throws IOException {
     Preconditions.checkArgument(
@@ -81,7 +85,7 @@ public class LinkageChecker {
   }
 
   @VisibleForTesting
-  ImmutableSetMultimap<ClassFile, SymbolProblem> findSymbolProblems() {
+  public ImmutableSetMultimap<ClassFile, SymbolProblem> findSymbolProblems() {
     // Having Problem in key will dedup SymbolProblems
     ImmutableSetMultimap.Builder<SymbolProblem, ClassFile> problemToClass =
         ImmutableSetMultimap.builder();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbol.java
@@ -20,14 +20,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
 import java.util.Objects;
+import org.apache.bcel.classfile.Utility;
 
 /** Symbol for a method of class. */
-final class MethodSymbol extends Symbol {
+public final class MethodSymbol extends Symbol {
   private final String name;
   private final String descriptor;
   private final boolean isInterfaceMethod;
 
-  MethodSymbol(String className, String name, String descriptor, boolean isInterfaceMethod) {
+  public MethodSymbol(String className, String name, String descriptor, boolean isInterfaceMethod) {
     super(className);
     this.name = checkNotNull(name);
     this.descriptor = checkNotNull(descriptor);
@@ -81,11 +82,7 @@ final class MethodSymbol extends Symbol {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("className", getClassName())
-        .add("name", name)
-        .add("descriptor", descriptor)
-        .add("isInterfaceMethod", isInterfaceMethod)
-        .toString();
+    return (isInterfaceMethod ? "Interface " : "") + getClassName() + "'s method " + Utility
+        .methodSignatureToString(descriptor, name, "");
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbol.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.opensource.classpath;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.MoreObjects;
 import java.util.Objects;
 import org.apache.bcel.classfile.Utility;
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
@@ -85,24 +85,6 @@ public final class SymbolProblem {
 
   @Override
   public final String toString() {
-    StringBuilder builder = new StringBuilder(symbol.toString());
-    switch (getErrorType()) {
-      case CLASS_NOT_FOUND:
-        builder.append(" is not found");
-        break;
-      case INACCESSIBLE_CLASS:
-        builder.append(" is not accessible class");
-        break;
-      case INCOMPATIBLE_CLASS_CHANGE:
-        builder.append(" has changed incompatibly");
-        break;
-      case SYMBOL_NOT_FOUND:
-        builder.append(" is not found in the class");
-        break;
-      case INACCESSIBLE_MEMBER:
-        builder.append(" is not accessible");
-        break;
-    }
-    return builder.toString();
+    return getErrorType().getMessage(symbol.toString());
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.opensource.classpath;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.MoreObjects;
 import java.util.Objects;
 import javax.annotation.Nullable;
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
@@ -30,13 +30,13 @@ import javax.annotation.Nullable;
  *     href="https://github.com/GoogleCloudPlatform/cloud-opensource-java/blob/master/library-best-practices/glossary.md#linkage-error">
  *     Java Dependency Glossary: Linkage Error</a>
  */
-final class SymbolProblem {
+public final class SymbolProblem {
 
   private final ErrorType errorType;
   private final Symbol symbol;
   private final ClassFile containingClass;
 
-  SymbolProblem(Symbol symbol, ErrorType errorType, @Nullable ClassFile containingClass) {
+  public SymbolProblem(Symbol symbol, ErrorType errorType, @Nullable ClassFile containingClass) {
     this.symbol = checkNotNull(symbol);
     this.errorType = checkNotNull(errorType);
     this.containingClass = containingClass;
@@ -85,12 +85,25 @@ final class SymbolProblem {
   }
 
   @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .omitNullValues()
-        .add("errorType", errorType)
-        .add("symbol", symbol)
-        .add("containingClass", containingClass)
-        .toString();
+  public final String toString() {
+    StringBuilder builder = new StringBuilder(symbol.toString());
+    switch (getErrorType()) {
+      case CLASS_NOT_FOUND:
+        builder.append(" is not found");
+        break;
+      case INACCESSIBLE_CLASS:
+        builder.append(" is not accessible class");
+        break;
+      case INCOMPATIBLE_CLASS_CHANGE:
+        builder.append(" has changed incompatibly");
+        break;
+      case SYMBOL_NOT_FOUND:
+        builder.append(" is not found in the class");
+        break;
+      case INACCESSIBLE_MEMBER:
+        builder.append(" is not accessible");
+        break;
+    }
+    return builder.toString();
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassSymbolTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassSymbolTest.java
@@ -42,7 +42,7 @@ public class ClassSymbolTest {
         .addEqualityGroup(new ClassSymbol("java.lang.Object"), new ClassSymbol("java.lang.Object"))
         .addEqualityGroup(new ClassSymbol("java.lang.Long"))
         .addEqualityGroup(new SuperClassSymbol("java.lang.Object"))
-        .addEqualityGroup(new MethodSymbol("java.lang.Object", "equals", "foo", false))
+        .addEqualityGroup(new MethodSymbol("java.lang.Object", "equals", "(I)Lcom.Foo;", false))
         .testEquals();
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/FieldSymbolTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/FieldSymbolTest.java
@@ -47,7 +47,13 @@ public class FieldSymbolTest {
         .addEqualityGroup(new FieldSymbol("java.lang.Float", "MAX_VALUE", "I"))
         .addEqualityGroup(new FieldSymbol("java.lang.Integer", "MIN_VALUE", "I"))
         .addEqualityGroup(new FieldSymbol("java.lang.Integer", "MAX_VALUE", "F"))
-        .addEqualityGroup(new MethodSymbol("java.lang.Integer", "MAX_VALUE", "I", false))
+        .addEqualityGroup(new MethodSymbol("java.lang.Integer", "MAX_VALUE", "(I)Lcom.Foo;", false))
         .testEquals();
+  }
+
+  @Test
+  public void testToString() {
+    FieldSymbol fieldSymbol = new FieldSymbol("java.lang.Integer", "MAX_VALUE", "I");
+    assertEquals("java.lang.Integer's field MAX_VALUE", fieldSymbol.toString());
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/MethodSymbolTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/MethodSymbolTest.java
@@ -49,14 +49,26 @@ public class MethodSymbolTest {
   public void testMethodSymbolEquality() {
     new EqualsTester()
         .addEqualityGroup(
-            new MethodSymbol("java.lang.Object", "equals", "foo", false),
-            new MethodSymbol("java.lang.Object", "equals", "foo", false))
-        .addEqualityGroup(new MethodSymbol("java.lang.Object", "hashCode", "foo", false))
-        .addEqualityGroup(new MethodSymbol("Object", "equals", "foo", false))
-        .addEqualityGroup(new MethodSymbol("java.lang.Object", "equals", "bar", false))
-        .addEqualityGroup(new MethodSymbol("java.lang.Object", "equals", "foo", true))
+            new MethodSymbol("java.lang.Object", "equals", "(I)Lcom.Foo;", false),
+            new MethodSymbol("java.lang.Object", "equals", "(I)Lcom.Foo;", false))
+        .addEqualityGroup(new MethodSymbol("java.lang.Object", "hashCode", "(I)Lcom.Foo;", false))
+        .addEqualityGroup(new MethodSymbol("Object", "equals", "(I)Lcom.Foo;", false))
+        .addEqualityGroup(new MethodSymbol("java.lang.Object", "equals", "(I)Lcom.Bar;", false))
+        .addEqualityGroup(new MethodSymbol("java.lang.Object", "equals", "(I)Lcom.Foo;", true))
         .addEqualityGroup(new ClassSymbol("java.lang.Object"))
-        .addEqualityGroup(new FieldSymbol("java.lang.Object", "equals", "foo"))
+        .addEqualityGroup(new FieldSymbol("java.lang.Object", "equals", "(I)Lcom.Foo;"))
         .testEquals();
+  }
+
+  @Test
+  public void testToString() {
+    MethodSymbol symbol = new MethodSymbol(
+        "java.lang.Object",
+        "equals",
+        "(Lcom/google/protobuf/Message;)Lio/grpc/MethodDescriptor$Marshaller;",
+        false);
+    assertEquals(
+        "java.lang.Object's method io.grpc.MethodDescriptor$Marshaller equals(com.google.protobuf.Message arg1)",
+        symbol.toString());
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SuperClassSymbolTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SuperClassSymbolTest.java
@@ -43,7 +43,7 @@ public class SuperClassSymbolTest {
             new SuperClassSymbol("java.lang.Object"), new SuperClassSymbol("java.lang.Object"))
         .addEqualityGroup(new SuperClassSymbol("java.lang.Long"))
         .addEqualityGroup(new ClassSymbol("java.lang.Object"))
-        .addEqualityGroup(new MethodSymbol("java.lang.Object", "equals", "foo", false))
+        .addEqualityGroup(new MethodSymbol("java.lang.Object", "equals", "(I)Lcom.Foo;", false))
         .testEquals();
   }
 }

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -139,7 +139,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
         // Count unique SymbolProblems
         int errorCount = Sets.newHashSet(symbolProblems.values()).size();
 
-        String foundError = reportOnlyReachable ? " reachable error" : " error";
+        String foundError = reportOnlyReachable ? "reachable error" : "error";
         if (errorCount > 1) {
           foundError += "s";
         }
@@ -147,6 +147,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
           String message =
               "Linkage Checker rule found "
                   + errorCount
+                  + " "
                   + foundError
                   + ". Linkage error report:\n"
                   + formatSymbolProblems(symbolProblems);
@@ -159,7 +160,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
           }
         } else {
           // arguably shouldn't log anything on success
-          logger.info("No" + foundError + " found");
+          logger.info("No " + foundError + " found");
         }
       } catch (IOException ex) {
         // Maven's "-e" flag does not work for EnforcerRuleException. Print stack trace here.

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -132,13 +132,9 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
             .findSymbolProblems();
         if (reportOnlyReachable) {
           ClassReferenceGraph classReferenceGraph = linkageChecker.getClassReferenceGraph();
-          symbolProblems = symbolProblems.entries().stream().filter(
-              entry -> classReferenceGraph.isReachable(entry.getKey().getClassName())).collect(
-              ImmutableSetMultimap.toImmutableSetMultimap(
-                  Entry::getKey,
-                  Entry::getValue
-              )
-          );
+          symbolProblems = symbolProblems.entries().stream()
+              .filter(entry -> classReferenceGraph.isReachable(entry.getKey().getClassName()))
+              .collect(ImmutableSetMultimap.toImmutableSetMultimap(Entry::getKey,Entry::getValue));
         }
         // Count unique SymbolProblems
         int errorCount = Sets.newHashSet(symbolProblems.values()).size();

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -20,18 +20,23 @@ import static com.google.cloud.tools.opensource.dependencies.RepositoryUtility.s
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.apache.maven.enforcer.rule.api.EnforcerLevel.WARN;
 
+import com.google.cloud.tools.opensource.classpath.ClassFile;
 import com.google.cloud.tools.opensource.classpath.ClassPathBuilder;
-import com.google.cloud.tools.opensource.classpath.JarLinkageReport;
-import com.google.cloud.tools.opensource.classpath.LinkageCheckReport;
+import com.google.cloud.tools.opensource.classpath.ClassReferenceGraph;
 import com.google.cloud.tools.opensource.classpath.LinkageChecker;
+import com.google.cloud.tools.opensource.classpath.SymbolProblem;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Sets;
 import com.google.common.graph.Traverser;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map.Entry;
 import javax.annotation.Nonnull;
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
@@ -123,34 +128,32 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
 
       try {
         LinkageChecker linkageChecker = LinkageChecker.create(classpath, directDependencies);
-        LinkageCheckReport linkageReport = linkageChecker.findLinkageErrors();
-        int errorCount =
-            linkageReport.getJarLinkageReports().stream()
-                .mapToInt(JarLinkageReport::getErrorCount)
-                .sum();
+        ImmutableSetMultimap<ClassFile, SymbolProblem> symbolProblems = linkageChecker
+            .findSymbolProblems();
         if (reportOnlyReachable) {
-          ImmutableList<JarLinkageReport> reachableErrorReports =
-              linkageReport.getJarLinkageReports().stream()
-                  .map(JarLinkageReport::reachableErrors)
-                  .collect(toImmutableList());
-          linkageReport = LinkageCheckReport.create(reachableErrorReports);
-          int reachableErrorCount =
-              reachableErrorReports.stream()
-                  .mapToInt(JarLinkageReport::getErrorCount)
-                  .sum();
-          errorCount = reachableErrorCount;
+          ClassReferenceGraph classReferenceGraph = linkageChecker.getClassReferenceGraph();
+          symbolProblems = symbolProblems.entries().stream().filter(
+              entry -> classReferenceGraph.isReachable(entry.getKey().getClassName())).collect(
+              ImmutableSetMultimap.toImmutableSetMultimap(
+                  Entry::getKey,
+                  Entry::getValue
+              )
+          );
         }
+        // Count unique SymbolProblems
+        int errorCount = Sets.newHashSet(symbolProblems.values()).size();
 
-        String foundError = reportOnlyReachable ? "reachable error" : "error";
+        String foundError = reportOnlyReachable ? " reachable error" : " error";
         if (errorCount > 1) {
           foundError += "s";
         }
         if (errorCount > 0) {
           String message =
               "Linkage Checker rule found "
+                  + errorCount
                   + foundError
                   + ". Linkage error report:\n"
-                  + linkageReport.getErrorString();
+                  + formatSymbolProblems(symbolProblems);
           if (getLevel() == WARN) {
             logger.warn(message);
           } else {
@@ -160,7 +163,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
           }
         } else {
           // arguably shouldn't log anything on success
-          logger.info("No " + foundError + " found");
+          logger.info("No" + foundError + " found");
         }
       } catch (IOException ex) {
         // Maven's "-e" flag does not work for EnforcerRuleException. Print stack trace here.
@@ -170,6 +173,28 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
     } catch (ExpressionEvaluationException ex) {
       throw new EnforcerRuleException("Unable to lookup an expression " + ex.getMessage(), ex);
     }
+  }
+
+  @VisibleForTesting
+  static String formatSymbolProblems(ImmutableSetMultimap<ClassFile, SymbolProblem> symbolProblems) {
+    ImmutableSetMultimap<SymbolProblem, ClassFile> inversedSymbolProblems = symbolProblems
+        .inverse();
+    StringBuilder output = new StringBuilder();
+
+    for (SymbolProblem problem : inversedSymbolProblems.keySet()) {
+      output.append(problem);
+      output.append("\n  referenced by ");
+      ImmutableSet<ClassFile> references = inversedSymbolProblems.get(problem);
+      int referenceCount = references.size();
+      output.append(referenceCount);
+      output.append(" class file");
+      if (referenceCount > 1) {
+        output.append("s");
+      }
+      output.append("\n");
+    }
+
+    return output.toString();
   }
 
   /** Builds a class path for {@code mavenProject}. */

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -306,18 +306,21 @@ public class LinkageCheckerRuleTest {
             ErrorType.CLASS_NOT_FOUND,
             null);
 
-    ClassFile source = new ClassFile(Paths.get("foo", "bar.jar"),
+    ClassFile source1 = new ClassFile(Paths.get("foo", "dummy.jar"),
+        "java.lang.Object");
+    ClassFile source2 = new ClassFile(Paths.get("bar", "dummy.jar"),
         "java.lang.Object");
 
     ImmutableSetMultimap<ClassFile, SymbolProblem> symbolProblems =
-        ImmutableSetMultimap.of(source, methodSymbolProblem,
-            source, classSymbolProblem);
+        ImmutableSetMultimap.of(source1, methodSymbolProblem,
+            source1, classSymbolProblem,
+            source2, classSymbolProblem);
     assertEquals(
         "java.lang.Object's method io.grpc.MethodDescriptor$Marshaller "
             + "equals(com.google.protobuf.Message arg1) is not found in the class\n"
             + "  referenced by 1 class file\n"
             + "Class java.lang.Integer is not found\n"
-            + "  referenced by 1 class file\n",
+            + "  referenced by 2 class files\n",
         LinkageCheckerRule.formatSymbolProblems(symbolProblems));
   }
 }


### PR DESCRIPTION
Fixes #628.

Updates to `toString` method helps the output of the enforcer rule message ([example in test case](https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/629/files#diff-86bd74d650f0820130645ec02069c5d6R319))