### PR TITLE
With Java 9 it's not sufficient to advise the developer to pay attention to where the class is coming from.

### DIFF
--- a/library-best-practices/JLBP-5.md
+++ b/library-best-practices/JLBP-5.md
@@ -36,8 +36,20 @@ Example 2: There are multiple artifacts that provide classes under
     might be used anywhere that is not a servlet. Define these status codes
     yourself or choose a different library to provide them.
 
+In Java 9 and later overlapping classes become compile-time errors when
+named modules are used.
+
 Problems caused by overlapping classes can be extremely difficult to resolve.
-If at all possible, eliminate all but one of the
-overlapping dependencies. Otherwise pay very close attention to which version of
-each overlapping class is chosen. Make sure the project does not depend on any
-behavior or API of the class that is not selected.
+Nonetheless it is critical, especially in Java 9 and later, to eliminate all but one of the
+overlapping dependencies. 
+
+If possible, upgrade all dependencies on the overlapping classes
+to import them only by the same group ID and artifact ID. 
+
+If this isn't possible, for instance because the dependency that imports the renamed
+artifact is unmaintained, then add
+[dependency exclusions](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html) for all but one of the renamed artifacts
+in your own pom.xml.
+
+
+

--- a/library-best-practices/JLBP-5.md
+++ b/library-best-practices/JLBP-5.md
@@ -36,20 +36,14 @@ Example 2: There are multiple artifacts that provide classes under
     might be used anywhere that is not a servlet. Define these status codes
     yourself or choose a different library to provide them.
 
-In Java 9 and later overlapping classes become compile-time errors when
-named modules are used.
-
-Problems caused by overlapping classes can be extremely difficult to resolve.
-Nonetheless it is critical, especially in Java 9 and later, to eliminate all but one of the
-overlapping dependencies. 
+In Java 9 and later overlapping classes become compile-time and runtime errors when
+named modules are used. It is critical, especially in Java 9 and later,
+to remove all but one of the overlapping classes from the classpath.
 
 If possible, upgrade all dependencies on the overlapping classes
-to import them only by the same group ID and artifact ID. 
+to import them only by the same group ID and artifact ID.
 
-If this isn't possible, for instance because the dependency that imports the renamed
-artifact is unmaintained, then add
+If this isn't possible, for instance because a dependency that imports the
+renamed artifact is unmaintained, then add
 [dependency exclusions](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html) for all but one of the renamed artifacts
 in your own pom.xml.
-
-
-

--- a/library-best-practices/JLBP-5.md
+++ b/library-best-practices/JLBP-5.md
@@ -38,12 +38,12 @@ Example 2: There are multiple artifacts that provide classes under
 
 In Java 9 and later overlapping classes become compile-time and runtime errors when
 named modules are used. It is critical, especially in Java 9 and later,
-to remove all but one of the overlapping classes from the classpath.
+to remove all but one of the artifacts that contain overlapping classes from the classpath.
+Generally this requires changing the POMs of multiple Maven artifacts so they no 
+longer include any dependencies on the artifacts you need to remove from your
+project's classpath.
 
-If possible, upgrade all dependencies on the overlapping classes
-to import them only by the same group ID and artifact ID.
-
-If this isn't possible, for instance because a dependency that imports the
-renamed artifact is unmaintained, then add
-[dependency exclusions](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html) for all but one of the renamed artifacts
-in your own pom.xml.
+If this isn't possible, for instance because a dependency that imports an undesired
+artifact is unmaintained, then add
+[dependency exclusions](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html)
+for the artifacts you wish to remove in your own project's pom.xml.

--- a/library-best-practices/JLBP-6.md
+++ b/library-best-practices/JLBP-6.md
@@ -18,7 +18,7 @@ repository system, library B needs two identifiers to find classes in library A:
    which is formed from Maven artifacts and possibly non-Maven sources, is
    searched for each fully-qualified class name at runtime.
 
-When breaking changes are introduced to library between major version 1 and
+When breaking changes are introduced to a library between major version 1 and
 major version 2, a choice needs to be made: to rename or not rename? This
 question applies to both items listed above, the Maven ID (1) and the Java
 package (2).
@@ -26,6 +26,7 @@ package (2).
 Recommendations:
 
 - When making a breaking change, take one of the following approaches:
+
   1. If the new library surface is delivered under a new Java package, either
      use a different Maven ID (different group ID or artifact ID) or bundle the
      old and new packages together under the original Maven ID.

--- a/library-best-practices/JLBP-6.md
+++ b/library-best-practices/JLBP-6.md
@@ -18,7 +18,7 @@ repository system, library B needs two identifiers to find classes in library A:
    which is formed from Maven artifacts and possibly non-Maven sources, is
    searched for each fully-qualified class name at runtime.
 
-When breaking changes are introduced to library A between major version 1 and
+When breaking changes are introduced to library between major version 1 and
 major version 2, a choice needs to be made: to rename or not rename? This
 question applies to both items listed above, the Maven ID (1) and the Java
 package (2).

--- a/library-best-practices/JLBP-6.md
+++ b/library-best-practices/JLBP-6.md
@@ -77,10 +77,8 @@ Given this scenario, here are the possible combinations of renamings:
     accidentally through transitive dependencies because Maven artifact
     resolution treats the two artifacts as distinct.  This results in
     "overlapping classes" since they have classes with the same fully-qualified
-    path. As a result, the classes are loaded in unpredictable ways, leading to
-    runtime exceptions (for example `ClassNotFoundException`). It is difficult
-    for users to ensure that their build tree only includes one of the
-    artifacts. **NEVER DO THIS**.
+    path. This can lead to runtime exceptions such as`NoSuchMethodDefError`
+    and can be a compile-time error in Java 9 and later. **NEVER DO THIS**.
 - **Rename Java package**:
   - **Case 3: Don't rename Maven ID**. The classes from `g1:a1:1.0.0` and
     `g1:a1:2.0.0` could technically be used together, but since they share the
@@ -109,11 +107,11 @@ Given this scenario, here are the possible combinations of renamings:
 Given the consequences, maintainers should avoid case 2
 (renaming the Maven ID while keeping the Java package the same)
 and case 3 (renaming the Java package while keeping the Maven ID the same).
-Among the remaining three cases, the impact of the Maven ID change is minuscule compared
+Among the remaining three cases, the impact of a Maven ID change is minuscule compared
 to the impact of a Java package rename, so the remaining discussion focuses
 only on the Java package rename.
 
-Basically, the cost of diamond dependency conflicts (due to not renaming) has to
+The cost of diamond dependency conflicts due to not renaming has to
 be weighed against the cost of updating import statements everywhere the library
 is used. Let's take examples from two extremes.
 
@@ -132,7 +130,7 @@ is used. Let's take examples from two extremes.
    version 1 and major version 2.
 
    In this case, changing consuming code would be a large undertaking.
-   It's likely that not all maintainers will feel it's worth migrating to the new
+   Not all maintainers will feel it's worth migrating to the new
    major version. If the library author decides to keep the same Java
    package, the ecosystem has to bifurcate to handle code paths
    requiring one major version or the other.
@@ -140,7 +138,7 @@ is used. Let's take examples from two extremes.
    the dependency.
    Therefore, there will be diamond dependency conflicts.
    In this scenario, it is clearly superior to rename the Java
-   package, and essentially treat the new major version as a new library.
+   package, and treat the new major version as a new library.
 
 Note that both of these examples are for a library with a large number of places
 that reference it. The fewer places that a library is referenced, and the closer


### PR DESCRIPTION
@garrettjonesgoogle @netdpb 

While working on JLBP-19 I realized that overlapping classes imply overlapping packages, which is a compile time error in Java 9+. It's no longer sufficient to advise the developer to pay attention to where the class is coming from.