### PR TITLE
Revert to gRPC 1.20.0

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -96,7 +96,7 @@
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-apache</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -46,7 +46,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>27.1-android</guava.version>
     <google.cloud.java.version>0.84.0-alpha</google.cloud.java.version>
-    <io.grpc.version>1.20.0</io.grpc.version>
+    <io.grpc.version>1.21.0</io.grpc.version>
     <protobuf.version>3.6.1</protobuf.version>
     <http.version>1.29.1</http.version>
   </properties>

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -46,7 +46,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>27.1-android</guava.version>
     <google.cloud.java.version>0.84.0-alpha</google.cloud.java.version>
-    <io.grpc.version>1.21.0</io.grpc.version>
+    <io.grpc.version>1.20.0</io.grpc.version>
     <protobuf.version>3.6.1</protobuf.version>
     <http.version>1.29.2</http.version>
   </properties>

--- a/boms/integration-tests/src/test/java/com/google/cloud/MaximumLinkageErrorsTest.java
+++ b/boms/integration-tests/src/test/java/com/google/cloud/MaximumLinkageErrorsTest.java
@@ -72,6 +72,6 @@ public class MaximumLinkageErrorsTest {
     
     // If this next line fails, then the situation has actually improved and we should update
     // the test to match. 
-    Assert.assertEquals("Total linkage errors reduced; update test", 525, symbolProblems.keys().size());
+    Assert.assertEquals("Total linkage errors reduced; update test", 516, symbolProblems.keys().size());
   }
 }


### PR DESCRIPTION
for fewer linkage errors
@suztomo 