### PR TITLE
Enforcer rule to include direct provided dependencies into the class path

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -202,7 +202,7 @@ public class DependencyGraphBuilder {
   public static List<Artifact> getDirectProvidedDependencies(Artifact artifact)
       throws RepositoryException {
     DependencyNode root = resolveProvidedDependencies(artifact);
-    Traverser<DependencyNode> traverser = Traverser.forTree(node -> node.getChildren());
+    Traverser<DependencyNode> traverser = Traverser.forTree(DependencyNode::getChildren);
 
     ImmutableList.Builder<Artifact> artifacts = ImmutableList.builder();
     traverser.breadthFirst(root.getChildren()).forEach(node -> artifacts.add(node.getArtifact()));

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -147,7 +147,6 @@ public final class RepositoryUtility {
     }
   }
 
-
   private RepositoryUtility() {}
 
   /**

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -132,8 +132,8 @@ public class DependencyGraphBuilderTest {
   public void testProvidedDependency() throws RepositoryException {
     Artifact artifact = new DefaultArtifact("net.bytebuddy:byte-buddy-agent:1.9.13");
     List<Artifact> dependencies = DependencyGraphBuilder.getDirectProvidedDependencies(artifact);
-    ImmutableList<String> coordinates = dependencies.stream().map(Artifacts::toCoordinates)
-        .collect(toImmutableList());
+    ImmutableList<String> coordinates =
+        dependencies.stream().map(Artifacts::toCoordinates).collect(toImmutableList());
     Truth.assertThat(coordinates).contains("com.kohlschutter.junixsocket:junixsocket-common:2.0.4");
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -28,6 +28,8 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 public class DependencyGraphBuilderTest {
 
   private DefaultArtifact datastore =
@@ -44,7 +46,7 @@ public class DependencyGraphBuilderTest {
 
     // This method should find Guava exactly once.
     int guavaCount = countGuava(graph);
-    Assert.assertEquals(1, guavaCount);
+    assertEquals(1, guavaCount);
   }
 
   @Test
@@ -55,11 +57,11 @@ public class DependencyGraphBuilderTest {
 
     // verify we didn't double count anything
     HashSet<DependencyPath> noDups = new HashSet<>(paths);
-    Assert.assertEquals(paths.size(), noDups.size());
+    assertEquals(paths.size(), noDups.size());
 
     // This method should find Guava multiple times.
     int guavaCount = countGuava(graph);
-    Assert.assertEquals(31, guavaCount);
+    assertEquals(31, guavaCount);
   }
 
   private static int countGuava(DependencyGraph graph) {
@@ -105,12 +107,12 @@ public class DependencyGraphBuilderTest {
     List<DependencyPath> list = graph.list();
     Assert.assertTrue(list.size() > 10);
     DependencyPath firstElement = list.get(0);
-    Assert.assertEquals(
+    assertEquals(
         "Level-order should pick up datastore as first element in the list",
         "google-cloud-datastore",
         firstElement.getLeaf().getArtifactId());
     DependencyPath secondElement = list.get(1);
-    Assert.assertEquals(
+    assertEquals(
         "Level-order should pick up guava before the dependencies of the two",
         "guava",
         secondElement.getLeaf().getArtifactId());
@@ -123,5 +125,13 @@ public class DependencyGraphBuilderTest {
     // Without system properties "os.detected.arch" and "os.detected.name", this would fail.
     List<Artifact> artifacts = DependencyGraphBuilder.getDirectDependencies(nettyArtifact);
     Truth.assertThat(artifacts).isNotEmpty();
+  }
+
+  @Test
+  public void testProvidedDependency() throws RepositoryException {
+    Artifact artifact = new DefaultArtifact("net.bytebuddy:byte-buddy-agent:1.9.13");
+    List<Artifact> dependencies = DependencyGraphBuilder.getDirectProvidedDependencies(artifact);
+    Truth.assertThat(dependencies).hasSize(2);
+    assertEquals("junixsocket-native-common", dependencies.get(0).getArtifactId());
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -16,6 +16,9 @@
 
 package com.google.cloud.tools.opensource.dependencies;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.junit.Assert.assertEquals;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.truth.Truth;
 import java.util.ArrayList;
@@ -27,8 +30,6 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Assert;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 public class DependencyGraphBuilderTest {
 
@@ -131,7 +132,8 @@ public class DependencyGraphBuilderTest {
   public void testProvidedDependency() throws RepositoryException {
     Artifact artifact = new DefaultArtifact("net.bytebuddy:byte-buddy-agent:1.9.13");
     List<Artifact> dependencies = DependencyGraphBuilder.getDirectProvidedDependencies(artifact);
-    Truth.assertThat(dependencies).hasSize(2);
-    assertEquals("junixsocket-native-common", dependencies.get(0).getArtifactId());
+    ImmutableList<String> coordinates = dependencies.stream().map(Artifacts::toCoordinates)
+        .collect(toImmutableList());
+    Truth.assertThat(coordinates).contains("com.kohlschutter.junixsocket:junixsocket-common:2.0.4");
   }
 }

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -55,6 +55,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.kohlschutter.junixsocket</groupId>
+      <artifactId>junixsocket-native-common</artifactId>
+      <version>2.0.4</version>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>dependencies</artifactId>
       <version>${project.version}</version>

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -208,13 +208,14 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
         }
 
         try {
-          List<Artifact> directProvidedDependencies = DependencyGraphBuilder
-              .getDirectProvidedDependencies(artifact);
-          for(Artifact providedDependency: directProvidedDependencies) {
+          List<Artifact> directProvidedDependencies =
+              DependencyGraphBuilder.getDirectProvidedDependencies(artifact);
+          for (Artifact providedDependency : directProvidedDependencies) {
             File file = providedDependency.getFile();
             if (file == null) {
               throw new EnforcerRuleException(
-                  "Provided artifact " + Artifacts.toCoordinates(providedDependency)
+                  "Provided artifact "
+                      + Artifacts.toCoordinates(providedDependency)
                       + " is not associated with a file."
                       + " The linkage checker enforcer rule should be bound to the verify phase.");
             }

--- a/pom.xml
+++ b/pom.xml
@@ -202,3 +202,4 @@
   </profiles>
 
 </project>
+


### PR DESCRIPTION
Fixes #752 

Enforcer rule to include direct provided dependencies into the class path.

Draft. In process of confirming the effect of this change.