### PR TITLE
Enforcer rule to work with "bundle" packaging

### DIFF
--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -66,11 +66,10 @@ import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
 public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
 
   /**
-   * List of Maven packaging known to be irrelevant to non-BOM project ({@code dependencySection ==
-   * DEPENDENCIES}).
+   * List of Maven packaging known to be irrelevant to Linkage Check for non-BOM project.
    *
-   * @see <a href="https://maven.apache.org/ref/3.6.1/maven-core/artifact-handlers.html"
-   * >Maven Core: Default Artifact Handlers Reference</a>
+   * @see <a href="https://maven.apache.org/ref/3.6.1/maven-core/artifact-handlers.html" >Maven
+   * Core: Default Artifact Handlers Reference</a>
    */
   private static final ImmutableSet<String> UNSUPPORTED_NONBOM_PACKAGING = ImmutableSet.of("pom",
       "java-source", "javadoc");

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -118,7 +118,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
 
       String projectType = project.getArtifact().getType();
       if (dependencySection == DependencySection.DEPENDENCIES && "pom".equals(projectType)) {
-        // When checking non-BOM project, not interested in pom artifact
+        // Unless checking BOM project, not interested in pom artifact
         return;
       }
 

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -66,7 +66,7 @@ import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
 public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
 
   /**
-   * List of Maven packaging known to be irrelevant to Linkage Check for non-BOM project.
+   * Maven packaging values known to be irrelevant to Linkage Check for non-BOM project.
    *
    * @see <a href="https://maven.apache.org/ref/3.6.1/maven-core/artifact-handlers.html" >Maven
    * Core: Default Artifact Handlers Reference</a>

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -68,7 +68,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
   /**
    * Maven packaging values known to be irrelevant to Linkage Check for non-BOM project.
    *
-   * @see <a href="https://maven.apache.org/ref/3.6.1/maven-core/artifact-handlers.html" >Maven
+   * @see <a href="https://maven.apache.org/ref/3.6.1/maven-core/artifact-handlers.html">Maven
    * Core: Default Artifact Handlers Reference</a>
    */
   private static final ImmutableSet<String> UNSUPPORTED_NONBOM_PACKAGING = ImmutableSet.of("pom",
@@ -134,7 +134,6 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
         }
       } else {
         if (UNSUPPORTED_NONBOM_PACKAGING.contains(projectType)) {
-          // Unless checking BOM project, not interested in pom artifact
           return;
         }
       }

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -128,11 +128,18 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
       }
 
       String projectType = project.getArtifact().getType();
-      if (!readingDependencyManagementSection &&
-          UNSUPPORTED_NONBOM_PACKAGING.contains(projectType)) {
-        // Unless checking BOM project, not interested in pom artifact
-        return;
+      if (readingDependencyManagementSection) {
+        if (!"pom".equals(projectType)) {
+          logger.warn("A BOM should have packaging pom");
+          return;
+        }
+      } else {
+        if (UNSUPPORTED_NONBOM_PACKAGING.contains(projectType)) {
+          // Unless checking BOM project, not interested in pom artifact
+          return;
+        }
       }
+
 
       ImmutableList<Path> classpath =
           readingDependencyManagementSection

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -117,8 +117,8 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
       }
 
       String projectType = project.getArtifact().getType();
-      if (dependencySection == DependencySection.DEPENDENCIES && !"jar".equals(projectType)) {
-        // When checking non-BOM project, not interested in non JAR artifact
+      if (dependencySection == DependencySection.DEPENDENCIES && "pom".equals(projectType)) {
+        // When checking non-BOM project, not interested in pom artifact
         return;
       }
 

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -339,7 +339,8 @@ public class LinkageCheckerRuleTest {
   }
 
   @Test
-  public void testExecute_shouldFailForBadProjectWithBundlePackaging() throws RepositoryException, URISyntaxException {
+  public void testExecute_shouldFailForBadProjectWithBundlePackaging() throws RepositoryException,
+      URISyntaxException {
     try {
       // This artifact is known to contain classes missing dependencies
       setupMockDependencyResolution("com.google.appengine:appengine-api-1.0-sdk:1.9.64");

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -305,6 +305,24 @@ public class LinkageCheckerRuleTest {
   }
 
   @Test
+  public void testExecute_shouldSkipBadBomWithNonPomPackaging() throws EnforcerRuleException {
+    rule.setDependencySection(DependencySection.DEPENDENCY_MANAGEMENT);
+    setupMockDependencyManagementSection(
+        "com.google.api-client:google-api-client:1.27.0", "io.grpc:grpc-core:1.17.1");
+    when(mockProject.getArtifact())
+        .thenReturn(
+            new org.apache.maven.artifact.DefaultArtifact(
+                "com.google.cloud",
+                "linkage-checker-rule-test-bom",
+                "0.0.1",
+                "compile",
+                "jar", // BOM should have pom here
+                null,
+                new DefaultArtifactHandler()));
+    rule.execute(mockRuleHelper);
+  }
+
+  @Test
   public void testExecute_shouldSkipNonBomPom() throws EnforcerRuleException {
     when(mockProject.getArtifact())
         .thenReturn(


### PR DESCRIPTION
Towards #781 

Jaxen uses [packaging: bundle.](https://github.com/jaxen-xpath/jaxen/blob/master/core/pom.xml#L15) The previous PR skipped such packaging.
