### PR TITLE
New dashboard URL in document

### DIFF
--- a/DECLARING_DEPENDENCIES.md
+++ b/DECLARING_DEPENDENCIES.md
@@ -179,9 +179,10 @@ It is possible for GCP open source Java libraries to have conflicts
 that cannot be resolved by following the recommendations of this
 document. Such conflicts are called *intrinsic conflicts*. There is an
 ongoing effort to remove intrinsic conflicts among GCP open source
-Java libraries and prevent new ones from occurring. A dashboard that
-reports the current results of compatibility checks is accessible from
-the [Cloud Open Source Java Dashboard](https://storage.googleapis.com/cloud-opensource-java-dashboard/dashboard/dashboard.html).
+Java libraries and prevent new ones from occurring.
+The [Cloud Open Source Java Dashboard](
+https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/snapshot/index.html)
+reports the current results of compatibility checks.
 As of the time of this writing, some conflicts are still in the
 process of being fixed, but they should not be encountered by most
 users who only use the public APIs of the libraries. If you encounter

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Java projects for the Google Cloud Platform.
 # Google Cloud Platform Java Dependency Dashboard
 
 [Google Cloud Platform Java Dependency Dashboard](
-https://storage.googleapis.com/cloud-opensource-java-dashboard/dashboard/dashboard.html)
+https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/snapshot/index.html)
 (runs daily; work in progress) shows multiple checks on the consistency among
 Google Cloud Java libraries. For manually generating the dashboard, see
 [its README](./dashboard/README.md).


### PR DESCRIPTION
Fixes #701 

Now it's available at https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/snapshot/index.html