### PR TITLE
Enforcer rule document to have latest version 0.2.1

### DIFF
--- a/enforcer-rules/README.md
+++ b/enforcer-rules/README.md
@@ -29,7 +29,7 @@ Add the following plugin configuration to your `pom.xml`:
           <dependency>
             <groupId>com.google.cloud.tools</groupId>
             <artifactId>linkage-checker-enforcer-rules</artifactId>
-            <version>0.2.0</version>
+            <version>0.2.1</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
0.2.1 is the latest release. Updating README.md
https://search.maven.org/artifact/com.google.cloud.tools/linkage-checker-enforcer-rules/0.2.1/jar
