### PR TITLE
Dashboard to use new value class

### DIFF
--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -20,8 +20,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.ImmutableTable.toImmutableTable;
 
-import com.google.common.collect.Table;
-import com.google.common.collect.Table.Cell;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -87,6 +85,8 @@ import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
+import com.google.common.collect.Table;
+import com.google.common.collect.Table.Cell;
 
 public class DashboardMain {
   public static final String TEST_NAME_LINKAGE_CHECK = "Linkage Errors";

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -203,12 +203,12 @@ public class DashboardMain {
 
   /**
    * Returns a table where rows are the Maven coordinates of BOM members, columns are symbol
-   * problems, and the values are set of class files.
+   * problems, and the values are sets of class files.
    *
    * <p>For example, {@code classFiles = symbolProblemTable.get("com.google.abc:foo:1.0.0",
-   * ProblemA)} means that the jar files of the {@code classFiles} are in the dependency tree of
-   * {@code "com.google.abc:foo:1.0.0"} and that the {@code classFiles} are referencing the symbol of
-   * {@code ProblemA}.
+   * ProblemA)} means that the jar files containing the {@code classFiles} are in the dependency
+   * tree of{@code "com.google.abc:foo:1.0.0"} and that the {@code classFiles} reference the
+   * symbol of {@code ProblemA}.
    */
   @VisibleForTesting
   static ImmutableTable<String, SymbolProblem, ImmutableSet<ClassFile>> createSymbolProblemTable(

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.opensource.dashboard;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableSetMultimap.toImmutableSetMultimap;
 
 import com.google.common.collect.Maps;
 import java.io.File;
@@ -158,8 +157,8 @@ public class DashboardMain {
     copyResource(output, "js/dashboard.js");
     Configuration configuration = configureFreemarker();
 
-    ImmutableMap<Path, ImmutableSetMultimap<SymbolProblem, String>> symbolProblemTable = indexByJar(
-        symbolProblems);
+    ImmutableMap<Path, ImmutableSetMultimap<SymbolProblem, String>> symbolProblemTable =
+        indexByJar(symbolProblems);
 
     List<ArtifactResults> table =
         generateReports(configuration, output, cache, symbolProblemTable, jarToDependencyPaths);
@@ -199,12 +198,12 @@ public class DashboardMain {
    */
   private static ImmutableSetMultimap<String, Path> bomMemberToJars(
       ListMultimap<Path, DependencyPath> jarToDependencyPaths) {
-    ImmutableSetMultimap.Builder<String, Path> bomMemberToJars = ImmutableSetMultimap
-        .builder();
-    jarToDependencyPaths.forEach((path, dependencyPath) -> {
-      Artifact artifact = dependencyPath.get(0);
-      bomMemberToJars.put(Artifacts.toCoordinates(artifact), path);
-    });
+    ImmutableSetMultimap.Builder<String, Path> bomMemberToJars = ImmutableSetMultimap.builder();
+    jarToDependencyPaths.forEach(
+        (path, dependencyPath) -> {
+          Artifact artifact = dependencyPath.get(0);
+          bomMemberToJars.put(Artifacts.toCoordinates(artifact), path);
+        });
 
     return bomMemberToJars.build();
   }
@@ -230,10 +229,10 @@ public class DashboardMain {
           table.add(unavailable);
         } else {
           Artifact artifact = entry.getKey();
-          ImmutableSet<Path> jarsInDependencyTree = bomMemberToJars
-              .get(Artifacts.toCoordinates(artifact));
-          Map<Path, ImmutableSetMultimap<SymbolProblem, String>> relevantSymbolProblemTable = Maps
-              .filterKeys(symbolProblemTable, jarsInDependencyTree::contains);
+          ImmutableSet<Path> jarsInDependencyTree =
+              bomMemberToJars.get(Artifacts.toCoordinates(artifact));
+          Map<Path, ImmutableSetMultimap<SymbolProblem, String>> relevantSymbolProblemTable =
+              Maps.filterKeys(symbolProblemTable, jarsInDependencyTree::contains);
 
           ArtifactResults results =
               generateArtifactReport(
@@ -323,11 +322,11 @@ public class DashboardMain {
 
       List<DependencyPath> dependencyPaths = completeDependencies.list();
 
-      long totalLinkageErrorCount = symbolProblemTable.values()
-          .stream()
-          .flatMap(problemToClasses -> problemToClasses.keySet().stream())
-          .distinct()
-          .count();
+      long totalLinkageErrorCount =
+          symbolProblemTable.values().stream()
+              .flatMap(problemToClasses -> problemToClasses.keySet().stream())
+              .distinct()
+              .count();
 
       ListMultimap<DependencyPath, DependencyPath> dependencyTree =
           DependencyTreeFormatter.buildDependencyPathTree(dependencyPaths);
@@ -421,7 +420,7 @@ public class DashboardMain {
       ImmutableMap<Path, ImmutableSetMultimap<SymbolProblem, String>> symbolProblemTable,
       ListMultimap<Path, DependencyPath> jarToDependencyPaths)
       throws IOException, TemplateException {
-    
+
     Map<String, String> latestArtifacts = collectLatestVersions(globalDependencies);
 
     Map<String, Object> templateData = new HashMap<>();

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.opensource.dashboard;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
-import com.google.common.collect.Maps;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -78,6 +77,7 @@ import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -197,21 +197,22 @@ public class DashboardMain {
   }
 
   /**
-   * Returns mapping from BOM member to jar files that are in the dependency tree of the BOM member.
+   * Returns mapping from the Maven coordinates of BOM members to jar files that are in the
+   * dependency tree of the BOM members.
    */
   private static ImmutableSetMultimap<String, Path> bomMemberToJars(
       ListMultimap<Path, DependencyPath> jarToDependencyPaths) {
     // Coordinates of BOM member -> One or more jar files (the BOM member and its dependencies)
-    ImmutableSetMultimap.Builder<String, Path> jarToCoordinatesBuilder = ImmutableSetMultimap
+    ImmutableSetMultimap.Builder<String, Path> bomMemberToJars = ImmutableSetMultimap
         .builder();
     for (Path path : jarToDependencyPaths.keySet()) {
       for (DependencyPath dependencyPath : jarToDependencyPaths.get(path)) {
         Artifact artifact = dependencyPath.get(0);
-        jarToCoordinatesBuilder.put(Artifacts.toCoordinates(artifact), path);
+        bomMemberToJars.put(Artifacts.toCoordinates(artifact), path);
       }
     }
 
-    return jarToCoordinatesBuilder.build();
+    return bomMemberToJars.build();
   }
 
   @VisibleForTesting
@@ -394,10 +395,9 @@ public class DashboardMain {
    * SymbolProblem}, and values are class names referencing the problems. When {@code jarFilter} is
    * {@code null}, jar files are not filtered.
    *
-   * <p>For example, {@code classes = table.get("com.google.abc:foo:1.0.0", ProblemA)} means that
-   * the jar files containing the {@code classFiles} are in the dependency tree of{@code
-   * "com.google.abc:foo:1.0.0"} and that the {@code classes} reference the symbol of {@code
-   * ProblemA}.
+   * <p>For example, {@code classes = table.get(JarX, SymbolProblemY)} means that {@code JarX} has
+   * {@code SymbolProblemY} and that {@code classes} in {@code JarX} reference the symbol of {@code
+   * SymbolProblemY}.
    */
   private static ImmutableTable<Path, SymbolProblem, ImmutableSet<String>> indexByJar(
       ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems,

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -374,8 +374,6 @@ public class DashboardMain {
 
       ImmutableTable<Path, SymbolProblem, Set<String>> jarToSymbolProblemToClasses =
           indexByJar(symbolProblems);
-//      ImmutableMap<SymbolProblem, Set<String>> row = jarToSymbolProblemToClasses.row(Paths.get(""));
-//      row.keySet();
 
       Map<String, Object> templateData = new HashMap<>();
       templateData.put("artifact", artifact);

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -410,7 +410,9 @@ public class DashboardMain {
     return ImmutableMap.copyOf(
         Maps.transformValues(
             jarMap,
-            entries -> entries.stream().collect(
+            entries -> entries // These entries have same JAR file for entry.getValue.getJar()
+                .stream()
+                .collect(
                 toImmutableSetMultimap(
                     Entry::getKey, // SymbolProblem
                     entry -> entry.getValue().getClassName())

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -137,7 +137,7 @@ public class DashboardMain {
 
     LinkageChecker linkageChecker = LinkageChecker.create(classpath, entryPoints);
 
-    ImmutableSetMultimap<ClassFile, SymbolProblem> symbolProblems =
+    ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems =
         linkageChecker.findSymbolProblems();
 
     Path output = generateHtml(cache, jarToDependencyPaths, symbolProblems);
@@ -148,7 +148,7 @@ public class DashboardMain {
   private static Path generateHtml(
       ArtifactCache cache,
       LinkedListMultimap<Path, DependencyPath> jarToDependencyPaths,
-      ImmutableSetMultimap<ClassFile, SymbolProblem> symbolProblems)
+      ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems)
       throws IOException, TemplateException, URISyntaxException {
 
     Path relativePath = Paths.get("target", "dashboard");
@@ -195,13 +195,13 @@ public class DashboardMain {
       Configuration configuration,
       Path output,
       ArtifactCache cache,
-      ImmutableSetMultimap<ClassFile, SymbolProblem> symbolProblems,
+      ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems,
       ListMultimap<Path, DependencyPath> jarToDependencyPaths) {
+    /*
     ImmutableMap<Path, JarLinkageReport> jarToLinkageReport =
         linkageCheckReport.getJarLinkageReports().stream()
             .collect(
                 toImmutableMap(JarLinkageReport::getJarPath, jarLinkageReport -> jarLinkageReport));
-
     // Map from Artifact's coordinates to (unique) JarLinkageReports.
     // Using string coordinates rather than Artifact class because its equality includes file.
     ImmutableSetMultimap.Builder<String, JarLinkageReport> builder = ImmutableSetMultimap.builder();
@@ -211,7 +211,9 @@ public class DashboardMain {
         builder.put(Artifacts.toCoordinates(artifact), jarToLinkageReport.get(path));
       }
     }
+
     ImmutableSetMultimap<String, JarLinkageReport> artifactToLinkageReports = builder.build();
+*/
 
     Map<Artifact, ArtifactInfo> artifacts = cache.getInfoMap();
     List<ArtifactResults> table = new ArrayList<>();
@@ -231,7 +233,7 @@ public class DashboardMain {
                   artifact,
                   entry.getValue(),
                   cache.getGlobalDependencies(),
-                  artifactToLinkageReports.get(Artifacts.toCoordinates(artifact)),
+                  null, //artifactToLinkageReports.get(Artifacts.toCoordinates(artifact)),
                   jarToDependencyPaths);
           table.add(results);
         }
@@ -383,7 +385,7 @@ public class DashboardMain {
       Path output,
       List<ArtifactResults> table,
       List<DependencyGraph> globalDependencies,
-      ImmutableSetMultimap<ClassFile, SymbolProblem> symbolProblems,
+      ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems,
       ListMultimap<Path, DependencyPath> jarToDependencyPaths)
       throws IOException, TemplateException {
     
@@ -393,7 +395,7 @@ public class DashboardMain {
     templateData.put("table", table);
     templateData.put("lastUpdated", LocalDateTime.now());
     templateData.put("latestArtifacts", latestArtifacts);
-    templateData.put("jarLinkageReports", linkageCheckReport.getJarLinkageReports());
+    templateData.put("jarLinkageReports", null);//linkageCheckReport.getJarLinkageReports());
     templateData.put("jarToDependencyPaths", jarToDependencyPaths);
     templateData.put("dependencyPathRootCauses", findRootCauses(jarToDependencyPaths));
 

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -347,7 +347,7 @@ public class DashboardMain {
       templateData.put("lastUpdated", LocalDateTime.now());
       templateData.put("dependencyTree", dependencyTree);
       templateData.put("dependencyRootNode", Iterables.getFirst(dependencyTree.values(), null));
-      templateData.put("jarToSymbolProblemToClasses", symbolProblemTable);
+      templateData.put("symbolProblems", symbolProblemTable);
       templateData.put("jarToDependencyPaths", jarToDependencyPathsForArtifact);
       templateData.put("totalLinkageErrorCount", totalLinkageErrorCount);
       report.process(templateData, out);
@@ -427,7 +427,7 @@ public class DashboardMain {
     templateData.put("table", table);
     templateData.put("lastUpdated", LocalDateTime.now());
     templateData.put("latestArtifacts", latestArtifacts);
-    templateData.put("jarToSymbolProblemToClasses", symbolProblemTable);
+    templateData.put("symbolProblems", symbolProblemTable);
     templateData.put("jarToDependencyPaths", jarToDependencyPaths);
     templateData.put("dependencyPathRootCauses", findRootCauses(jarToDependencyPaths));
 

--- a/dashboard/src/main/resources/templates/artifact_details.ftl
+++ b/dashboard/src/main/resources/templates/artifact_details.ftl
@@ -45,9 +45,8 @@
 
     <h2>Linkage Errors</h2>
 
-    <#list jarToSymbolProblemToClasses.rowKeySet() as jar >
-      <#assign problemsToClassFiles = jarToSymbolProblemToClasses.row(jar) />
-      <@formatJarLinkageReport jar problemsToClassFiles jarToDependencyPaths dependencyPathRootCauses/>
+    <#list jarToSymbolProblemToClasses as jar, problemsToClasses>
+      <@formatJarLinkageReport jar problemsToClasses jarToDependencyPaths dependencyPathRootCauses/>
     </#list>
 
     <hr />

--- a/dashboard/src/main/resources/templates/artifact_details.ftl
+++ b/dashboard/src/main/resources/templates/artifact_details.ftl
@@ -45,8 +45,8 @@
 
     <h2>Linkage Errors</h2>
 
-    <#list coordinatesToProblems as symbolProblem>
-      <@formatJarLinkageReport jarLinkageReport jarToDependencyPaths dependencyPathRootCauses/>
+    <#list coordinatesToProblems as coordinates, problems>
+      <@formatJarLinkageReport coordinates problems jarToDependencyPaths dependencyPathRootCauses/>
     </#list>
 
     <hr />

--- a/dashboard/src/main/resources/templates/artifact_details.ftl
+++ b/dashboard/src/main/resources/templates/artifact_details.ftl
@@ -45,7 +45,7 @@
 
     <h2>Linkage Errors</h2>
 
-    <#list jarLinkageReports as jarLinkageReport>
+    <#list coordinatesToProblems as symbolProblem>
       <@formatJarLinkageReport jarLinkageReport jarToDependencyPaths dependencyPathRootCauses/>
     </#list>
 

--- a/dashboard/src/main/resources/templates/artifact_details.ftl
+++ b/dashboard/src/main/resources/templates/artifact_details.ftl
@@ -45,7 +45,7 @@
 
     <h2>Linkage Errors</h2>
 
-    <#list jarToSymbolProblemToClasses as jar, problemsToClasses>
+    <#list symbolProblems as jar, problemsToClasses>
       <@formatJarLinkageReport jar problemsToClasses jarToDependencyPaths dependencyPathRootCauses/>
     </#list>
 

--- a/dashboard/src/main/resources/templates/artifact_details.ftl
+++ b/dashboard/src/main/resources/templates/artifact_details.ftl
@@ -45,8 +45,9 @@
 
     <h2>Linkage Errors</h2>
 
-    <#list coordinatesToProblems as coordinates, problems>
-      <@formatJarLinkageReport coordinates problems jarToDependencyPaths dependencyPathRootCauses/>
+    <#list jarToSymbolProblemToClasses.rowKeySet() as jar >
+      <#assign problemsToClassFiles = jarToSymbolProblemToClasses.row(jar) />
+      <@formatJarLinkageReport jar problemsToClassFiles jarToDependencyPaths dependencyPathRootCauses/>
     </#list>
 
     <hr />

--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -141,7 +141,7 @@
     <p id="linkage-errors-total">${totalLinkageErrorCount} linkage error(s)</p>
     <#list jarToSymbolProblemToClasses.rowKeySet() as jar >
       <#assign problemsToClassFiles = jarToSymbolProblemToClasses.row(jar) />
-      <@formatJarLinkageReport jar problemsToClassFiles jarToDependencyPaths dependencyPathRootCauses/>
+      <@formatJarLinkageReport jar problemsToClassFiles jarToDependencyPaths {} />
     </#list>
 
     <h2>Dependencies</h2>

--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -139,8 +139,9 @@
     <h2 id="linkage-errors">Linkage Check</h2>
 
     <p id="linkage-errors-total">${totalLinkageErrorCount} linkage error(s)</p>
-    <#list jarLinkageReports as jarLinkageReport>
-      <@formatJarLinkageReport jarLinkageReport jarToDependencyPaths {} />
+    <#list jarToSymbolProblemToClasses.rowKeySet() as jar >
+      <#assign problemsToClassFiles = jarToSymbolProblemToClasses.row(jar) />
+      <@formatJarLinkageReport jar problemsToClassFiles jarToDependencyPaths dependencyPathRootCauses/>
     </#list>
 
     <h2>Dependencies</h2>

--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -139,7 +139,7 @@
     <h2 id="linkage-errors">Linkage Check</h2>
 
     <p id="linkage-errors-total">${totalLinkageErrorCount} linkage error(s)</p>
-    <#list jarToSymbolProblemToClasses as jar, problemsToClasses>
+    <#list symbolProblems as jar, problemsToClasses>
       <@formatJarLinkageReport jar problemsToClasses jarToDependencyPaths {} />
     </#list>
 

--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -139,9 +139,8 @@
     <h2 id="linkage-errors">Linkage Check</h2>
 
     <p id="linkage-errors-total">${totalLinkageErrorCount} linkage error(s)</p>
-    <#list jarToSymbolProblemToClasses.rowKeySet() as jar >
-      <#assign problemsToClassFiles = jarToSymbolProblemToClasses.row(jar) />
-      <@formatJarLinkageReport jar problemsToClassFiles jarToDependencyPaths {} />
+    <#list jarToSymbolProblemToClasses as jar, problemsToClasses>
+      <@formatJarLinkageReport jar problemsToClasses jarToDependencyPaths {} />
     </#list>
 
     <h2>Dependencies</h2>

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -8,23 +8,25 @@
   <#return plural?string(pluralNoun, singularNoun)>
 </#function>
 
-<#macro formatJarLinkageReport jar problemsToClassFiles jarToDependencyPaths dependencyPathRootCauses>
-  <!-- problemsToClassFiles: ImmutableMap<SymbolProblem, Set<String>> -->
-  <#if problemsToClassFiles?size gt 0>
+<#macro formatJarLinkageReport jar problemsToClassesMultimap jarToDependencyPaths dependencyPathRootCauses>
+  <!-- problemsToClasses: ImmutableSetMultimap<SymbolProblem, String>
+    converted to ImmutableMap<SymbolProblem, Collection<String>> -->
+  <#assign problemsToClasses = problemsToClassesMultimap.asMap() />
+  <#if problemsToClasses?size gt 0>
     <h3>${jar.getFileName()?html}</h3>
-    <#assign symbolProblemCount = problemsToClassFiles?keys?size />
+    <#assign symbolProblemCount = problemsToClasses?keys?size />
     <#assign sourceClassCount = 0 />
-    <#list problemsToClassFiles?values as classFiles>
-      <#assign sourceClassCount = sourceClassCount + classFiles?size />
+    <#list problemsToClasses as symbolProblem, sourceClasses>
+      <#assign sourceClassCount = sourceClassCount + sourceClasses?size />
     </#list>
     <p class="jar-linkage-report">
       ${pluralize(symbolProblemCount, "symbol", "symbols")}
       causing linkage errors referenced from
       ${pluralize(sourceClassCount, "class", "classes")}.
     </p>
-    <#list problemsToClassFiles as symbolProblem, sourceClasses>
+    <#list problemsToClasses as symbolProblem, sourceClasses>
       <p class="jar-linkage-report-cause">${symbolProblem?html}, referenced from ${
-        pluralize(sourceClasses?size, "source class", "source classes")?html}
+        pluralize(sourceClasses?size, "class", "classes")?html}
         <button onclick="toggleSourceClassListVisibility(this)"
                 title="Toggle visibility of source class list">▶
         </button>

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -9,47 +9,45 @@
 </#function>
 
 <#macro formatJarLinkageReport jar problemsWithClass jarToDependencyPaths dependencyPathRootCauses>
-  <#if problemsWithClass?size gt 0>
-    <!-- problemsWithClass: ImmutableSetMultimap<SymbolProblem, String> converted to
-      ImmutableMap<SymbolProblem, Collection<String>> to get key and set of values in Freemarker -->
-    <#assign problemsToClasses = problemsWithClass.asMap() />
-    <#assign symbolProblemCount = problemsToClasses?size />
-    <#assign sourceClassCount = problemsWithClass.inverse().keySet()?size />
+  <!-- problemsWithClass: ImmutableSetMultimap<SymbolProblem, String> converted to
+    ImmutableMap<SymbolProblem, Collection<String>> to get key and set of values in Freemarker -->
+  <#assign problemsToClasses = problemsWithClass.asMap() />
+  <#assign symbolProblemCount = problemsToClasses?size />
+  <#assign sourceClassCount = problemsWithClass.inverse().keySet()?size />
 
-    <h3>${jar.getFileName()?html}</h3>
-    <p class="jar-linkage-report">
-      ${pluralize(symbolProblemCount, "symbol", "symbols")}
-      causing linkage errors referenced from
-      ${pluralize(sourceClassCount, "class", "classes")}.
+  <h3>${jar.getFileName()?html}</h3>
+  <p class="jar-linkage-report">
+    ${pluralize(symbolProblemCount, "symbol", "symbols")}
+    causing linkage errors referenced from
+    ${pluralize(sourceClassCount, "class", "classes")}.
+  </p>
+  <#list problemsToClasses as symbolProblem, sourceClasses>
+    <p class="jar-linkage-report-cause">${symbolProblem?html}, referenced from ${
+      pluralize(sourceClasses?size, "class", "classes")?html}
+      <button onclick="toggleSourceClassListVisibility(this)"
+              title="Toggle visibility of source class list">▶
+      </button>
     </p>
-    <#list problemsToClasses as symbolProblem, sourceClasses>
-      <p class="jar-linkage-report-cause">${symbolProblem?html}, referenced from ${
-        pluralize(sourceClasses?size, "class", "classes")?html}
-        <button onclick="toggleSourceClassListVisibility(this)"
-                title="Toggle visibility of source class list">▶
-        </button>
-      </p>
 
-      <!-- The visibility of this list is toggled via the button above. Hidden by default -->
-      <ul class="jar-linkage-report-cause" style="display:none">
-        <#list sourceClasses as sourceClass>
-          <li>${sourceClass?html}</li>
+    <!-- The visibility of this list is toggled via the button above. Hidden by default -->
+    <ul class="jar-linkage-report-cause" style="display:none">
+      <#list sourceClasses as sourceClass>
+        <li>${sourceClass?html}</li>
+      </#list>
+    </ul>
+  </#list>
+  <p class="linkage-check-dependency-paths">
+    The following paths to the jar file from the BOM are found in the dependency tree:
+  </p>
+  <#if dependencyPathRootCauses[jar]?? >
+    <p class="linkage-check-dependency-paths">${dependencyPathRootCauses[jar]?html}
+    </p>
+  <#else>
+    <ul class="linkage-check-dependency-paths">
+        <#list jarToDependencyPaths.get(jar) as dependencyPath >
+          <li>${dependencyPath}</li>
         </#list>
-      </ul>
-    </#list>
-    <p class="linkage-check-dependency-paths">
-      The following paths to the jar file from the BOM are found in the dependency tree:
-    </p>
-    <#if dependencyPathRootCauses[jar]?? >
-      <p class="linkage-check-dependency-paths">${dependencyPathRootCauses[jar]?html}
-      </p>
-    <#else>
-      <ul class="linkage-check-dependency-paths">
-          <#list jarToDependencyPaths.get(jar) as dependencyPath >
-            <li>${dependencyPath}</li>
-          </#list>
-      </ul>
-    </#if>
+    </ul>
   </#if>
 </#macro>
 

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -4,19 +4,10 @@
 </#function>
 
 <#macro formatJarLinkageReport jar problemsToClassFiles jarToDependencyPaths dependencyPathRootCauses>
-  <!-- problemsToClassFiles is an ImmutableMap<SymbolProblem, Set<String>>, but keySet() does not
-    work in Freemarker template -->
+  <!-- problemsToClassFiles: ImmutableMap<SymbolProblem, Set<String>> -->
   <#if problemsToClassFiles?size gt 0>
     <h3>${jar.getFileName()?html}</h3>
-    <#--
-    <#assign targetClassCount = jarLinkageReport.getTargetClassCount() />
-    <#assign sourceClassCount = jarLinkageReport.getErrorCount() />
-    <p class="jar-linkage-report">
-      ${pluralize(targetClassCount, "target class", "target classes")}
-      causing linkage errors referenced from
-      ${pluralize(sourceClassCount, "source class", "source classes")}.
-    </p>
-    -->
+
     <#list problemsToClassFiles as symbolProblem, sourceClasses>
       <p class="jar-linkage-report-cause">${symbolProblem?html}, referenced from ${
         pluralize(sourceClasses?size, "source class", "source classes")?html}

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -3,8 +3,8 @@
   <#return number + " " + plural?string(pluralNoun, singularNoun)>
 </#function>
 
-<#macro formatJarLinkageReport jarLinkageReport jarToDependencyPaths dependencyPathRootCauses>
-  <#if jarLinkageReport.getErrorCount() gt 0>
+<#macro formatJarLinkageReport coordinates problems jarToDependencyPaths dependencyPathRootCauses>
+  <#if problems.keySet()?size gt 0>
     <#assign jarPath = jarLinkageReport.getJarPath() />
     <h3>${jarPath.getFileName()?html}</h3>
 

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -12,7 +12,16 @@
   <!-- problemsToClassFiles: ImmutableMap<SymbolProblem, Set<String>> -->
   <#if problemsToClassFiles?size gt 0>
     <h3>${jar.getFileName()?html}</h3>
-
+    <#assign symbolProblemCount = problemsToClassFiles?keys?size />
+    <#assign sourceClassCount = 0 />
+    <#list problemsToClassFiles?values as classFiles>
+      <#assign sourceClassCount = sourceClassCount + classFiles?size />
+    </#list>
+    <p class="jar-linkage-report">
+      ${pluralize(symbolProblemCount, "symbol", "symbols")}
+      causing linkage errors referenced from
+      ${pluralize(sourceClassCount, "class", "classes")}.
+    </p>
     <#list problemsToClassFiles as symbolProblem, sourceClasses>
       <p class="jar-linkage-report-cause">${symbolProblem?html}, referenced from ${
         pluralize(sourceClasses?size, "source class", "source classes")?html}

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -3,10 +3,10 @@
   <#return number + " " + plural?string(pluralNoun, singularNoun)>
 </#function>
 
-<#macro formatJarLinkageReport coordinates problems jarToDependencyPaths dependencyPathRootCauses>
-  <#if problems.keySet()?size gt 0>
-    <#assign jarPath = jarLinkageReport.getJarPath() />
-    <h3>${jarPath.getFileName()?html}</h3>
+<#macro formatJarLinkageReport jar problemsToClassFiles jarToDependencyPaths dependencyPathRootCauses>
+  <#assign problemSize = problemsToClassFiles.keySet()?size />
+  <#if problemSize gt 0>
+    <h3>${jar.getFileName()?html}</h3>
 
     <#assign targetClassCount = jarLinkageReport.getTargetClassCount() />
     <#assign sourceClassCount = jarLinkageReport.getErrorCount() />
@@ -34,12 +34,12 @@
     <p class="linkage-check-dependency-paths">
       The following paths to the jar file from the BOM are found in the dependency tree:
     </p>
-    <#if dependencyPathRootCauses[jarPath]?? >
-      <p class="linkage-check-dependency-paths">${dependencyPathRootCauses[jarPath]?html}
+    <#if dependencyPathRootCauses[jar]?? >
+      <p class="linkage-check-dependency-paths">${dependencyPathRootCauses[jar]?html}
       </p>
     <#else>
       <ul class="linkage-check-dependency-paths">
-          <#list jarToDependencyPaths.get(jarPath) as dependencyPath >
+          <#list jarToDependencyPaths.get(jar) as dependencyPath >
             <li>${dependencyPath}</li>
           </#list>
       </ul>

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -13,13 +13,16 @@
     ImmutableMap<SymbolProblem, Collection<String>> to get key and set of values in Freemarker -->
   <#assign problemsToClasses = problemsWithClass.asMap() />
   <#assign symbolProblemCount = problemsToClasses?size />
-  <#assign sourceClassCount = problemsWithClass.inverse().keySet()?size />
+  <#assign referenceCount = 0 />
+  <#list problemsToClasses?values as classes>
+    <#assign referenceCount += classes?size />
+  </#list>
 
   <h3>${jar.getFileName()?html}</h3>
   <p class="jar-linkage-report">
     ${pluralize(symbolProblemCount, "symbol", "symbols")}
-    causing linkage errors referenced from
-    ${pluralize(sourceClassCount, "class", "classes")}.
+    causing linkage errors on
+    ${pluralize(referenceCount, "reference", "references")}.
   </p>
   <#list problemsToClasses as symbolProblem, sourceClasses>
     <p class="jar-linkage-report-cause">${symbolProblem?html}, referenced from ${

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -14,11 +14,8 @@
   <#assign problemsToClasses = problemsWithClass.asMap() />
   <#if problemsToClasses?size gt 0>
     <h3>${jar.getFileName()?html}</h3>
-    <#assign symbolProblemCount = problemsToClasses?keys?size />
-    <#assign sourceClassCount = 0 />
-    <#list problemsToClasses as symbolProblem, sourceClasses>
-      <#assign sourceClassCount = sourceClassCount + sourceClasses?size />
-    </#list>
+    <#assign symbolProblemCount = problemsToClasses?size />
+    <#assign sourceClassCount = problemsWithClass.inverse().keySet()?size />
     <p class="jar-linkage-report">
       ${pluralize(symbolProblemCount, "symbol", "symbols")}
       causing linkage errors referenced from

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -8,10 +8,10 @@
   <#return plural?string(pluralNoun, singularNoun)>
 </#function>
 
-<#macro formatJarLinkageReport jar problemsToClassesMultimap jarToDependencyPaths dependencyPathRootCauses>
-  <!-- problemsToClasses: ImmutableSetMultimap<SymbolProblem, String>
-    converted to ImmutableMap<SymbolProblem, Collection<String>> -->
-  <#assign problemsToClasses = problemsToClassesMultimap.asMap() />
+<#macro formatJarLinkageReport jar problemsWithClass jarToDependencyPaths dependencyPathRootCauses>
+  <!-- problemsToClasses: ImmutableSetMultimap<SymbolProblem, String> converted to
+    ImmutableMap<SymbolProblem, Collection<String>>; Multimaps don't work well with Freemarker -->
+  <#assign problemsToClasses = problemsWithClass.asMap() />
   <#if problemsToClasses?size gt 0>
     <h3>${jar.getFileName()?html}</h3>
     <#assign symbolProblemCount = problemsToClasses?keys?size />

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -20,9 +20,9 @@
 
   <h3>${jar.getFileName()?html}</h3>
   <p class="jar-linkage-report">
-    ${pluralize(symbolProblemCount, "symbol", "symbols")}
-    causing linkage errors on
-    ${pluralize(referenceCount, "reference", "references")}.
+    ${pluralize(symbolProblemCount, "target class", "target classes")}
+    causing linkage errors referenced from
+    ${pluralize(referenceCount, "source class", "source classes")}.
   </p>
   <#list problemsToClasses as symbolProblem, sourceClasses>
     <p class="jar-linkage-report-cause">${symbolProblem?html}, referenced from ${

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -9,13 +9,14 @@
 </#function>
 
 <#macro formatJarLinkageReport jar problemsWithClass jarToDependencyPaths dependencyPathRootCauses>
-  <!-- problemsToClasses: ImmutableSetMultimap<SymbolProblem, String> converted to
-    ImmutableMap<SymbolProblem, Collection<String>>; Multimaps don't work well with Freemarker -->
-  <#assign problemsToClasses = problemsWithClass.asMap() />
-  <#if problemsToClasses?size gt 0>
-    <h3>${jar.getFileName()?html}</h3>
+  <#if problemsWithClass?size gt 0>
+    <!-- problemsWithClass: ImmutableSetMultimap<SymbolProblem, String> converted to
+      ImmutableMap<SymbolProblem, Collection<String>> to get key and set of values in Freemarker -->
+    <#assign problemsToClasses = problemsWithClass.asMap() />
     <#assign symbolProblemCount = problemsToClasses?size />
     <#assign sourceClassCount = problemsWithClass.inverse().keySet()?size />
+
+    <h3>${jar.getFileName()?html}</h3>
     <p class="jar-linkage-report">
       ${pluralize(symbolProblemCount, "symbol", "symbols")}
       causing linkage errors referenced from

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -4,10 +4,11 @@
 </#function>
 
 <#macro formatJarLinkageReport jar problemsToClassFiles jarToDependencyPaths dependencyPathRootCauses>
-  <#assign problemSize = problemsToClassFiles.keySet()?size />
-  <#if problemSize gt 0>
+  <!-- problemsToClassFiles is an ImmutableMap<SymbolProblem, Set<String>>, but keySet() does not
+    work in Freemarker template -->
+  <#if problemsToClassFiles?size gt 0>
     <h3>${jar.getFileName()?html}</h3>
-
+    <#--
     <#assign targetClassCount = jarLinkageReport.getTargetClassCount() />
     <#assign sourceClassCount = jarLinkageReport.getErrorCount() />
     <p class="jar-linkage-report">
@@ -15,9 +16,9 @@
       causing linkage errors referenced from
       ${pluralize(sourceClassCount, "source class", "source classes")}.
     </p>
-    <#list jarLinkageReport.getUnresolvableTargets() as unresolvableTarget >
-      <#assign sourceClasses = jarLinkageReport.getSourceClasses(unresolvableTarget) />
-      <p class="jar-linkage-report-cause">${unresolvableTarget?html}, referenced from ${
+    -->
+    <#list problemsToClassFiles as symbolProblem, sourceClasses>
+      <p class="jar-linkage-report-cause">${symbolProblem?html}, referenced from ${
         pluralize(sourceClasses?size, "source class", "source classes")?html}
         <button onclick="toggleSourceClassListVisibility(this)"
                 title="Toggle visibility of source class list">▶

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -290,7 +290,6 @@ public class DashboardTest {
                 + " referenced from 21 source classes ▶"); // '▶' is the toggle button
   }
 
-
   @Test
   public void testComponent_success() throws IOException, ParsingException {
     Document document = parseOutputFile(

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -203,7 +203,7 @@ public class DashboardTest {
     Nodes reports = details.query("//p[@class='jar-linkage-report']");
     // appengine-api-sdk, shown as first item in linkage errors, has these errors
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
-        .isEqualTo("106 symbols causing linkage errors referenced from 51 classes.");
+        .isEqualTo("106 symbols causing linkage errors on 516 references.");
 
     Nodes dependencyPaths = details.query(
         "//p[@class='linkage-check-dependency-paths'][position()=last()]");
@@ -279,7 +279,7 @@ public class DashboardTest {
     Nodes reports = document.query("//p[@class='jar-linkage-report']");
     Assert.assertEquals(1, reports.size());
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
-        .isEqualTo("106 symbols causing linkage errors referenced from 51 classes.");
+        .isEqualTo("106 symbols causing linkage errors on 516 references.");
 
     Nodes causes = document.query("//p[@class='jar-linkage-report-cause']");
     Truth.assertWithMessage(

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -203,7 +203,8 @@ public class DashboardTest {
     Nodes reports = details.query("//p[@class='jar-linkage-report']");
     // appengine-api-sdk, shown as first item in linkage errors, has these errors
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
-        .isEqualTo("106 symbols causing linkage errors on 516 references.");
+        .isEqualTo(
+            "106 target classes causing linkage errors referenced from 516 source classes.");
 
     Nodes dependencyPaths = details.query(
         "//p[@class='linkage-check-dependency-paths'][position()=last()]");
@@ -279,7 +280,7 @@ public class DashboardTest {
     Nodes reports = document.query("//p[@class='jar-linkage-report']");
     Assert.assertEquals(1, reports.size());
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
-        .isEqualTo("106 symbols causing linkage errors on 516 references.");
+        .isEqualTo("106 target classes causing linkage errors referenced from 516 source classes.");
 
     Nodes causes = document.query("//p[@class='jar-linkage-report-cause']");
     Truth.assertWithMessage(

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -192,12 +192,6 @@ public class DashboardTest {
 
   @Test
   public void testLinkageReports() {
-    Nodes reports = details.query("//p[@class='jar-linkage-report']");
-    // appengine-api-sdk, shown as first item in linkage errors, has these errors
-    Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
-        .isEqualTo(
-            "106 target classes causing linkage errors referenced from 516 source classes.");
-
     Nodes dependencyPaths = details.query(
         "//p[@class='linkage-check-dependency-paths'][position()=last()]");
     Node dependencyPathMessage = dependencyPaths.get(0);
@@ -269,11 +263,6 @@ public class DashboardTest {
   public void testComponent_linkageCheckResult() throws IOException, ParsingException {
     Document document = parseOutputFile(
         "com.google.http-client_google-http-client-appengine_1.29.1.html");
-    Nodes reports = document.query("//p[@class='jar-linkage-report']");
-    Assert.assertEquals(1, reports.size());
-    Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
-        .isEqualTo(
-            "106 target classes causing linkage errors referenced from 516 source classes.");
     Nodes causes = document.query("//p[@class='jar-linkage-report-cause']");
     Truth.assertWithMessage("google-http-client-appengine should show linkage errors for RpcStubDescriptor")
         .that(causes)
@@ -327,7 +316,7 @@ public class DashboardTest {
     Nodes linkageCheckMessages = document.query("//ul[@class='jar-linkage-report-cause']/li");
     Truth.assertThat(linkageCheckMessages.size()).isGreaterThan(0);
     Truth.assertThat(linkageCheckMessages.get(0).getValue())
-        .contains("com.google.appengine.api.appidentity.AppIdentityServicePb");
+        .contains("com.google.appengine.api.xmpp.XMPPServicePb$XmppService_3$1");
   }
 
   @Test

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -203,7 +203,7 @@ public class DashboardTest {
     Nodes reports = details.query("//p[@class='jar-linkage-report']");
     // appengine-api-sdk, shown as first item in linkage errors, has these errors
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
-        .isEqualTo("115 symbols causing linkage errors referenced from 1,648 source classes.");
+        .isEqualTo("115 symbols causing linkage errors referenced from 1,648 classes.");
 
     Nodes dependencyPaths = details.query(
         "//p[@class='linkage-check-dependency-paths'][position()=last()]");
@@ -279,7 +279,8 @@ public class DashboardTest {
     Nodes reports = document.query("//p[@class='jar-linkage-report']");
     Assert.assertEquals(1, reports.size());
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
-        .isEqualTo("115 symbols causing linkage errors referenced from 1,648 source classes.");
+        .isEqualTo("115 symbols causing linkage errors referenced from 1,648 classes.");
+
     Nodes causes = document.query("//p[@class='jar-linkage-report-cause']");
     Truth.assertWithMessage("google-http-client-appengine should show linkage errors for RpcStubDescriptor")
         .that(causes)

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -203,7 +203,7 @@ public class DashboardTest {
     Nodes reports = details.query("//p[@class='jar-linkage-report']");
     // appengine-api-sdk, shown as first item in linkage errors, has these errors
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
-        .isEqualTo("106 symbols causing linkage errors referenced from 741 classes.");
+        .isEqualTo("106 symbols causing linkage errors referenced from 51 classes.");
 
     Nodes dependencyPaths = details.query(
         "//p[@class='linkage-check-dependency-paths'][position()=last()]");
@@ -279,10 +279,11 @@ public class DashboardTest {
     Nodes reports = document.query("//p[@class='jar-linkage-report']");
     Assert.assertEquals(1, reports.size());
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
-        .isEqualTo("106 symbols causing linkage errors referenced from 741 classes.");
+        .isEqualTo("106 symbols causing linkage errors referenced from 51 classes.");
 
     Nodes causes = document.query("//p[@class='jar-linkage-report-cause']");
-    Truth.assertWithMessage("google-http-client-appengine should show linkage errors for RpcStubDescriptor")
+    Truth.assertWithMessage(
+            "google-http-client-appengine should show linkage errors for RpcStubDescriptor")
         .that(causes)
         .comparingElementsUsing(NODE_VALUES)
         .contains(
@@ -333,7 +334,7 @@ public class DashboardTest {
     Nodes linkageCheckMessages = document.query("//ul[@class='jar-linkage-report-cause']/li");
     Truth.assertThat(linkageCheckMessages.size()).isGreaterThan(0);
     Truth.assertThat(linkageCheckMessages.get(0).getValue())
-        .contains("com.google.appengine.api.appidentity.AppIdentityServicePb$SigningService$1");
+        .contains("com.google.appengine.api.appidentity.AppIdentityServicePb");
   }
 
   @Test

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -339,13 +339,13 @@ public class DashboardTest {
 
   @Test
   public void testLinkageErrors_ensureNoDuplicateSymbols() throws IOException, ParsingException {
-    Document document = parseOutputFile(
-        "com.google.http-client_google-http-client-appengine_1.29.1.html");
+    Document document =
+        parseOutputFile("com.google.http-client_google-http-client-appengine_1.29.1.html");
     Nodes linkageCheckMessages = document.query("//p[@class='jar-linkage-report-cause']");
     Truth.assertThat(linkageCheckMessages.size()).isGreaterThan(0);
 
     List<String> messages = new ArrayList<>();
-    for (int i =0 ;i<linkageCheckMessages.size(); ++i) {
+    for (int i = 0; i < linkageCheckMessages.size(); ++i) {
       messages.add(linkageCheckMessages.get(i).getValue());
     }
 

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -203,7 +203,7 @@ public class DashboardTest {
     Nodes reports = details.query("//p[@class='jar-linkage-report']");
     // appengine-api-sdk, shown as first item in linkage errors, has these errors
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
-        .isEqualTo("115 symbols causing linkage errors referenced from 1,648 classes.");
+        .isEqualTo("106 symbols causing linkage errors referenced from 741 classes.");
 
     Nodes dependencyPaths = details.query(
         "//p[@class='linkage-check-dependency-paths'][position()=last()]");
@@ -279,7 +279,7 @@ public class DashboardTest {
     Nodes reports = document.query("//p[@class='jar-linkage-report']");
     Assert.assertEquals(1, reports.size());
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
-        .isEqualTo("115 symbols causing linkage errors referenced from 1,648 classes.");
+        .isEqualTo("106 symbols causing linkage errors referenced from 741 classes.");
 
     Nodes causes = document.query("//p[@class='jar-linkage-report-cause']");
     Truth.assertWithMessage("google-http-client-appengine should show linkage errors for RpcStubDescriptor")
@@ -334,6 +334,22 @@ public class DashboardTest {
     Truth.assertThat(linkageCheckMessages.size()).isGreaterThan(0);
     Truth.assertThat(linkageCheckMessages.get(0).getValue())
         .contains("com.google.appengine.api.appidentity.AppIdentityServicePb$SigningService$1");
+  }
+
+  @Test
+  public void testLinkageErrors_ensureNoDuplicateSymbols() throws IOException, ParsingException {
+    Document document = parseOutputFile(
+        "com.google.http-client_google-http-client-appengine_1.29.1.html");
+    Nodes linkageCheckMessages = document.query("//p[@class='jar-linkage-report-cause']");
+    Truth.assertThat(linkageCheckMessages.size()).isGreaterThan(0);
+
+    List<String> messages = new ArrayList<>();
+    for (int i =0 ;i<linkageCheckMessages.size(); ++i) {
+      messages.add(linkageCheckMessages.get(i).getValue());
+    }
+
+    // When uniqueness of SymbolProblem and Symbol classes are incorrect, dashboard has duplicates.
+    Truth.assertThat(messages).containsNoDuplicates();
   }
 
   @Test

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -276,7 +276,7 @@ public class DashboardTest {
         .that(causes)
         .comparingElementsUsing(NODE_VALUES)
         .contains(
-            "com.google.net.rpc3.client.RpcStubDescriptor is not found,"
+            "Class com.google.net.rpc3.client.RpcStubDescriptor is not found,"
                 + " referenced from 21 source classes ▶"); // '▶' is the toggle button
   }
 

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -324,7 +324,7 @@ public class DashboardTest {
     Nodes linkageCheckMessages = document.query("//ul[@class='jar-linkage-report-cause']/li");
     Truth.assertThat(linkageCheckMessages.size()).isGreaterThan(0);
     Truth.assertThat(linkageCheckMessages.get(0).getValue())
-        .contains("com.google.appengine.api.xmpp.XMPPServicePb$XmppService_3$1");
+        .contains("com.google.appengine.api.appidentity.AppIdentityServicePb$SigningService$1");
   }
 
   @Test

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -287,7 +287,7 @@ public class DashboardTest {
         .comparingElementsUsing(NODE_VALUES)
         .contains(
             "Class com.google.net.rpc3.client.RpcStubDescriptor is not found,"
-                + " referenced from 21 source classes ▶"); // '▶' is the toggle button
+                + " referenced from 21 classes ▶"); // '▶' is the toggle button
   }
 
   @Test

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -200,6 +200,11 @@ public class DashboardTest {
 
   @Test
   public void testLinkageReports() {
+    Nodes reports = details.query("//p[@class='jar-linkage-report']");
+    // appengine-api-sdk, shown as first item in linkage errors, has these errors
+    Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
+        .isEqualTo("115 symbols causing linkage errors referenced from 1,648 source classes.");
+
     Nodes dependencyPaths = details.query(
         "//p[@class='linkage-check-dependency-paths'][position()=last()]");
     Node dependencyPathMessage = dependencyPaths.get(0);
@@ -271,6 +276,10 @@ public class DashboardTest {
   public void testComponent_linkageCheckResult() throws IOException, ParsingException {
     Document document = parseOutputFile(
         "com.google.http-client_google-http-client-appengine_1.29.1.html");
+    Nodes reports = document.query("//p[@class='jar-linkage-report']");
+    Assert.assertEquals(1, reports.size());
+    Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
+        .isEqualTo("115 symbols causing linkage errors referenced from 1,648 source classes.");
     Nodes causes = document.query("//p[@class='jar-linkage-report-cause']");
     Truth.assertWithMessage("google-http-client-appengine should show linkage errors for RpcStubDescriptor")
         .that(causes)

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -17,10 +17,9 @@
 package com.google.cloud.tools.opensource.dashboard;
 
 import com.google.cloud.tools.opensource.classpath.JarLinkageReport;
-import com.google.cloud.tools.opensource.classpath.LinkageCheckReport;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
@@ -80,11 +79,9 @@ public class DashboardUnavailableArtifactTest {
     
     ArtifactCache cache = new ArtifactCache();
     cache.setInfoMap(map);
-    LinkageCheckReport linkageCheckReport =
-        LinkageCheckReport.create(ImmutableList.of());
     List<ArtifactResults> artifactResults =
         DashboardMain.generateReports(
-            configuration, outputDirectory, cache, linkageCheckReport,
+            configuration, outputDirectory, cache, ImmutableSetMultimap.of(),
             LinkedListMultimap.create());
 
     Assert.assertEquals(
@@ -119,15 +116,19 @@ public class DashboardUnavailableArtifactTest {
     Artifact invalidArtifact = new DefaultArtifact("io.grpc:nonexistent:jar:1.15.0");
     ArtifactResults errorArtifactResult = new ArtifactResults(invalidArtifact);
     errorArtifactResult.setExceptionMessage(
-        "Could not find artifact io.grpc:nonexistent:jar:1.15.0 in central (http://repo1.maven.org/maven2/)");
+        "Could not find artifact io.grpc:nonexistent:jar:1.15.0 in central"
+            + " (http://repo1.maven.org/maven2/)");
     List<ArtifactResults> table = new ArrayList<>();
     table.add(validArtifactResult);
     table.add(errorArtifactResult);
 
-    Iterable<JarLinkageReport> list = new ArrayList<>();
-    LinkageCheckReport report = LinkageCheckReport.create(list);
     DashboardMain.generateDashboard(
-        configuration, outputDirectory, table, null, report, LinkedListMultimap.create());
+        configuration,
+        outputDirectory,
+        table,
+        null,
+        ImmutableSetMultimap.of(),
+        LinkedListMultimap.create());
 
     Path generatedHtml = outputDirectory.resolve("artifact_details.html");
     Assert.assertTrue(Files.isRegularFile(generatedHtml));

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.opensource.classpath.JarLinkageReport;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
 import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
@@ -81,7 +82,7 @@ public class DashboardUnavailableArtifactTest {
     cache.setInfoMap(map);
     List<ArtifactResults> artifactResults =
         DashboardMain.generateReports(
-            configuration, outputDirectory, cache, ImmutableSetMultimap.of(),
+            configuration, outputDirectory, cache, ImmutableTable.of(),
             LinkedListMultimap.create());
 
     Assert.assertEquals(
@@ -127,7 +128,7 @@ public class DashboardUnavailableArtifactTest {
         outputDirectory,
         table,
         null,
-        ImmutableSetMultimap.of(),
+        ImmutableTable.of(),
         LinkedListMultimap.create());
 
     Path generatedHtml = outputDirectory.resolve("artifact_details.html");

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -16,11 +16,10 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
-import com.google.cloud.tools.opensource.classpath.JarLinkageReport;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
@@ -82,7 +81,7 @@ public class DashboardUnavailableArtifactTest {
     cache.setInfoMap(map);
     List<ArtifactResults> artifactResults =
         DashboardMain.generateReports(
-            configuration, outputDirectory, cache, ImmutableSetMultimap.of(),
+            configuration, outputDirectory, cache, ImmutableMap.of(),
             LinkedListMultimap.create());
 
     Assert.assertEquals(
@@ -128,7 +127,7 @@ public class DashboardUnavailableArtifactTest {
         outputDirectory,
         table,
         null,
-        ImmutableSetMultimap.of(),
+        ImmutableMap.of(),
         LinkedListMultimap.create());
 
     Path generatedHtml = outputDirectory.resolve("artifact_details.html");

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -82,7 +82,7 @@ public class DashboardUnavailableArtifactTest {
     cache.setInfoMap(map);
     List<ArtifactResults> artifactResults =
         DashboardMain.generateReports(
-            configuration, outputDirectory, cache, ImmutableTable.of(),
+            configuration, outputDirectory, cache, ImmutableSetMultimap.of(),
             LinkedListMultimap.create());
 
     Assert.assertEquals(
@@ -128,7 +128,7 @@ public class DashboardUnavailableArtifactTest {
         outputDirectory,
         table,
         null,
-        ImmutableTable.of(),
+        ImmutableSetMultimap.of(),
         LinkedListMultimap.create());
 
     Path generatedHtml = outputDirectory.resolve("artifact_details.html");

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.opensource.dashboard;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
@@ -81,8 +80,7 @@ public class DashboardUnavailableArtifactTest {
     cache.setInfoMap(map);
     List<ArtifactResults> artifactResults =
         DashboardMain.generateReports(
-            configuration, outputDirectory, cache, ImmutableMap.of(),
-            LinkedListMultimap.create());
+            configuration, outputDirectory, cache, ImmutableMap.of(), LinkedListMultimap.create());
 
     Assert.assertEquals(
         "The length of the ArtifactResults should match the length of artifacts",

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -45,7 +45,6 @@ import nu.xom.Builder;
 import nu.xom.Document;
 import nu.xom.Nodes;
 import nu.xom.ParsingException;
-import nu.xom.ValidityException;
 
 
 /**

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
-import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.ImmutableTable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,6 +32,7 @@ import org.junit.Test;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
 import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.io.MoreFiles;

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
+import com.google.common.collect.ImmutableSetMultimap;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,7 +30,6 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.google.cloud.tools.opensource.classpath.LinkageCheckReport;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
 import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.collect.ImmutableList;
@@ -69,12 +69,9 @@ public class FreemarkerTest {
   }
 
   @Test
-  public void testCountFailures() throws IOException, TemplateException, ValidityException, ParsingException {
+  public void testCountFailures() throws IOException, TemplateException, ParsingException {
     Configuration configuration = DashboardMain.configureFreemarker();
 
-    LinkageCheckReport linkageCheckReport =
-        LinkageCheckReport.create(ImmutableList.of());
-    
     Artifact artifact1 = new DefaultArtifact("io.grpc:grpc-context:1.15.0");
     ArtifactResults results1 = new ArtifactResults(artifact1);
     results1.addResult("Linkage Errors", 56);
@@ -87,7 +84,7 @@ public class FreemarkerTest {
     List<DependencyGraph> globalDependencies = ImmutableList.of();
     ListMultimap<Path, DependencyPath> jarToDependencyPaths = LinkedListMultimap.create();
     DashboardMain.generateDashboard(configuration, outputDirectory, table, globalDependencies,
-        linkageCheckReport, jarToDependencyPaths);
+        ImmutableSetMultimap.of(), jarToDependencyPaths);
     
     Path dashboardHtml = outputDirectory.resolve("dashboard.html");
     Assert.assertTrue(Files.isRegularFile(dashboardHtml));

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.opensource.dashboard;
 
 import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.ImmutableTable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -83,7 +84,7 @@ public class FreemarkerTest {
     List<DependencyGraph> globalDependencies = ImmutableList.of();
     ListMultimap<Path, DependencyPath> jarToDependencyPaths = LinkedListMultimap.create();
     DashboardMain.generateDashboard(configuration, outputDirectory, table, globalDependencies,
-        ImmutableSetMultimap.of(), jarToDependencyPaths);
+        ImmutableTable.of(), jarToDependencyPaths);
     
     Path dashboardHtml = outputDirectory.resolve("dashboard.html");
     Assert.assertTrue(Files.isRegularFile(dashboardHtml));

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
-import com.google.cloud.tools.opensource.classpath.ClassSymbol;
-import com.google.cloud.tools.opensource.classpath.ErrorType;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,6 +29,8 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.google.cloud.tools.opensource.classpath.ClassSymbol;
+import com.google.cloud.tools.opensource.classpath.ErrorType;
 import com.google.cloud.tools.opensource.classpath.SymbolProblem;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
 import com.google.cloud.tools.opensource.dependencies.DependencyPath;

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -84,7 +84,7 @@ public class FreemarkerTest {
     List<DependencyGraph> globalDependencies = ImmutableList.of();
     ListMultimap<Path, DependencyPath> jarToDependencyPaths = LinkedListMultimap.create();
     DashboardMain.generateDashboard(configuration, outputDirectory, table, globalDependencies,
-        ImmutableTable.of(), jarToDependencyPaths);
+        ImmutableSetMultimap.of(), jarToDependencyPaths);
     
     Path dashboardHtml = outputDirectory.resolve("dashboard.html");
     Assert.assertTrue(Files.isRegularFile(dashboardHtml));

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -64,12 +64,11 @@ public class FreemarkerTest {
   public static void setUp() throws IOException {
     outputDirectory = Files.createDirectories(Paths.get("target", "dashboard"));
 
-    ImmutableSetMultimap<SymbolProblem, String> dummyProblems = ImmutableSetMultimap.of(
-        new SymbolProblem(new ClassSymbol("com.foo.Bar"), ErrorType.CLASS_NOT_FOUND, null),
-        "abc.def.G"
-    );
-    symbolProblemTable = ImmutableMap.of(Paths.get("foo", "bar-1.2.3.jar"),
-        dummyProblems);
+    ImmutableSetMultimap<SymbolProblem, String> dummyProblems =
+        ImmutableSetMultimap.of(
+            new SymbolProblem(new ClassSymbol("com.foo.Bar"), ErrorType.CLASS_NOT_FOUND, null),
+            "abc.def.G");
+    symbolProblemTable = ImmutableMap.of(Paths.get("foo", "bar-1.2.3.jar"), dummyProblems);
   }
 
   @AfterClass
@@ -94,9 +93,14 @@ public class FreemarkerTest {
     List<ArtifactResults> table = ImmutableList.of(results1, results2);
     List<DependencyGraph> globalDependencies = ImmutableList.of();
     ListMultimap<Path, DependencyPath> jarToDependencyPaths = LinkedListMultimap.create();
-    DashboardMain.generateDashboard(configuration, outputDirectory, table, globalDependencies,
-        symbolProblemTable, jarToDependencyPaths);
-    
+    DashboardMain.generateDashboard(
+        configuration,
+        outputDirectory,
+        table,
+        globalDependencies,
+        symbolProblemTable,
+        jarToDependencyPaths);
+
     Path dashboardHtml = outputDirectory.resolve("dashboard.html");
     Assert.assertTrue(Files.isRegularFile(dashboardHtml));
     Document document = builder.build(dashboardHtml.toFile());

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
@@ -45,6 +45,14 @@ public final class ClassFile {
     return className;
   }
 
+  /**
+   * Returns {@link ClassFile} with top level class if this class is an inner class by checking "$"
+   * character; otherwise the instance itself.
+   */
+  public ClassFile topLevelClassFile() {
+    return className.contains("$") ? new ClassFile(jar, className.split("\\$")[0]) : this;
+  }
+
   @Override
   public boolean equals(Object other) {
     if (this == other) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
@@ -36,7 +36,7 @@ public final class ClassFile {
   }
 
   /** Returns the path to the JAR file containing the class. */
-  Path getJar() {
+  public Path getJar() {
     return jar;
   }
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbol.java
@@ -26,4 +26,6 @@ public class ClassSymbol extends Symbol {
   public String toString() {
     return "Class " + getClassName();
   }
+
+
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbol.java
@@ -26,6 +26,4 @@ public class ClassSymbol extends Symbol {
   public String toString() {
     return "Class " + getClassName();
   }
-
-
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -102,7 +102,7 @@ public class LinkageChecker {
               .classesDefinedInJar(classFile.getJar())
               .contains(classSymbol.getClassName())) {
             findSymbolProblem(classFile, classSymbol)
-                .ifPresent(problem -> problemToClass.put(problem, classFile));
+                .ifPresent(problem -> problemToClass.put(problem, classFile.topLevelClassFile()));
           }
         });
 
@@ -114,7 +114,7 @@ public class LinkageChecker {
               .classesDefinedInJar(classFile.getJar())
               .contains(methodSymbol.getClassName())) {
             findSymbolProblem(classFile, methodSymbol)
-                .ifPresent(problem -> problemToClass.put(problem, classFile));
+                .ifPresent(problem -> problemToClass.put(problem, classFile.topLevelClassFile()));
           }
         });
 
@@ -126,18 +126,11 @@ public class LinkageChecker {
               .classesDefinedInJar(classFile.getJar())
               .contains(fieldSymbol.getClassName())) {
             findSymbolProblem(classFile, fieldSymbol)
-                .ifPresent(problem -> problemToClass.put(problem, classFile));
+                .ifPresent(problem -> problemToClass.put(problem, classFile.topLevelClassFile()));
           }
         });
 
-    // Remove duplicate references from inner classes of same Java class file
-    return ImmutableSetMultimap.copyOf(
-        Multimaps.transformValues(
-            problemToClass.build(),
-            classFile ->
-                classFile.getClassName().contains("$")
-                    ? new ClassFile(classFile.getJar(), classFile.getClassName().split("\\$")[0])
-                    : classFile));
+    return problemToClass.build();
   }
 
   /**

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -199,7 +199,8 @@ public class LinkageChecker {
       if (classDumper.catchesNoClassDefFoundError(sourceClassName)) {
         return Optional.empty();
       }
-      return Optional.of(new SymbolProblem(symbol, ErrorType.CLASS_NOT_FOUND, null));
+      ClassSymbol classSymbol = new ClassSymbol(symbol.getClassName());
+      return Optional.of(new SymbolProblem(classSymbol, ErrorType.CLASS_NOT_FOUND, null));
     }
   }
 
@@ -244,7 +245,8 @@ public class LinkageChecker {
       if (classDumper.catchesNoClassDefFoundError(sourceClassName)) {
         return Optional.empty();
       }
-      return Optional.of(new SymbolProblem(symbol, ErrorType.CLASS_NOT_FOUND, null));
+      ClassSymbol classSymbol = new ClassSymbol(symbol.getClassName());
+      return Optional.of(new SymbolProblem(classSymbol, ErrorType.CLASS_NOT_FOUND, null));
     }
   }
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimaps;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -129,7 +130,14 @@ public class LinkageChecker {
           }
         });
 
-    return problemToClass.build();
+    // Remove duplicate references from inner classes of same Java class file
+    return ImmutableSetMultimap.copyOf(
+        Multimaps.transformValues(
+            problemToClass.build(),
+            classFile ->
+                classFile.getClassName().contains("$")
+                    ? new ClassFile(classFile.getJar(), classFile.getClassName().split("\\$")[0])
+                    : classFile));
   }
 
   /**

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -84,7 +84,11 @@ public class LinkageChecker {
     this.classToSymbols = Preconditions.checkNotNull(symbolReferenceMaps);
   }
 
-  public ImmutableSetMultimap<ClassFile, SymbolProblem> findSymbolProblems() {
+  /**
+   * Returns {@link SymbolProblem}s found in the class path and referencing classes for each
+   * problem.
+   */
+  public ImmutableSetMultimap<SymbolProblem, ClassFile> findSymbolProblems() {
     // Having Problem in key will dedup SymbolProblems
     ImmutableSetMultimap.Builder<SymbolProblem, ClassFile> problemToClass =
         ImmutableSetMultimap.builder();
@@ -125,13 +129,7 @@ public class LinkageChecker {
           }
         });
 
-    return problemToClass.build().inverse();
-  }
-
-  /** Finds linkage errors in the input classpath and generates a linkage check report. */
-  public LinkageCheckReport findLinkageErrors() {
-    // TODO(#574): This method will be removed once the refactoring is done.
-    return LinkageCheckReport.fromSymbolProblems(findSymbolProblems(), jars, classReferenceGraph);
+    return problemToClass.build();
   }
 
   /**

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Multimaps;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
@@ -49,8 +49,8 @@ class LinkageCheckerMain {
     LinkageChecker linkageChecker = LinkageChecker.create(
         linkageCheckerArguments.getInputClasspath(),
         linkageCheckerArguments.getEntryPointJars());
-    ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems = linkageChecker
-        .findSymbolProblems();
+    ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems =
+        linkageChecker.findSymbolProblems();
 
     System.out.println(SymbolProblem.formatSymbolProblems(symbolProblems));
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
+import com.google.common.collect.ImmutableSetMultimap;
 import java.io.IOException;
 import org.apache.commons.cli.ParseException;
 import org.eclipse.aether.RepositoryException;
@@ -48,9 +49,10 @@ class LinkageCheckerMain {
     LinkageChecker linkageChecker = LinkageChecker.create(
         linkageCheckerArguments.getInputClasspath(),
         linkageCheckerArguments.getEntryPointJars());
-    LinkageCheckReport report = linkageChecker.findLinkageErrors();
+    ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems = linkageChecker
+        .findSymbolProblems();
 
-    System.out.println(report);
+    System.out.println(symbolProblems);
   }
 
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
@@ -52,7 +52,7 @@ class LinkageCheckerMain {
     ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems = linkageChecker
         .findSymbolProblems();
 
-    System.out.println(symbolProblems);
+    System.out.println(SymbolProblem.formatSymbolProblems(symbolProblems));
   }
 
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
@@ -99,11 +99,10 @@ public final class SymbolProblem {
 
     for (SymbolProblem problem : symbolProblems.keySet()) {
       int referenceCount = symbolProblems.get(problem).size();
-      output.append(String.format("%s\n  referenced by %d class file%s\n",
-          problem,
-          referenceCount,
-          referenceCount > 1 ? "s" : ""
-      ));
+      output.append(
+          String.format(
+              "%s\n  referenced by %d class file%s\n",
+              problem, referenceCount, referenceCount > 1 ? "s" : ""));
     }
 
     return output.toString();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.opensource.classpath;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -38,7 +37,11 @@ public final class SymbolProblem {
   private final ClassFile containingClass;
 
   public SymbolProblem(Symbol symbol, ErrorType errorType, @Nullable ClassFile containingClass) {
-    this.symbol = checkNotNull(symbol);
+    checkNotNull(symbol);
+
+    // After finding symbol problem, there is no need to have SuperClassSymbol over ClassSymbol.
+    this.symbol =
+        symbol instanceof SuperClassSymbol ? new ClassSymbol(symbol.getClassName()) : symbol;
     this.errorType = checkNotNull(errorType);
     this.containingClass = containingClass;
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
@@ -18,6 +18,8 @@ package com.google.cloud.tools.opensource.classpath;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
@@ -86,5 +88,25 @@ public final class SymbolProblem {
   @Override
   public final String toString() {
     return getErrorType().getMessage(symbol.toString());
+  }
+
+  public static String formatSymbolProblems(
+      ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems) {
+    StringBuilder output = new StringBuilder();
+
+    for (SymbolProblem problem : symbolProblems.keySet()) {
+      output.append(problem);
+      output.append("\n  referenced by ");
+      ImmutableSet<ClassFile> references = symbolProblems.get(problem);
+      int referenceCount = references.size();
+      output.append(referenceCount);
+      output.append(" class file");
+      if (referenceCount > 1) {
+        output.append("s");
+      }
+      output.append("\n");
+    }
+
+    return output.toString();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
@@ -95,16 +95,12 @@ public final class SymbolProblem {
     StringBuilder output = new StringBuilder();
 
     for (SymbolProblem problem : symbolProblems.keySet()) {
-      output.append(problem);
-      output.append("\n  referenced by ");
-      ImmutableSet<ClassFile> references = symbolProblems.get(problem);
-      int referenceCount = references.size();
-      output.append(referenceCount);
-      output.append(" class file");
-      if (referenceCount > 1) {
-        output.append("s");
-      }
-      output.append("\n");
+      int referenceCount = symbolProblems.get(problem).size();
+      output.append(String.format("%s\n  referenced by %d class file%s\n",
+          problem,
+          referenceCount,
+          referenceCount > 1 ? "s" : ""
+      ));
     }
 
     return output.toString();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -186,12 +186,12 @@ public class ClassPathBuilderTest {
                 httpClientJar, "org.apache.http.client.protocol.ResponseContentEncoding"),
             new ClassSymbol("org.apache.http.client.entity.GZIPInputStreamFactory"));
 
-    ImmutableSetMultimap<ClassFile, SymbolProblem> symbolProblems =
+    ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems =
         linkageChecker.findSymbolProblems();
     assertEquals(
         "Method references within the same jar file should not be reported",
         0,
-        symbolProblems.keySet().stream()
+        symbolProblems.values().stream()
             .filter(classFile -> httpClientJar.equals(classFile.getJar()))
             .count());
   }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.opensource.classpath;
 import static com.google.cloud.tools.opensource.classpath.ClassPathBuilderTest.PATH_FILE_NAMES;
 import static com.google.cloud.tools.opensource.classpath.TestHelper.absolutePathOfResource;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -734,9 +735,11 @@ public class LinkageCheckerTest {
     boolean hasClassSymbolProblem = symbolProblems.keySet().stream().anyMatch(problem -> problem.getSymbol() instanceof ClassSymbol);
     assertTrue(hasClassSymbolProblem);
     boolean hasMethodSymbolProblem = symbolProblems.keySet().stream().anyMatch(problem -> problem.getSymbol() instanceof MethodSymbol);
-    assertTrue(hasMethodSymbolProblem);
+    assertFalse("Method reference missing class should be reported as class symbol problem",
+        hasMethodSymbolProblem);
     boolean hasFieldSymbolProblem = symbolProblems.keySet().stream().anyMatch(problem -> problem.getSymbol() instanceof FieldSymbol);
-    assertTrue(hasFieldSymbolProblem);
+    assertFalse("Field reference missing class should be reported as class symbol problem",
+        hasFieldSymbolProblem);
   }
 
   @Test

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -279,7 +279,8 @@ public class LinkageCheckerTest {
     Truth8.assertThat(problemFound).isPresent();
     SymbolProblem symbolProblem = problemFound.get();
     assertSame(ErrorType.CLASS_NOT_FOUND, symbolProblem.getErrorType());
-    assertTrue("Method reference missing class should report it as class symbol problem",
+    assertTrue(
+        "Method reference missing class should report it as class symbol problem",
         symbolProblem.getSymbol() instanceof ClassSymbol);
   }
 
@@ -327,15 +328,13 @@ public class LinkageCheckerTest {
     Optional<SymbolProblem> problemFound =
         linkageChecker.findSymbolProblem(
             new ClassFile(paths.get(0), "com.google.common.collect.ImmutableList"),
-            new FieldSymbol(
-                "com.google.NoSuchClass",
-                "DUMMY_FIELD",
-                "Ljava.lang.String;"));
+            new FieldSymbol("com.google.NoSuchClass", "DUMMY_FIELD", "Ljava.lang.String;"));
 
     Truth8.assertThat(problemFound).isPresent();
     SymbolProblem symbolProblem = problemFound.get();
     assertSame(ErrorType.CLASS_NOT_FOUND, symbolProblem.getErrorType());
-    assertTrue("Field reference missing class should report it as class symbol problem",
+    assertTrue(
+        "Field reference missing class should report it as class symbol problem",
         symbolProblem.getSymbol() instanceof ClassSymbol);
   }
 
@@ -417,8 +416,7 @@ public class LinkageCheckerTest {
   }
 
   @Test
-  public void testFindSymbolProblem_privateField()
-      throws IOException, URISyntaxException {
+  public void testFindSymbolProblem_privateField() throws IOException, URISyntaxException {
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/api-common-1.7.0.jar"));
     LinkageChecker linkageChecker = LinkageChecker.create(paths, paths);
 
@@ -438,8 +436,7 @@ public class LinkageCheckerTest {
   }
 
   @Test
-  public void testFindSymbolProblem_protectedFieldFromSamePackage()
-      throws IOException {
+  public void testFindSymbolProblem_protectedFieldFromSamePackage() throws IOException {
     String targetClassName = "com.google.common.io.CharSource$CharSequenceCharSource";
 
     List<Path> paths = ImmutableList.of(guavaPath);
@@ -544,7 +541,8 @@ public class LinkageCheckerTest {
   }
 
   @Test
-  public void testFindSymbolProblems_shouldStripSourceInnerClasses() throws IOException, URISyntaxException {
+  public void testFindSymbolProblems_shouldStripSourceInnerClasses()
+      throws IOException, URISyntaxException {
     // The superclass of AbstractApiService$InnerService (Guava's ApiService) is not in the paths
     Path dummySource = firestorePath;
     List<Path> paths = ImmutableList.of(absolutePathOfResource("testdata/api-common-1.7.0.jar"));
@@ -558,8 +556,11 @@ public class LinkageCheckerTest {
     ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems =
         linkageChecker.cloneWith(builder.build()).findSymbolProblems();
 
-    long innerClassCount = symbolProblems.values().stream().map(ClassFile::getClassName)
-        .filter(className -> className.contains("$")).count();
+    long innerClassCount =
+        symbolProblems.values().stream()
+            .map(ClassFile::getClassName)
+            .filter(className -> className.contains("$"))
+            .count();
     assertEquals(0L, innerClassCount);
   }
 
@@ -750,14 +751,21 @@ public class LinkageCheckerTest {
     ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems =
         linkageChecker.findSymbolProblems();
 
-
-    boolean hasClassSymbolProblem = symbolProblems.keySet().stream().anyMatch(problem -> problem.getSymbol() instanceof ClassSymbol);
+    boolean hasClassSymbolProblem =
+        symbolProblems.keySet().stream()
+            .anyMatch(problem -> problem.getSymbol() instanceof ClassSymbol);
     assertTrue(hasClassSymbolProblem);
-    boolean hasMethodSymbolProblem = symbolProblems.keySet().stream().anyMatch(problem -> problem.getSymbol() instanceof MethodSymbol);
-    assertFalse("Method reference missing class should be reported as class symbol problem",
+    boolean hasMethodSymbolProblem =
+        symbolProblems.keySet().stream()
+            .anyMatch(problem -> problem.getSymbol() instanceof MethodSymbol);
+    assertFalse(
+        "Method reference missing class should be reported as class symbol problem",
         hasMethodSymbolProblem);
-    boolean hasFieldSymbolProblem = symbolProblems.keySet().stream().anyMatch(problem -> problem.getSymbol() instanceof FieldSymbol);
-    assertFalse("Field reference missing class should be reported as class symbol problem",
+    boolean hasFieldSymbolProblem =
+        symbolProblems.keySet().stream()
+            .anyMatch(problem -> problem.getSymbol() instanceof FieldSymbol);
+    assertFalse(
+        "Field reference missing class should be reported as class symbol problem",
         hasFieldSymbolProblem);
   }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -19,7 +19,10 @@ package com.google.cloud.tools.opensource.classpath;
 import static com.google.cloud.tools.opensource.classpath.ClassPathBuilderTest.PATH_FILE_NAMES;
 import static com.google.cloud.tools.opensource.classpath.TestHelper.absolutePathOfResource;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -88,7 +91,7 @@ public class LinkageCheckerTest {
 
     // Array's clone is available in Java runtime and thus should not be reported as linkage error
     long arraySymbolProblemCount =
-        linkageChecker.findSymbolProblems().values().stream()
+        linkageChecker.findSymbolProblems().keys().stream()
             .filter(problem -> problem.getSymbol().getClassName().startsWith("["))
             .count();
     assertEquals(0, arraySymbolProblemCount);
@@ -108,7 +111,7 @@ public class LinkageCheckerTest {
             "(Ljava/util/Map;)V",
             false));
 
-    ImmutableSetMultimap<ClassFile, SymbolProblem> symbolProblems =
+    ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems =
         linkageChecker.cloneWith(builder.build()).findSymbolProblems();
 
     Truth.assertThat(symbolProblems).isEmpty();
@@ -469,7 +472,7 @@ public class LinkageCheckerTest {
         new ClassFile(paths.get(0), LinkageCheckReportTest.class.getName()),
         // This inner class is defined as public in firestore-v1beta1-0.28.0.jar
         new ClassSymbol("com.google.firestore.v1beta1.FirestoreGrpc$FirestoreStub"));
-    ImmutableSetMultimap<ClassFile, SymbolProblem> symbolProblems =
+    ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems =
         linkageChecker.cloneWith(builder.build()).findSymbolProblems();
 
     Truth.assertThat(symbolProblems).isEmpty();
@@ -488,17 +491,17 @@ public class LinkageCheckerTest {
         new ClassFile(dummySource, LinkageCheckReportTest.class.getName()),
         // This private inner class is defined in firestore-v1beta1-0.28.0.jar
         new ClassSymbol("com.google.api.core.AbstractApiService$InnerService"));
-    ImmutableSetMultimap<ClassFile, SymbolProblem> symbolProblems =
+    ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems =
         linkageChecker.cloneWith(builder.build()).findSymbolProblems();
 
     Truth.assertThat(symbolProblems).hasSize(1);
-    Map.Entry<ClassFile, SymbolProblem> entry = symbolProblems.entries().asList().get(0);
-    SymbolProblem problem = entry.getValue();
+    Map.Entry<SymbolProblem, ClassFile> entry = symbolProblems.entries().asList().get(0);
+    SymbolProblem problem = entry.getKey();
     assertSame(ErrorType.INACCESSIBLE_CLASS, problem.getErrorType());
 
     Truth.assertWithMessage(
             "When the superclass is unavailable, it should report the location of InnerService")
-        .that(entry.getValue().getContainingClass().getJar().getFileName().toString())
+        .that(entry.getKey().getContainingClass().getJar().getFileName().toString())
         .endsWith("api-common-1.7.0.jar");
   }
 
@@ -654,17 +657,17 @@ public class LinkageCheckerTest {
             "listDocuments",
             "()Ljava/lang/Iterable;",
             false));
-    ImmutableSetMultimap<ClassFile, SymbolProblem> symbolProblems65First =
+    ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems65First =
         linkageChecker65First.cloneWith(builder.build()).findSymbolProblems();
     Truth.assertThat(symbolProblems65First).hasSize(1);
 
-    ImmutableSetMultimap<ClassFile, SymbolProblem> symbolProblems66First =
+    ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems66First =
         linkageChecker66First.cloneWith(builder.build()).findSymbolProblems();
     Truth.assertThat(symbolProblems66First).isEmpty();
   }
 
   @Test
-  public void testFindLinkageErrors_catchesNoClassDefFoundError()
+  public void testFindSymbolProblems_catchesNoClassDefFoundError()
       throws RepositoryException, IOException {
     // SLF4J classes catch NoClassDefFoundError to detect the availability of logger backends
     // the tool should not show errors for such classes.
@@ -674,31 +677,33 @@ public class LinkageCheckerTest {
 
     LinkageChecker linkageChecker = LinkageChecker.create(paths, paths);
 
-    LinkageCheckReport linkageErrors = linkageChecker.findLinkageErrors();
+    ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems =
+        linkageChecker.findSymbolProblems();
 
-    JarLinkageReport slf4jLinkageReport = linkageErrors.getJarLinkageReports().get(0);
-    Truth.assertThat(slf4jLinkageReport.getMissingClassErrors()).isEmpty();
-    Truth.assertThat(slf4jLinkageReport.getMissingFieldErrors()).isEmpty();
-    Truth.assertThat(slf4jLinkageReport.getMissingMethodErrors()).isEmpty();
+    Truth.assertThat(symbolProblems).isEmpty();
   }
 
   @Test
-  public void testFindLinkageErrors_doesNotCatchNoClassDefFoundError() throws IOException {
+  public void testFindSymbolProblems_doesNotCatchNoClassDefFoundError() throws IOException {
     // Checking Firestore jar file without its dependency should have linkage errors
     // Note that FirestoreGrpc.java does not have catch clause of NoClassDefFoundError
     List<Path> paths = ImmutableList.of(firestorePath);
     LinkageChecker linkageChecker = LinkageChecker.create(paths, paths);
 
-    LinkageCheckReport linkageErrors = linkageChecker.findLinkageErrors();
+    ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems =
+        linkageChecker.findSymbolProblems();
 
-    JarLinkageReport firestoreLinkageReport = linkageErrors.getJarLinkageReports().get(0);
-    Truth.assertThat(firestoreLinkageReport.getMissingClassErrors()).isNotEmpty();
-    Truth.assertThat(firestoreLinkageReport.getMissingMethodErrors()).isNotEmpty();
-    Truth.assertThat(firestoreLinkageReport.getMissingFieldErrors()).isNotEmpty();
+
+    boolean hasClassSymbolProblem = symbolProblems.keySet().stream().anyMatch(problem -> problem.getSymbol() instanceof ClassSymbol);
+    assertTrue(hasClassSymbolProblem);
+    boolean hasMethodSymbolProblem = symbolProblems.keySet().stream().anyMatch(problem -> problem.getSymbol() instanceof MethodSymbol);
+    assertTrue(hasMethodSymbolProblem);
+    boolean hasFieldSymbolProblem = symbolProblems.keySet().stream().anyMatch(problem -> problem.getSymbol() instanceof FieldSymbol);
+    assertTrue(hasFieldSymbolProblem);
   }
 
   @Test
-  public void testFindLinkageErrors_shouldNotFailOnDuplicateClass()
+  public void testFindSymbolProblems_shouldNotFailOnDuplicateClass()
       throws RepositoryException, IOException {
     // There was an issue (#495) where com.google.api.client.http.apache.ApacheHttpRequest is in
     // both google-http-client-1.19.0.jar and google-http-client-apache-2.0.0.jar.
@@ -713,8 +718,9 @@ public class LinkageCheckerTest {
     LinkageChecker linkageChecker = LinkageChecker.create(paths, paths);
 
     // This should not raise an exception
-    LinkageCheckReport report = linkageChecker.findLinkageErrors();
-    Truth.assertThat(report).isNotNull();
+    ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems =
+        linkageChecker.findSymbolProblems();
+    assertNotNull(symbolProblems);
   }
 
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolProblemTest.java
@@ -87,8 +87,8 @@ public class SymbolProblemTest {
     SymbolProblem methodSymbolProblem =
         new SymbolProblem(
             new MethodSymbol(
-                "java.lang.Object",
-                "equals",
+                "io.grpc.protobuf.ProtoUtils.marshaller",
+                "marshaller",
                 "(Lcom/google/protobuf/Message;)Lio/grpc/MethodDescriptor$Marshaller;",
                 false),
             ErrorType.SYMBOL_NOT_FOUND,
@@ -104,8 +104,8 @@ public class SymbolProblemTest {
         ImmutableSetMultimap.of(
             methodSymbolProblem, source1, classSymbolProblem, source1, classSymbolProblem, source2);
     assertEquals(
-        "java.lang.Object's method io.grpc.MethodDescriptor$Marshaller "
-            + "equals(com.google.protobuf.Message arg1) is not found in the class\n"
+        "io.grpc.protobuf.ProtoUtils.marshaller's method io.grpc.MethodDescriptor$Marshaller "
+            + "marshaller(com.google.protobuf.Message arg1) is not found in the class\n"
             + "  referenced by 1 class file\n"
             + "Class java.lang.Integer is not found\n"
             + "  referenced by 2 class files\n",

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolProblemTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.opensource.classpath;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
+import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
 import com.google.common.testing.NullPointerTester.Visibility;
@@ -79,5 +80,35 @@ public class SymbolProblemTest {
             new SymbolProblem(
                 new ClassSymbol("java.lang.Integer"), ErrorType.CLASS_NOT_FOUND, null))
         .testEquals();
+  }
+
+  @Test
+  public void testFormatSymbolProblems() {
+    SymbolProblem methodSymbolProblem =
+        new SymbolProblem(
+            new MethodSymbol(
+                "java.lang.Object",
+                "equals",
+                "(Lcom/google/protobuf/Message;)Lio/grpc/MethodDescriptor$Marshaller;",
+                false),
+            ErrorType.SYMBOL_NOT_FOUND,
+            new ClassFile(Paths.get("aaa", "bbb.jar"), "java.lang.Object"));
+
+    SymbolProblem classSymbolProblem =
+        new SymbolProblem(new ClassSymbol("java.lang.Integer"), ErrorType.CLASS_NOT_FOUND, null);
+
+    ClassFile source1 = new ClassFile(Paths.get("foo", "dummy.jar"), "java.lang.Object");
+    ClassFile source2 = new ClassFile(Paths.get("bar", "dummy.jar"), "java.lang.Object");
+
+    ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems =
+        ImmutableSetMultimap.of(
+            methodSymbolProblem, source1, classSymbolProblem, source1, classSymbolProblem, source2);
+    assertEquals(
+        "java.lang.Object's method io.grpc.MethodDescriptor$Marshaller "
+            + "equals(com.google.protobuf.Message arg1) is not found in the class\n"
+            + "  referenced by 1 class file\n"
+            + "Class java.lang.Integer is not found\n"
+            + "  referenced by 2 class files\n",
+        SymbolProblem.formatSymbolProblems(symbolProblems));
   }
 }

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -28,9 +28,7 @@ import com.google.cloud.tools.opensource.classpath.SymbolProblem;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Sets;
 import com.google.common.graph.Traverser;
 import java.io.File;
 import java.io.IOException;
@@ -128,16 +126,16 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
 
       try {
         LinkageChecker linkageChecker = LinkageChecker.create(classpath, directDependencies);
-        ImmutableSetMultimap<ClassFile, SymbolProblem> symbolProblems = linkageChecker
+        ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems = linkageChecker
             .findSymbolProblems();
         if (reportOnlyReachable) {
           ClassReferenceGraph classReferenceGraph = linkageChecker.getClassReferenceGraph();
           symbolProblems = symbolProblems.entries().stream()
-              .filter(entry -> classReferenceGraph.isReachable(entry.getKey().getClassName()))
+              .filter(entry -> classReferenceGraph.isReachable(entry.getValue().getClassName()))
               .collect(ImmutableSetMultimap.toImmutableSetMultimap(Entry::getKey,Entry::getValue));
         }
         // Count unique SymbolProblems
-        int errorCount = Sets.newHashSet(symbolProblems.values()).size();
+        int errorCount = symbolProblems.keySet().size();
 
         String foundError = reportOnlyReachable ? "reachable error" : "error";
         if (errorCount > 1) {
@@ -150,7 +148,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
                   + " "
                   + foundError
                   + ". Linkage error report:\n"
-                  + formatSymbolProblems(symbolProblems);
+                  + SymbolProblem.formatSymbolProblems(symbolProblems);
           if (getLevel() == WARN) {
             logger.warn(message);
           } else {
@@ -170,28 +168,6 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
     } catch (ExpressionEvaluationException ex) {
       throw new EnforcerRuleException("Unable to lookup an expression " + ex.getMessage(), ex);
     }
-  }
-
-  @VisibleForTesting
-  static String formatSymbolProblems(ImmutableSetMultimap<ClassFile, SymbolProblem> symbolProblems) {
-    ImmutableSetMultimap<SymbolProblem, ClassFile> inversedSymbolProblems = symbolProblems
-        .inverse();
-    StringBuilder output = new StringBuilder();
-
-    for (SymbolProblem problem : inversedSymbolProblems.keySet()) {
-      output.append(problem);
-      output.append("\n  referenced by ");
-      ImmutableSet<ClassFile> references = inversedSymbolProblems.get(problem);
-      int referenceCount = references.size();
-      output.append(referenceCount);
-      output.append(" class file");
-      if (referenceCount > 1) {
-        output.append("s");
-      }
-      output.append("\n");
-    }
-
-    return output.toString();
   }
 
   /** Builds a class path for {@code mavenProject}. */

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -126,13 +126,15 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
 
       try {
         LinkageChecker linkageChecker = LinkageChecker.create(classpath, directDependencies);
-        ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems = linkageChecker
-            .findSymbolProblems();
+        ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems =
+            linkageChecker.findSymbolProblems();
         if (reportOnlyReachable) {
           ClassReferenceGraph classReferenceGraph = linkageChecker.getClassReferenceGraph();
-          symbolProblems = symbolProblems.entries().stream()
-              .filter(entry -> classReferenceGraph.isReachable(entry.getValue().getClassName()))
-              .collect(ImmutableSetMultimap.toImmutableSetMultimap(Entry::getKey,Entry::getValue));
+          symbolProblems =
+              symbolProblems.entries().stream()
+                  .filter(entry -> classReferenceGraph.isReachable(entry.getValue().getClassName()))
+                  .collect(
+                      ImmutableSetMultimap.toImmutableSetMultimap(Entry::getKey, Entry::getValue));
         }
         // Count unique SymbolProblems
         int errorCount = symbolProblems.keySet().size();
@@ -142,11 +144,10 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
           foundError += "s";
         }
         if (errorCount > 0) {
-          String message = String.format(
-              "Linkage Checker rule found %d %s. Linkage error report:\n%s",
-              errorCount,
-              foundError,
-              SymbolProblem.formatSymbolProblems(symbolProblems));
+          String message =
+              String.format(
+                  "Linkage Checker rule found %d %s. Linkage error report:\n%s",
+                  errorCount, foundError, SymbolProblem.formatSymbolProblems(symbolProblems));
           if (getLevel() == WARN) {
             logger.warn(message);
           } else {

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -142,13 +142,11 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
           foundError += "s";
         }
         if (errorCount > 0) {
-          String message =
-              "Linkage Checker rule found "
-                  + errorCount
-                  + " "
-                  + foundError
-                  + ". Linkage error report:\n"
-                  + SymbolProblem.formatSymbolProblems(symbolProblems);
+          String message = String.format(
+              "Linkage Checker rule found %d %s. Linkage error report:\n%s",
+              errorCount,
+              foundError,
+              SymbolProblem.formatSymbolProblems(symbolProblems));
           if (getLevel() == WARN) {
             logger.warn(message);
           } else {

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -164,7 +164,7 @@ public class LinkageCheckerRuleTest {
           "The rule should raise an EnforcerRuleException for artifacts missing dependencies");
     } catch (EnforcerRuleException ex) {
       // pass
-      verify(mockLog).error(ArgumentMatchers.startsWith("Linkage Checker rule found 123 errors."));
+      verify(mockLog).error(ArgumentMatchers.startsWith("Linkage Checker rule found 112 errors."));
       assertEquals("Failed while checking class path. See above error report.", ex.getMessage());
     }
   }

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -24,16 +24,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule.DependencySection;
-import com.google.cloud.tools.opensource.classpath.ClassFile;
-import com.google.cloud.tools.opensource.classpath.ClassSymbol;
-import com.google.cloud.tools.opensource.classpath.ErrorType;
-import com.google.cloud.tools.opensource.classpath.MethodSymbol;
-import com.google.cloud.tools.opensource.classpath.SymbolProblem;
 import com.google.cloud.tools.opensource.dependencies.RepositoryUtility;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.graph.Traverser;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Collectors;

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -287,40 +287,4 @@ public class LinkageCheckerRuleTest {
       // pass
     }
   }
-
-  @Test
-  public void testFormatSymbolProblems() {
-    SymbolProblem methodSymbolProblem =
-        new SymbolProblem(
-            new MethodSymbol(
-                "java.lang.Object",
-                "equals",
-                "(Lcom/google/protobuf/Message;)Lio/grpc/MethodDescriptor$Marshaller;",
-                false),
-            ErrorType.SYMBOL_NOT_FOUND,
-            new ClassFile(Paths.get("aaa", "bbb.jar"), "java.lang.Object"));
-
-    SymbolProblem classSymbolProblem =
-        new SymbolProblem(
-            new ClassSymbol("java.lang.Integer"),
-            ErrorType.CLASS_NOT_FOUND,
-            null);
-
-    ClassFile source1 = new ClassFile(Paths.get("foo", "dummy.jar"),
-        "java.lang.Object");
-    ClassFile source2 = new ClassFile(Paths.get("bar", "dummy.jar"),
-        "java.lang.Object");
-
-    ImmutableSetMultimap<ClassFile, SymbolProblem> symbolProblems =
-        ImmutableSetMultimap.of(source1, methodSymbolProblem,
-            source1, classSymbolProblem,
-            source2, classSymbolProblem);
-    assertEquals(
-        "java.lang.Object's method io.grpc.MethodDescriptor$Marshaller "
-            + "equals(com.google.protobuf.Message arg1) is not found in the class\n"
-            + "  referenced by 1 class file\n"
-            + "Class java.lang.Integer is not found\n"
-            + "  referenced by 2 class files\n",
-        LinkageCheckerRule.formatSymbolProblems(symbolProblems));
-  }
 }

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -164,9 +164,8 @@ public class LinkageCheckerRuleTest {
           "The rule should raise an EnforcerRuleException for artifacts missing dependencies");
     } catch (EnforcerRuleException ex) {
       // pass
-      verify(mockLog).error(ArgumentMatchers.startsWith("Linkage Checker rule found 384 errors."));
-      assertEquals(
-          "Failed while checking class path. See above error report.", ex.getMessage());
+      verify(mockLog).error(ArgumentMatchers.startsWith("Linkage Checker rule found 123 errors."));
+      assertEquals("Failed while checking class path. See above error report.", ex.getMessage());
     }
   }
 


### PR DESCRIPTION
Fixes #630 .

- inversed `findSymbolProblems()`'s return value because the caller was always inversing it.
- Deletion of the old value classes will come in another PR after this.
- A symbol problem caused by CLASS_NOT_FOUND has a ClassSymbol regardless of its origin (class reference, method reference, or field reference). This helps uniquely count symbol problems.
- Dashboard shows counting of references rather than source classes.