### PR TITLE
Enforcer rule not to count test scoped dependencies

### DIFF
--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -133,10 +133,11 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
 
       // As sorted by level order, the first elements in classpath are the project and its direct
       // non-test dependencies.
-      int projectDependencyCount = (int) project.getDependencies()
-          .stream()
-          .filter(dependency -> !"test".equals(dependency.getScope()))
-          .count();
+      int projectDependencyCount =
+          (int)
+              project.getDependencies().stream()
+                  .filter(dependency -> !"test".equals(dependency.getScope()))
+                  .count();
       List<Path> entryPoints = classpath.subList(0, projectDependencyCount + 1);
 
       try {

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -133,7 +133,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
 
       // As sorted by level order, the first elements in classpath are the project and its direct
       // non-test dependencies.
-      long projectDependencyCount =           project.getDependencies().stream()
+      long projectDependencyCount = project.getDependencies().stream()
                   .filter(dependency -> !"test".equals(dependency.getScope()))
                   .count();
       List<Path> entryPoints = classpath.subList(0, (int) projectDependencyCount + 1);

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -133,12 +133,12 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
 
       // As sorted by level order, the first elements in classpath are the project and its direct
       // non-test dependencies.
-      int projectDependencyCount =
-          (int)
+      long projectDependencyCount =
+
               project.getDependencies().stream()
                   .filter(dependency -> !"test".equals(dependency.getScope()))
                   .count();
-      List<Path> entryPoints = classpath.subList(0, projectDependencyCount + 1);
+      List<Path> entryPoints = classpath.subList(0, (int) projectDependencyCount + 1);
 
       try {
 

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -132,8 +132,12 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
       }
 
       // As sorted by level order, the first elements in classpath are the project and its direct
-      // dependencies.
-      List<Path> entryPoints = classpath.subList(0, project.getDependencies().size() + 1);
+      // non-test dependencies.
+      int projectDependencyCount = (int) project.getDependencies()
+          .stream()
+          .filter(dependency -> !"test".equals(dependency.getScope()))
+          .count();
+      List<Path> entryPoints = classpath.subList(0, projectDependencyCount + 1);
 
       try {
 

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -133,9 +133,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
 
       // As sorted by level order, the first elements in classpath are the project and its direct
       // non-test dependencies.
-      long projectDependencyCount =
-
-              project.getDependencies().stream()
+      long projectDependencyCount =           project.getDependencies().stream()
                   .filter(dependency -> !"test".equals(dependency.getScope()))
                   .count();
       List<Path> entryPoints = classpath.subList(0, (int) projectDependencyCount + 1);


### PR DESCRIPTION
Towards #781 .

After applying #782 locally, Jaxen project still does not work with the enforcer rule because of the following IndexOutOfBoundsException:

```
Caused by: java.lang.IndexOutOfBoundsException: end index (2) must not be greater than size (1)
    at com.google.common.base.Preconditions.checkPositionIndexes (Preconditions.java:1418)
    at com.google.common.collect.SingletonImmutableList.subList (SingletonImmutableList.java:64)
    at com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule.execute (LinkageCheckerRule.java:137)
    at org.apache.maven.plugins.enforcer.EnforceMojo.execute (EnforceMojo.java:194)
```

This is because the jaxen has junit in dependency (inherited from parent), while the enforcer rule does not include test-scoped dependencies.

The enforcer rule was trying to create sublist of classpath (which only contains jaxen.jar) with length 2 (jaxen and junit)


