### PR TITLE
Remove "dashboard/target" from the dashboard URL

### DIFF
--- a/kokoro/ubuntu/periodic.cfg
+++ b/kokoro/ubuntu/periodic.cfg
@@ -6,6 +6,6 @@ build_file: "cloud-opensource-java/kokoro/ubuntu/periodic.sh"
 action {
   define_artifacts {
     regex: "**/target/dashboard/**"
-    strip_prefix: "github/cloud-opensource-java/"
+    strip_prefix: "github/cloud-opensource-java/dashboard/target"
   }
 }


### PR DESCRIPTION
Fixes #666.

After this attempt successfully creates the dashboard at https://storage.googleapis.com/cloud-opensource-java-dashboard/dashboard/dashboard.html (currently not found), I'll create another PR to update the link in README.md.