### PR TITLE
Maven version to 3.6.1

### DIFF
--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -79,6 +79,11 @@
           <groupId>org.eclipse.aether</groupId>
           <artifactId>aether-util</artifactId>
         </exclusion>
+        <exclusion>
+          <!-- To avoid NoClassDefFoundError org.codehaus.plexus.util.xml.Xpp3DomBuilder$InputLocationBuilder -->
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -87,6 +92,13 @@
       <artifactId>maven-enforcer-plugin</artifactId>
       <version>${enforcer.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <!-- To avoid NoClassDefFoundError org.codehaus.plexus.util.xml.Xpp3DomBuilder$InputLocationBuilder -->
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -53,6 +53,18 @@
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven</artifactId>
+        <version>${maven.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -79,11 +91,6 @@
           <groupId>org.eclipse.aether</groupId>
           <artifactId>aether-util</artifactId>
         </exclusion>
-        <exclusion>
-          <!-- To avoid NoClassDefFoundError org.codehaus.plexus.util.xml.Xpp3DomBuilder$InputLocationBuilder -->
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-utils</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -92,13 +99,6 @@
       <artifactId>maven-enforcer-plugin</artifactId>
       <version>${enforcer.version}</version>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <!-- To avoid NoClassDefFoundError org.codehaus.plexus.util.xml.Xpp3DomBuilder$InputLocationBuilder -->
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-utils</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -55,6 +55,7 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- To avoid plexus-util version conflict (#803) -->
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven</artifactId>

--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -11,5 +11,4 @@ cd github/cloud-opensource-java
 mkdir -p ${HOME}/.m2
 cp settings.xml ${HOME}/.m2
 
-mvn -version
 mvn -B clean install javadoc:jar

--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -11,4 +11,5 @@ cd github/cloud-opensource-java
 mkdir -p ${HOME}/.m2
 cp settings.xml ${HOME}/.m2
 
+mvn -version
 mvn -B clean install javadoc:jar

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>28.0-jre</guava.version>
     <resolver.version>1.4.0</resolver.version>
-    <maven.version>3.6.0</maven.version>
+    <maven.version>3.6.1</maven.version>
     <truth.version>1.0</truth.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -156,8 +156,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.1</version>
           <configuration>
-            <!-- To avoid ForkedBooter loading issue -->
-            <useSystemClassLoader>false</useSystemClassLoader>
+            <!-- To avoid ForkedBooter loading issue
+            <useSystemClassLoader>false</useSystemClassLoader>-->
             <argLine>-Xms128m -Xmx1024m</argLine>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -156,8 +156,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.1</version>
           <configuration>
-            <!-- To avoid ForkedBooter loading issue
-            <useSystemClassLoader>false</useSystemClassLoader>-->
+            <!-- To avoid ForkedBooter loading issue -->
+            <useSystemClassLoader>false</useSystemClassLoader>
             <argLine>-Xms128m -Xmx1024m</argLine>
           </configuration>
         </plugin>


### PR DESCRIPTION
Fixes #803 (ClassNotFoundError due to dependency conflict)

Initially I was thinking to fix it by multiple exclusion elements
([commit](https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/802/commits/da0a77f47b501d3c14d6ebed5a407c22ca480c66)), but leveraging Maven's BOM for version 3.6.1 is more straightforward to control the version of plexus-util in the transitive dependency.

