### PR TITLE
LinkageMonitor: newline after each reference

### DIFF
--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
@@ -122,7 +122,7 @@ public class LinkageMonitor {
         for (ClassFile classFile : snapshotSymbolProblems.get(problem)) {
           message.append(
               String.format(
-                  "  referenced from %s (%s)",
+                  "  referenced from %s (%s)\n",
                   classFile.getClassName(), classFile.getJar().getFileName()));
         }
       }


### PR DESCRIPTION
Fixes #740 (contains ill-formatted output)

Fixed output for google-cloud-java:

```
suztomo@suxtomo24:~/google-cloud-java$ java -jar ../cloud-opensource-java/linkage-monitor/target/linkage-monitor-0.2.2-SNAPSHOT-all-deps.jar  com.google.cloud:libraries-bom
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
BOM Coordinates: com.google.cloud:libraries-bom:2.1.0-SNAPSHOT
Newly introduced problems:
Class io.opencensus.tags.TagMetadata$TagTtl is not found
  referenced from io.grpc.internal.testing.StatsTestUtils (grpc-testing-1.21.0.jar)
Class io.opencensus.tags.TagMetadata is not found
  referenced from io.grpc.internal.testing.StatsTestUtils (grpc-testing-1.21.0.jar)
(opencensus-api-0.18.0.jar) io.opencensus.trace.unsafe.ContextUtils's method getValue(io.grpc.Context arg1) is not found
  referenced from io.grpc.internal.CensusTracingModule (grpc-core-1.21.0.jar)
(opencensus-api-0.18.0.jar) io.opencensus.tags.TagContextBuilder's method putPropagating(io.opencensus.tags.TagKey arg1, io.opencensus.tags.TagValue arg2) is not found
  referenced from io.grpc.internal.CensusStatsModule (grpc-core-1.21.0.jar)
  referenced from io.grpc.internal.testing.StatsTestUtils (grpc-testing-1.21.0.jar)
(opencensus-api-0.18.0.jar) io.opencensus.trace.unsafe.ContextUtils's method withValue(io.grpc.Context arg1, io.opencensus.trace.Span arg2) is not found
  referenced from io.grpc.internal.CensusTracingModule (grpc-core-1.21.0.jar)
(opencensus-api-0.18.0.jar) io.opencensus.tags.unsafe.ContextUtils's method withValue(io.grpc.Context arg1, io.opencensus.tags.TagContext arg2) is not found
  referenced from io.grpc.internal.CensusStatsModule (grpc-core-1.21.0.jar)
(opencensus-api-0.18.0.jar) io.opencensus.tags.Tag's method create(io.opencensus.tags.TagKey arg1, io.opencensus.tags.TagValue arg2, io.opencensus.tags.TagMetadata arg3) is not found
  referenced from io.grpc.internal.testing.StatsTestUtils (grpc-testing-1.21.0.jar)
(opencensus-api-0.18.0.jar) io.opencensus.tags.unsafe.ContextUtils's method getValue(io.grpc.Context arg1) is not found
  referenced from io.grpc.internal.testing.StatsTestUtils (grpc-testing-1.21.0.jar)

Exception in thread "main" com.google.cloud.tools.dependencies.linkagemonitor.LinkageMonitorException: Found 8 new linkage errors
	at com.google.cloud.tools.dependencies.linkagemonitor.LinkageMonitor.run(LinkageMonitor.java:131)
	at com.google.cloud.tools.dependencies.linkagemonitor.LinkageMonitor.main(LinkageMonitor.java:63)

```