### PR TITLE
Dashboard URL updated in documents

### DIFF
--- a/DECLARING_DEPENDENCIES.md
+++ b/DECLARING_DEPENDENCIES.md
@@ -181,7 +181,7 @@ document. Such conflicts are called *intrinsic conflicts*. There is an
 ongoing effort to remove intrinsic conflicts among GCP open source
 Java libraries and prevent new ones from occurring. A dashboard that
 reports the current results of compatibility checks is accessible from
-the [Cloud Open Source Java Dashboard](https://storage.googleapis.com/cloud-opensource-java-dashboard/dashboard/target/dashboard/dashboard.html).
+the [Cloud Open Source Java Dashboard](https://storage.googleapis.com/cloud-opensource-java-dashboard/dashboard/dashboard.html).
 As of the time of this writing, some conflicts are still in the
 process of being fixed, but they should not be encountered by most
 users who only use the public APIs of the libraries. If you encounter

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Java projects for the Google Cloud Platform.
 # Google Cloud Platform Java Dependency Dashboard
 
 [Google Cloud Platform Java Dependency Dashboard](
-https://storage.googleapis.com/cloud-opensource-java-dashboard/dashboard/target/dashboard/dashboard.html)
+https://storage.googleapis.com/cloud-opensource-java-dashboard/dashboard/dashboard.html)
 (runs daily; work in progress) shows multiple checks on the consistency among
 Google Cloud Java libraries. For manually generating the dashboard, see
 [its README](./dashboard/README.md).


### PR DESCRIPTION
Fixes #668

- New (shorter) URL works now: https://storage.googleapis.com/cloud-opensource-java-dashboard/dashboard/dashboard.html
- The dashboard in the old URL still is still there https://storage.googleapis.com/cloud-opensource-java-dashboard/dashboard/target/dashboard/dashboard.html . I'll manually remove them via Google Cloud Console. 