### PR TITLE
Enforcer rule to use session that picks up all but test dependencies

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/NonTestDependencySelector.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/NonTestDependencySelector.java
@@ -23,9 +23,9 @@ import org.eclipse.aether.graph.Dependency;
 /**
  * Selects dependencies except {@code test} scope.
  *
- * <p>This class selects all scopes except {@code test} even for direct dependencies, while Maven's
- * default {@link org.eclipse.aether.util.graph.selector.ScopeDependencySelector} selects all direct
- * dependencies regardless of their scope.
+ * <p>This class selects all dependencies except {@code test}-scoped ones, while Maven's default
+ * {@link org.eclipse.aether.util.graph.selector.ScopeDependencySelector} selects all direct
+ * dependencies (including {@code test} scope).
  */
 public class NonTestDependencySelector implements DependencySelector {
   @Override

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/NonTestDependencySelector.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/NonTestDependencySelector.java
@@ -6,6 +6,9 @@ import org.eclipse.aether.graph.Dependency;
 
 /**
  * Selects dependencies except {@code test} scope.
+ *
+ * <p>{@link org.eclipse.aether.util.graph.selector.ScopeDependencySelector} has similar capability
+ * but it selects all direct dependencies regardless of their scope.
  */
 public class NonTestDependencySelector implements DependencySelector {
   @Override

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/NonTestDependencySelector.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/NonTestDependencySelector.java
@@ -1,0 +1,18 @@
+package com.google.cloud.tools.opensource.dependencies;
+
+import org.eclipse.aether.collection.DependencyCollectionContext;
+import org.eclipse.aether.collection.DependencySelector;
+import org.eclipse.aether.graph.Dependency;
+
+public class NonTestDependencySelector implements DependencySelector {
+  @Override
+  public boolean selectDependency(Dependency dependency) {
+    return !"test".equals(dependency.getScope());
+  }
+
+  @Override
+  public DependencySelector deriveChildSelector(
+      DependencyCollectionContext dependencyCollectionContext) {
+    return this;
+  }
+}

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/NonTestDependencySelector.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/NonTestDependencySelector.java
@@ -23,8 +23,9 @@ import org.eclipse.aether.graph.Dependency;
 /**
  * Selects dependencies except {@code test} scope.
  *
- * <p>{@link org.eclipse.aether.util.graph.selector.ScopeDependencySelector} has similar capability
- * but it selects all direct dependencies regardless of their scope.
+ * <p>This class selects all scopes except {@code test} even for direct dependencies, while Maven's
+ * default {@link org.eclipse.aether.util.graph.selector.ScopeDependencySelector} selects all direct
+ * dependencies regardless of their scope.
  */
 public class NonTestDependencySelector implements DependencySelector {
   @Override

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/NonTestDependencySelector.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/NonTestDependencySelector.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.tools.opensource.dependencies;
 
 import org.eclipse.aether.collection.DependencyCollectionContext;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/NonTestDependencySelector.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/NonTestDependencySelector.java
@@ -4,6 +4,9 @@ import org.eclipse.aether.collection.DependencyCollectionContext;
 import org.eclipse.aether.collection.DependencySelector;
 import org.eclipse.aether.graph.Dependency;
 
+/**
+ * Selects dependencies except {@code test} scope.
+ */
 public class NonTestDependencySelector implements DependencySelector {
   @Override
   public boolean selectDependency(Dependency dependency) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -96,6 +96,21 @@ public final class RepositoryUtility {
   private static final ImmutableSet<String> ALLOWED_REPOSITORY_URL_SCHEMES =
       ImmutableSet.of("file", "http", "https");
 
+  public static final DependencySelector selectNonTestDependencySelector =
+      new DependencySelector() {
+
+        @Override
+        public boolean selectDependency(Dependency dependency) {
+          return ! "test".equals(dependency.getScope());
+        }
+
+        @Override
+        public DependencySelector deriveChildSelector(
+            DependencyCollectionContext dependencyCollectionContext) {
+          return this;
+        }
+      };
+
   private RepositoryUtility() {}
 
   /**

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -101,7 +101,7 @@ public final class RepositoryUtility {
 
         @Override
         public boolean selectDependency(Dependency dependency) {
-          return ! "test".equals(dependency.getScope());
+          return !"test".equals(dependency.getScope());
         }
 
         @Override

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -96,21 +96,6 @@ public final class RepositoryUtility {
   private static final ImmutableSet<String> ALLOWED_REPOSITORY_URL_SCHEMES =
       ImmutableSet.of("file", "http", "https");
 
-  public static final DependencySelector nonTestDependencySelector =
-      new DependencySelector() {
-
-        @Override
-        public boolean selectDependency(Dependency dependency) {
-          return !"test".equals(dependency.getScope());
-        }
-
-        @Override
-        public DependencySelector deriveChildSelector(
-            DependencyCollectionContext dependencyCollectionContext) {
-          return this;
-        }
-      };
-
   private RepositoryUtility() {}
 
   /**

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -96,7 +96,7 @@ public final class RepositoryUtility {
   private static final ImmutableSet<String> ALLOWED_REPOSITORY_URL_SCHEMES =
       ImmutableSet.of("file", "http", "https");
 
-  public static final DependencySelector selectNonTestDependencySelector =
+  public static final DependencySelector nonTestDependencySelector =
       new DependencySelector() {
 
         @Override

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.dependencies.enforcer;
 
-import static com.google.cloud.tools.opensource.dependencies.RepositoryUtility.nonTestDependencySelector;
 import static com.google.cloud.tools.opensource.dependencies.RepositoryUtility.shouldSkipBomMember;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.apache.maven.enforcer.rule.api.EnforcerLevel.WARN;
@@ -27,6 +26,7 @@ import com.google.cloud.tools.opensource.classpath.ClassReferenceGraph;
 import com.google.cloud.tools.opensource.classpath.LinkageChecker;
 import com.google.cloud.tools.opensource.classpath.SymbolProblem;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
+import com.google.cloud.tools.opensource.dependencies.NonTestDependencySelector;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSetMultimap;
@@ -58,6 +58,8 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.ArtifactTypeRegistry;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.util.graph.selector.AndDependencySelector;
+import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
 
 /** Linkage Checker Maven Enforcer Rule. */
 public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
@@ -185,7 +187,12 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
           helper.getComponent(ProjectDependenciesResolver.class);
       DefaultRepositorySystemSession fullDependencyResolutionSession =
           new DefaultRepositorySystemSession(session);
-      fullDependencyResolutionSession.setDependencySelector(nonTestDependencySelector);
+      fullDependencyResolutionSession.setDependencySelector(
+          new AndDependencySelector(
+              new NonTestDependencySelector(),
+              new ExclusionDependencySelector()
+          )
+      );
       DependencyResolutionRequest dependencyResolutionRequest =
           new DefaultDependencyResolutionRequest(mavenProject, fullDependencyResolutionSession);
 

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.dependencies.enforcer;
 
-import static com.google.cloud.tools.opensource.dependencies.RepositoryUtility.selectNonTestDependencySelector;
+import static com.google.cloud.tools.opensource.dependencies.RepositoryUtility.nonTestDependencySelector;
 import static com.google.cloud.tools.opensource.dependencies.RepositoryUtility.shouldSkipBomMember;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.apache.maven.enforcer.rule.api.EnforcerLevel.WARN;
@@ -184,7 +184,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
       ProjectDependenciesResolver projectDependenciesResolver =
           helper.getComponent(ProjectDependenciesResolver.class);
       DefaultRepositorySystemSession fullDependencyResolutionSession = new DefaultRepositorySystemSession(session);
-      fullDependencyResolutionSession.setDependencySelector(selectNonTestDependencySelector);
+      fullDependencyResolutionSession.setDependencySelector(nonTestDependencySelector);
       DependencyResolutionRequest dependencyResolutionRequest =
           new DefaultDependencyResolutionRequest(mavenProject, fullDependencyResolutionSession);
 

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -189,10 +189,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
           new DefaultRepositorySystemSession(session);
       fullDependencyResolutionSession.setDependencySelector(
           new AndDependencySelector(
-              new NonTestDependencySelector(),
-              new ExclusionDependencySelector()
-          )
-      );
+              new NonTestDependencySelector(), new ExclusionDependencySelector()));
       DependencyResolutionRequest dependencyResolutionRequest =
           new DefaultDependencyResolutionRequest(mavenProject, fullDependencyResolutionSession);
 

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -183,7 +183,8 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
     try {
       ProjectDependenciesResolver projectDependenciesResolver =
           helper.getComponent(ProjectDependenciesResolver.class);
-      DefaultRepositorySystemSession fullDependencyResolutionSession = new DefaultRepositorySystemSession(session);
+      DefaultRepositorySystemSession fullDependencyResolutionSession =
+          new DefaultRepositorySystemSession(session);
       fullDependencyResolutionSession.setDependencySelector(nonTestDependencySelector);
       DependencyResolutionRequest dependencyResolutionRequest =
           new DefaultDependencyResolutionRequest(mavenProject, fullDependencyResolutionSession);

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.dependencies.enforcer;
 
+import static com.google.cloud.tools.opensource.dependencies.RepositoryUtility.selectNonTestDependencySelector;
 import static com.google.cloud.tools.opensource.dependencies.RepositoryUtility.shouldSkipBomMember;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.apache.maven.enforcer.rule.api.EnforcerLevel.WARN;
@@ -50,6 +51,7 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectDependenciesResolver;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -181,8 +183,11 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
     try {
       ProjectDependenciesResolver projectDependenciesResolver =
           helper.getComponent(ProjectDependenciesResolver.class);
+      DefaultRepositorySystemSession fullDependencyResolutionSession = new DefaultRepositorySystemSession(session);
+      fullDependencyResolutionSession.setDependencySelector(selectNonTestDependencySelector);
       DependencyResolutionRequest dependencyResolutionRequest =
-          new DefaultDependencyResolutionRequest(mavenProject, session);
+          new DefaultDependencyResolutionRequest(mavenProject, fullDependencyResolutionSession);
+
       DependencyResolutionResult resolutionResult =
           projectDependenciesResolver.resolve(dependencyResolutionRequest);
 

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -75,18 +75,20 @@ public class LinkageCheckerRuleTest {
   private DependencyResolutionResult mockDependencyResolutionResult;
 
   @Before
-  public void setup() {
+  public void setup() throws ExpressionEvaluationException, ComponentLookupException,
+      DependencyResolutionException {
     rule = new LinkageCheckerRule();
     repositorySystem = RepositoryUtility.newRepositorySystem();
     repositorySystemSession = RepositoryUtility.newSession(repositorySystem);
+    setupMock();
   }
 
-  @Before
   public void setupMock()
       throws ExpressionEvaluationException, ComponentLookupException,
           DependencyResolutionException {
     mockProject = mock(MavenProject.class);
     mockMavenSession = mock(MavenSession.class);
+    when(mockMavenSession.getRepositorySession()).thenReturn(repositorySystemSession);
     mockRuleHelper = mock(EnforcerRuleHelper.class);
     mockProjectDependenciesResolver = mock(ProjectDependenciesResolver.class);
     mockDependencyResolutionResult = mock(DependencyResolutionResult.class);

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -84,7 +84,7 @@ public class LinkageCheckerRuleTest {
     setupMock();
   }
 
-  public void setupMock()
+  private void setupMock()
       throws ExpressionEvaluationException, ComponentLookupException,
           DependencyResolutionException {
     mockProject = mock(MavenProject.class);

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -75,8 +75,9 @@ public class LinkageCheckerRuleTest {
   private DependencyResolutionResult mockDependencyResolutionResult;
 
   @Before
-  public void setup() throws ExpressionEvaluationException, ComponentLookupException,
-      DependencyResolutionException {
+  public void setup()
+      throws ExpressionEvaluationException, ComponentLookupException,
+          DependencyResolutionException {
     rule = new LinkageCheckerRule();
     repositorySystem = RepositoryUtility.newRepositorySystem();
     repositorySystemSession = RepositoryUtility.newSession(repositorySystem);


### PR DESCRIPTION
Fixes #762 

The errors from Spring libraries, when this enforcer rule is applied for spring-cloud-gcp, are noted in #769 ; these errors are from omission of optional dependencies in their pom.xml.

The enforcer rule works with the example project:

```
# The example project added the enforcer rule
suztomo@suxtomo24:~/cloud-opensource-java/example-problems/no-such-method-error-signature-mismatch$ mvn install
...
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce) @ no-such-method-error-example ---
[ERROR] Linkage Checker rule found 1 reachable error. Linkage error report:
(guava-20.0.jar) com.google.common.base.Verify's method verify(boolean arg1, String arg2, Object arg3) is not found;
  referenced by 3 class files
    io.grpc.internal.ServiceConfigInterceptor (grpc-core-1.17.1.jar)
    io.grpc.internal.JndiResourceResolverFactory (grpc-core-1.17.1.jar)
    io.grpc.internal.DnsNameResolver (grpc-core-1.17.1.jar)
```


