### PR TITLE
Exclude zip artifact in the enforcer rule

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/FilteringZipDependencySelector.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/FilteringZipDependencySelector.java
@@ -22,8 +22,8 @@ import org.eclipse.aether.collection.DependencyCollectionContext;
 import org.eclipse.aether.collection.DependencySelector;
 import org.eclipse.aether.graph.Dependency;
 
-/** Filters artifacts with {@code zip} type. */
-public class FilteringZipDependencySelector implements DependencySelector {
+/** Excludes artifacts with {@code zip} type. */
+public final class FilteringZipDependencySelector implements DependencySelector {
   // To exclude log4j-api-java9:zip:2.11.1, which is not published.
   // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/339
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/FilteringZipDependencySelector.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/FilteringZipDependencySelector.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.dependencies;
+
+import java.util.Map;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.collection.DependencyCollectionContext;
+import org.eclipse.aether.collection.DependencySelector;
+import org.eclipse.aether.graph.Dependency;
+
+/** Filters artifacts with {@code zip} type. */
+public class FilteringZipDependencySelector implements DependencySelector {
+  // To exclude log4j-api-java9:zip:2.11.1, which is not published.
+  // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/339
+
+  @Override
+  public boolean selectDependency(Dependency dependency) {
+    Artifact artifact = dependency.getArtifact();
+    Map<String, String> properties = artifact.getProperties();
+    // Because LinkageChecker only checks jar file, zip files are not needed
+    return !"zip".equals(properties.get("type"));
+  }
+
+  @Override
+  public DependencySelector deriveChildSelector(
+      DependencyCollectionContext dependencyCollectionContext) {
+    return this;
+  }
+}

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -30,7 +30,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Logger;
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
@@ -58,7 +57,6 @@ import org.eclipse.aether.artifact.ArtifactProperties;
 import org.eclipse.aether.artifact.ArtifactTypeRegistry;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
-import org.eclipse.aether.collection.DependencyCollectionContext;
 import org.eclipse.aether.collection.DependencySelector;
 import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
 import org.eclipse.aether.graph.Dependency;
@@ -137,26 +135,6 @@ public final class RepositoryUtility {
   static RepositorySystemSession newSessionWithProvidedScope(RepositorySystem system) {
     DefaultRepositorySystemSession session = createDefaultRepositorySystemSession(system);
 
-    // To exclude log4j-api-java9:zip:2.11.1, which is not published.
-    // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/339
-    DependencySelector filteringZipDependencySelector =
-        new DependencySelector() {
-
-          @Override
-          public boolean selectDependency(Dependency dependency) {
-            Artifact artifact = dependency.getArtifact();
-            Map<String, String> properties = artifact.getProperties();
-            // Because LinkageChecker only checks jar file, zip files are not needed
-            return !"zip".equals(properties.get("type"));
-          }
-
-          @Override
-          public DependencySelector deriveChildSelector(
-              DependencyCollectionContext dependencyCollectionContext) {
-            return this;
-          }
-        };
-
     // This combination of DependencySelector comes from the default specified in
     // `MavenRepositorySystemUtils.newSession`.
     // LinkageChecker needs to include 'provided' scope.
@@ -167,7 +145,7 @@ public final class RepositoryUtility {
             new ScopeDependencySelector("test"),
             new OptionalDependencySelector(),
             new ExclusionDependencySelector(),
-            filteringZipDependencySelector);
+            new FilteringZipDependencySelector());
     session.setDependencySelector(dependencySelector);
     session.setReadOnly();
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/FilteringZipDependencySelectorTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/FilteringZipDependencySelectorTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 
 public class FilteringZipDependencySelectorTest {
 
-  private FilteringZipDependencySelector selector = new FilteringZipDependencySelector();
+  private final FilteringZipDependencySelector selector = new FilteringZipDependencySelector();
 
   @Test
   public void testDeriveChildSelector() {
@@ -39,16 +39,14 @@ public class FilteringZipDependencySelectorTest {
 
   @Test
   public void testFilteringZip() {
-    Artifact artifact =
-        new DefaultArtifact(
-            "org.apache.logging.log4j:log4j-api-java9:zip:2.11.1", ImmutableMap.of("type", "zip"));
+    Artifact artifact = new DefaultArtifact("test:dummy:zip:1.0.0", ImmutableMap.of("type", "zip"));
     Dependency dependency = new Dependency(artifact, "compile");
     assertFalse(selector.selectDependency(dependency));
   }
 
   @Test
   public void testFilteringNonZip() {
-    Artifact artifact = new DefaultArtifact("com.google.guava", "guava", "jar", "28.0-android");
+    Artifact artifact = new DefaultArtifact("test", "dummy", "jar", "1.0.0");
     Dependency dependency = new Dependency(artifact, "compile");
     assertTrue(selector.selectDependency(dependency));
   }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/FilteringZipDependencySelectorTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/FilteringZipDependencySelectorTest.java
@@ -1,0 +1,39 @@
+package com.google.cloud.tools.opensource.dependencies;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.DependencySelector;
+import org.eclipse.aether.graph.Dependency;
+import org.junit.Test;
+
+public class FilteringZipDependencySelectorTest {
+
+  private FilteringZipDependencySelector selector = new FilteringZipDependencySelector();
+
+  @Test
+  public void testDeriveChildSelector() {
+    DependencySelector derivedSelector = selector.deriveChildSelector(null);
+    assertSame(selector, derivedSelector);
+  }
+
+  @Test
+  public void testFilteringZip() {
+    Artifact artifact =
+        new DefaultArtifact(
+            "org.apache.logging.log4j:log4j-api-java9:zip:2.11.1", ImmutableMap.of("type", "zip"));
+    Dependency dependency = new Dependency(artifact, "compile");
+    assertFalse(selector.selectDependency(dependency));
+  }
+
+  @Test
+  public void testFilteringNonZip() {
+    Artifact artifact = new DefaultArtifact("com.google.guava", "guava", "jar", "28.0-android");
+    Dependency dependency = new Dependency(artifact, "compile");
+    assertTrue(selector.selectDependency(dependency));
+  }
+}

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/FilteringZipDependencySelectorTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/FilteringZipDependencySelectorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.tools.opensource.dependencies;
 
 import static org.junit.Assert.assertFalse;

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -26,6 +26,7 @@ import com.google.cloud.tools.opensource.classpath.ClassReferenceGraph;
 import com.google.cloud.tools.opensource.classpath.LinkageChecker;
 import com.google.cloud.tools.opensource.classpath.SymbolProblem;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
+import com.google.cloud.tools.opensource.dependencies.FilteringZipDependencySelector;
 import com.google.cloud.tools.opensource.dependencies.NonTestDependencySelector;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
@@ -218,7 +219,9 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
           new DefaultRepositorySystemSession(session);
       fullDependencyResolutionSession.setDependencySelector(
           new AndDependencySelector(
-              new NonTestDependencySelector(), new ExclusionDependencySelector()));
+              new NonTestDependencySelector(),
+              new ExclusionDependencySelector(),
+              new FilteringZipDependencySelector()));
       DependencyResolutionRequest dependencyResolutionRequest =
           new DefaultDependencyResolutionRequest(mavenProject, fullDependencyResolutionSession);
 


### PR DESCRIPTION
Towards  #809 where `org.apache.logging.log4j:log4j-api-java9:zip:2.11.1` is not found:

```
[ERROR] Paths to the missing artifact:
 org.springframework.cloud:spring-cloud-gcp-core:jar:1.1.2.RELEASE
 > org.springframework:spring-core:jar:5.1.8.RELEASE (compile)
 > org.springframework:spring-jcl:jar:5.1.8.RELEASE (compile)
 > org.apache.logging.log4j:log4j-api:jar:2.11.2 (compile?)
 > org.apache.logging.log4j:log4j-api-java9:zip:2.11.2 (provided?)
```

For dashboard (which uses session given by RepositoryUtility), artifacts with zip type have been filtered already. This PR applies the filtering to the enforcer rule too.