### PR TITLE
Maven license plugin to validate license header in Java code

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.tools.opensource.classpath;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 Google LLC.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.google.cloud.tools.opensource.classpath;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,6 @@
     <resolver.version>1.4.0</resolver.version>
     <maven.version>3.6.0</maven.version>
     <truth.version>1.0</truth.version>
-    <license.plugin.version>3.0</license.plugin.version>
   </properties>
 
   <licenses>
@@ -165,7 +164,7 @@
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>${license.plugin.version}</version>
+          <version>3.0</version>
           <configuration>
             <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
             <skipExistingHeaders>true</skipExistingHeaders>
@@ -188,7 +187,6 @@
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>${license.plugin.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,7 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <!-- this plugin is bound to validate phase -->
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <version>${license.plugin.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@
               <goals>
                 <goal>check</goal>
               </goals>
+              <phase>validate</phase>
             </execution>
           </executions>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,6 @@
     </pluginManagement>
     <plugins>
       <plugin>
-        <!-- this plugin is bound to validate phase -->
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <version>${license.plugin.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <resolver.version>1.4.0</resolver.version>
     <maven.version>3.6.0</maven.version>
     <truth.version>1.0</truth.version>
+    <license.plugin.version>3.0</license.plugin.version>
   </properties>
 
   <licenses>
@@ -161,8 +162,34 @@
             <argLine>-Xms128m -Xmx1024m</argLine>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>com.mycila</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>${license.plugin.version}</version>
+          <configuration>
+            <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
+            <skipExistingHeaders>true</skipExistingHeaders>
+            <includes>
+              <include>**/*.java</include>
+            </includes>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>${license.plugin.version}</version>
+      </plugin>
+    </plugins>
   </build>
 
   <profiles>


### PR DESCRIPTION
Fixes #772 

When license header is missing, build fails:

```
[INFO] --- license-maven-plugin:3.0:check (default) @ dependencies ---
[INFO] Checking licenses...
[WARNING] Missing header in: /home/circleci/cloud-opensource-java/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassFile.java
...
Caused by: org.apache.maven.plugin.MojoExecutionException: Some files do not have the expected license header
    at com.mycila.maven.plugin.license.LicenseCheckMojo.execute (LicenseCheckMojo.java:74)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
```

https://circleci.com/gh/GoogleCloudPlatform/cloud-opensource-java/2045?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link



