### PR TITLE
Index page for different versions

### DIFF
--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -87,7 +87,7 @@ public class DashboardMain {
   public static final String TEST_NAME_GLOBAL_UPPER_BOUND = "Global Upper Bounds";
   public static final String TEST_NAME_DEPENDENCY_CONVERGENCE = "Dependency Convergence";
 
-  private static Configuration freemarkerConfiguration = configureFreemarker();
+  private static final Configuration freemarkerConfiguration = configureFreemarker();
 
   /**
    * Generates a code hygiene dashboard for a BOM. This tool takes a path to pom.xml of the BOM as
@@ -130,6 +130,7 @@ public class DashboardMain {
     generateVersionIndex(groupId, artifactId, versions);
   }
 
+  @VisibleForTesting
   static Path generateVersionIndex(String groupId, String artifactId, List<String> versions)
       throws IOException, TemplateException, URISyntaxException {
     Path directory = outputDirectory(groupId, artifactId, ".");

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -134,6 +134,7 @@ public class DashboardMain {
   static Path generateVersionIndex(String groupId, String artifactId, List<String> versions)
       throws IOException, TemplateException, URISyntaxException {
     Path directory = outputDirectory(groupId, artifactId, "snapshot").getParent();
+    directory.toFile().mkdirs();
     Path page = directory.resolve("index.html");
 
     Map<String, Object> templateData = new HashMap<>();

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -133,7 +133,7 @@ public class DashboardMain {
   @VisibleForTesting
   static Path generateVersionIndex(String groupId, String artifactId, List<String> versions)
       throws IOException, TemplateException, URISyntaxException {
-    Path directory = outputDirectory(groupId, artifactId, ".");
+    Path directory = outputDirectory(groupId, artifactId, "snapshot").getParent();
     Path page = directory.resolve("index.html");
 
     Map<String, Object> templateData = new HashMap<>();

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -87,6 +87,8 @@ public class DashboardMain {
   public static final String TEST_NAME_GLOBAL_UPPER_BOUND = "Global Upper Bounds";
   public static final String TEST_NAME_DEPENDENCY_CONVERGENCE = "Dependency Convergence";
 
+  private static Configuration freemarkerConfiguration = configureFreemarker();
+
   /**
    * Generates a code hygiene dashboard for a BOM. This tool takes a path to pom.xml of the BOM as
    * an argument or Maven coordinates to a BOM.
@@ -125,6 +127,23 @@ public class DashboardMain {
     for (String version : versions) {
       generate(String.format("%s:%s:%s", groupId, artifactId, version));
     }
+    generateVersionIndex(groupId, artifactId, versions);
+  }
+
+  static Path generateVersionIndex(String groupId, String artifactId, List<String> versions)
+      throws IOException, TemplateException {
+    Path page = outputDirectory(groupId, artifactId, ".").resolve("index.html");
+    Map<String, Object> templateData = new HashMap<>();
+    templateData.put("versions", versions);
+    templateData.put("groupId", groupId);
+    templateData.put("artifactId", artifactId);
+    File dashboardFile = page.toFile();
+    try (Writer out = new OutputStreamWriter(
+        new FileOutputStream(dashboardFile), StandardCharsets.UTF_8)) {
+      Template dashboard = freemarkerConfiguration.getTemplate("/templates/version_index.ftl");
+      dashboard.process(templateData, out);
+    }
+    return page;
   }
 
   @VisibleForTesting
@@ -171,6 +190,12 @@ public class DashboardMain {
     return output;
   }
 
+  private static Path outputDirectory(String groupId, String artifactId, String version) {
+    String versionPathElement = version.contains("-SNAPSHOT") ? "snapshot" : version;
+    return Paths.get(
+        "target", groupId, artifactId, versionPathElement);
+  }
+
   private static Path generateHtml(
       Bom bom,
       ArtifactCache cache,
@@ -180,26 +205,21 @@ public class DashboardMain {
 
     Artifact bomArtifact = new DefaultArtifact(bom.getCoordinates());
 
-    String version = bomArtifact.getVersion();
-    String versionPathElement = version.contains("-SNAPSHOT") ? "snapshot" : version;
-    Path relativePath =
-        Paths.get(
-            "target", bomArtifact.getGroupId(), bomArtifact.getArtifactId(), versionPathElement);
+    Path relativePath = outputDirectory(bomArtifact.getGroupId(), bomArtifact.getArtifactId(), bomArtifact.getVersion());
     Path output = Files.createDirectories(relativePath);
 
     copyResource(output, "css/dashboard.css");
     copyResource(output, "js/dashboard.js");
-    Configuration configuration = configureFreemarker();
 
     ImmutableMap<Path, ImmutableSetMultimap<SymbolProblem, String>> symbolProblemTable =
         indexByJar(symbolProblems);
 
     List<ArtifactResults> table =
         generateReports(
-            configuration, output, cache, symbolProblemTable, jarToDependencyPaths, bom);
+            freemarkerConfiguration, output, cache, symbolProblemTable, jarToDependencyPaths, bom);
 
     generateDashboard(
-        configuration,
+        freemarkerConfiguration,
         output,
         table,
         cache.getGlobalDependencies(),

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -138,8 +138,8 @@ public class DashboardMain {
     templateData.put("groupId", groupId);
     templateData.put("artifactId", artifactId);
     File dashboardFile = page.toFile();
-    try (Writer out = new OutputStreamWriter(
-        new FileOutputStream(dashboardFile), StandardCharsets.UTF_8)) {
+    try (Writer out =
+        new OutputStreamWriter(new FileOutputStream(dashboardFile), StandardCharsets.UTF_8)) {
       Template dashboard = freemarkerConfiguration.getTemplate("/templates/version_index.ftl");
       dashboard.process(templateData, out);
     }
@@ -192,8 +192,7 @@ public class DashboardMain {
 
   private static Path outputDirectory(String groupId, String artifactId, String version) {
     String versionPathElement = version.contains("-SNAPSHOT") ? "snapshot" : version;
-    return Paths.get(
-        "target", groupId, artifactId, versionPathElement);
+    return Paths.get("target", groupId, artifactId, versionPathElement);
   }
 
   private static Path generateHtml(
@@ -205,7 +204,9 @@ public class DashboardMain {
 
     Artifact bomArtifact = new DefaultArtifact(bom.getCoordinates());
 
-    Path relativePath = outputDirectory(bomArtifact.getGroupId(), bomArtifact.getArtifactId(), bomArtifact.getVersion());
+    Path relativePath =
+        outputDirectory(
+            bomArtifact.getGroupId(), bomArtifact.getArtifactId(), bomArtifact.getVersion());
     Path output = Files.createDirectories(relativePath);
 
     copyResource(output, "css/dashboard.css");

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -131,18 +131,24 @@ public class DashboardMain {
   }
 
   static Path generateVersionIndex(String groupId, String artifactId, List<String> versions)
-      throws IOException, TemplateException {
-    Path page = outputDirectory(groupId, artifactId, ".").resolve("index.html");
+      throws IOException, TemplateException, URISyntaxException {
+    Path directory = outputDirectory(groupId, artifactId, ".");
+    Path page = directory.resolve("index.html");
+
     Map<String, Object> templateData = new HashMap<>();
     templateData.put("versions", versions);
     templateData.put("groupId", groupId);
     templateData.put("artifactId", artifactId);
+
     File dashboardFile = page.toFile();
     try (Writer out =
         new OutputStreamWriter(new FileOutputStream(dashboardFile), StandardCharsets.UTF_8)) {
       Template dashboard = freemarkerConfiguration.getTemplate("/templates/version_index.ftl");
       dashboard.process(templateData, out);
     }
+
+    copyResource(directory, "css/dashboard.css");
+
     return page;
   }
 

--- a/dashboard/src/main/resources/templates/version_index.ftl
+++ b/dashboard/src/main/resources/templates/version_index.ftl
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<#include "macros.ftl">
+<head>
+  <meta charset="utf-8" />
+  <title>${groupId}:${artifactId}</title>
+  <link rel="stylesheet" href="dashboard.css" />
+</head>
+<body>
+<h1>${groupId}:${artifactId}</h1>
+
+<ul>
+  <#list versions as version>
+    <li><a href="./${version?contains('-SNAPSHOT')?then('snapshot', version)}/index.html">${version}</a></li>
+  </#list>
+</ul>
+
+</body>
+</html>

--- a/dashboard/src/main/resources/templates/version_index.ftl
+++ b/dashboard/src/main/resources/templates/version_index.ftl
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en-US">
-<#include "macros.ftl">
 <head>
   <meta charset="utf-8" />
   <title>${groupId}:${artifactId}</title>
@@ -11,7 +10,9 @@
 
 <ul>
   <#list versions as version>
-    <li><a href="./${version?contains('-SNAPSHOT')?then('snapshot', version)}/index.html">${version}</a></li>
+    <li>
+      <a href="${version?contains('-SNAPSHOT')?then('snapshot', version)}/index.html">${version}</a>
+    </li>
   </#list>
 </ul>
 

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -40,6 +40,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import nu.xom.Builder;
 import nu.xom.Document;
+import nu.xom.Node;
 import nu.xom.Nodes;
 import nu.xom.ParsingException;
 import org.eclipse.aether.artifact.Artifact;
@@ -115,7 +116,8 @@ public class FreemarkerTest {
   }
 
   @Test
-  public void testVersionIndex() throws IOException, TemplateException, URISyntaxException {
+  public void testVersionIndex()
+      throws IOException, TemplateException, URISyntaxException, ParsingException {
     Path output =
         DashboardMain.generateVersionIndex(
             "com.google.cloud",
@@ -129,5 +131,12 @@ public class FreemarkerTest {
             Paths.get("index.html"))
         .inOrder();
     Assert.assertTrue(Files.isRegularFile(output));
+
+    Document document = builder.build(output.toFile());
+    Nodes links = document.query("//a/@href");
+    Assert.assertEquals(3, links.size());
+    Node snapshotlink = links.get(2);
+    // 2.1.0-SNAPSHOT has directory 'snapshot'
+    Assert.assertEquals("snapshot/index.html", snapshotlink.getValue());
   }
 }

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -16,20 +16,6 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.DefaultArtifact;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.google.cloud.tools.opensource.classpath.ClassSymbol;
 import com.google.cloud.tools.opensource.classpath.ErrorType;
 import com.google.cloud.tools.opensource.classpath.SymbolProblem;
@@ -44,14 +30,24 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
 import com.google.common.truth.Truth;
-
 import freemarker.template.Configuration;
 import freemarker.template.TemplateException;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 import nu.xom.Builder;
 import nu.xom.Document;
 import nu.xom.Nodes;
 import nu.xom.ParsingException;
-
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Unit tests for FreeMarker logic without reading any JAR files. 

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -119,13 +118,17 @@ public class FreemarkerTest {
 
   @Test
   public void testVersionIndex() throws IOException, TemplateException {
-    Path output = DashboardMain.generateVersionIndex("com.google.cloud", "libraries-bom",
-        ImmutableList.of("1.0.0", "2.0.0", "2.1.0-SNAPSHOT"));
-    Truth.assertThat((Iterable<Path>) output).containsAtLeast(
-        Paths.get("target"),
-        Paths.get("com.google.cloud"),
-        Paths.get("libraries-bom"),
-        Paths.get("index.html"))
+    Path output =
+        DashboardMain.generateVersionIndex(
+            "com.google.cloud",
+            "libraries-bom",
+            ImmutableList.of("1.0.0", "2.0.0", "2.1.0-SNAPSHOT"));
+    Truth.assertThat((Iterable<Path>) output)
+        .containsAtLeast(
+            Paths.get("target"),
+            Paths.get("com.google.cloud"),
+            Paths.get("libraries-bom"),
+            Paths.get("index.html"))
         .inOrder();
     Assert.assertTrue(Files.isRegularFile(output));
   }

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -71,7 +72,7 @@ public class FreemarkerTest {
     symbolProblemTable = ImmutableMap.of(Paths.get("foo", "bar-1.2.3.jar"), dummyProblems);
   }
 
-
+  @AfterClass
   public static void cleanUp() throws IOException {
     // Mac's APFS fails with InsecureRecursiveDeleteException without ALLOW_INSECURE.
     // Still safe as this test does not use symbolic links

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.opensource.dashboard;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -118,7 +119,7 @@ public class FreemarkerTest {
   }
 
   @Test
-  public void testVersionIndex() throws IOException, TemplateException {
+  public void testVersionIndex() throws IOException, TemplateException, URISyntaxException {
     Path output =
         DashboardMain.generateVersionIndex(
             "com.google.cloud",

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -72,7 +72,7 @@ public class FreemarkerTest {
     symbolProblemTable = ImmutableMap.of(Paths.get("foo", "bar-1.2.3.jar"), dummyProblems);
   }
 
-  @AfterClass
+
   public static void cleanUp() throws IOException {
     // Mac's APFS fails with InsecureRecursiveDeleteException without ALLOW_INSECURE.
     // Still safe as this test does not use symbolic links
@@ -115,5 +115,18 @@ public class FreemarkerTest {
     }
     // Linkage Errors
     Truth.assertThat(counts.get(1).getValue().trim()).isEqualTo("1");
+  }
+
+  @Test
+  public void testVersionIndex() throws IOException, TemplateException {
+    Path output = DashboardMain.generateVersionIndex("com.google.cloud", "libraries-bom",
+        ImmutableList.of("1.0.0", "2.0.0", "2.1.0-SNAPSHOT"));
+    Truth.assertThat((Iterable<Path>) output).containsAtLeast(
+        Paths.get("target"),
+        Paths.get("com.google.cloud"),
+        Paths.get("libraries-bom"),
+        Paths.get("index.html"))
+        .inOrder();
+    Assert.assertTrue(Files.isRegularFile(output));
   }
 }


### PR DESCRIPTION
Fixes #702 

```
~/cloud-opensource-java/dashboard$ mvn -B exec:java -Dexec.mainClass="com.google.cloud.tools.opensource.dashboard.DashboardMain"   -Dexec.arguments="-a com.google.cloud:libraries-bom"
...
```

![image](https://user-images.githubusercontent.com/28604/60137535-39e83d80-9775-11e9-9959-5e77a3aaad3e.png)


