### PR TITLE
Linkage Checker enforcer rule to resolve os.detected.classifier

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -20,6 +20,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -57,22 +58,25 @@ public class DependencyGraphBuilder {
       CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('0', '9'));
 
   static {
-    setDetectedOsSystemProperties();
+    detectOsProperties().forEach(System::setProperty);
   }
 
   // caching cuts time by about a factor of 4.
   private static final Map<String, DependencyNode> cacheWithProvidedScope = new HashMap<>();
   private static final Map<String, DependencyNode> cacheWithoutProvidedScope = new HashMap<>();
 
-  private static void setDetectedOsSystemProperties() {
+  public static ImmutableMap<String, String> detectOsProperties() {
     // System properties to select Netty dependencies through os-maven-plugin
     // Definition of the properties: https://github.com/trustin/os-maven-plugin
-
     String osDetectedName = osDetectedName();
-    System.setProperty("os.detected.name", osDetectedName);
     String osDetectedArch = osDetectedArch();
-    System.setProperty("os.detected.arch", osDetectedArch);
-    System.setProperty("os.detected.classifier", osDetectedName + "-" + osDetectedArch);
+    return ImmutableMap.of(
+        "os.detected.name",
+        osDetectedName,
+        "os.detected.arch",
+        osDetectedArch,
+        "os.detected.classifier",
+        osDetectedName + "-" + osDetectedArch);
   }
 
   private static String osDetectedName() {

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -109,5 +109,10 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -26,6 +26,7 @@ import com.google.cloud.tools.opensource.classpath.ClassReferenceGraph;
 import com.google.cloud.tools.opensource.classpath.LinkageChecker;
 import com.google.cloud.tools.opensource.classpath.SymbolProblem;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
+import com.google.cloud.tools.opensource.dependencies.DependencyGraphBuilder;
 import com.google.cloud.tools.opensource.dependencies.FilteringZipDependencySelector;
 import com.google.cloud.tools.opensource.dependencies.NonTestDependencySelector;
 import com.google.common.annotations.VisibleForTesting;
@@ -217,6 +218,11 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
           helper.getComponent(ProjectDependenciesResolver.class);
       DefaultRepositorySystemSession fullDependencyResolutionSession =
           new DefaultRepositorySystemSession(session);
+
+      // For netty-handler referencing its dependencies with ${os.detected.classifier}
+      fullDependencyResolutionSession.setSystemProperties(
+          DependencyGraphBuilder.detectOsProperties());
+
       fullDependencyResolutionSession.setDependencySelector(
           new AndDependencySelector(
               new NonTestDependencySelector(),

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -191,7 +191,7 @@ public class LinkageCheckerRuleTest {
         ArgumentCaptor.forClass(DependencyResolutionRequest.class);
     verify(mockProjectDependenciesResolver).resolve(argumentCaptor.capture());
     Truth.assertWithMessage(
-            "RepositorySystemSession should have variables defined in os-maven-plugin")
+            "RepositorySystemSession should have variables such as os.detected.classifier")
         .that(argumentCaptor.getValue().getRepositorySession().getSystemProperties())
         .containsAtLeastEntriesIn(DependencyGraphBuilder.detectOsProperties());
   }

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -190,7 +190,9 @@ public class LinkageCheckerRuleTest {
     ArgumentCaptor<DependencyResolutionRequest> argumentCaptor =
         ArgumentCaptor.forClass(DependencyResolutionRequest.class);
     verify(mockProjectDependenciesResolver).resolve(argumentCaptor.capture());
-    Truth.assertThat(argumentCaptor.getValue().getRepositorySession().getSystemProperties())
+    Truth.assertWithMessage(
+            "RepositorySystemSession should have variables defined in os-maven-plugin")
+        .that(argumentCaptor.getValue().getRepositorySession().getSystemProperties())
         .containsAtLeastEntriesIn(DependencyGraphBuilder.detectOsProperties());
   }
 
@@ -435,5 +437,4 @@ public class LinkageCheckerRuleTest {
                   + "aopalliance:aopalliance:jar:1.0 (compile)");
     }
   }
-
 }


### PR DESCRIPTION
Fixes #809 . 

This PR uses RepositorySystemSession that contains the properties when resolving project's dependency tree.