### PR TITLE
ClassDumper. findClassLocation to check special class file name too

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -74,8 +74,8 @@ class ClassDumper {
   private final ImmutableList<Path> inputClassPath;
   private final Repository classRepository;
   private final ClassLoader extensionClassLoader;
-  private final ImmutableSetMultimap<Path, String> jarFileToClasses;
-  private final ImmutableListMultimap<String, Path> classToJarFiles;
+  private final ImmutableSetMultimap<Path, String> jarFileToClassFileNames;
+  private final ImmutableListMultimap<String, Path> classFileNameToJarFiles;
 
   private static Repository createClassRepository(List<Path> paths) {
     ClassPath classPath = new LinkageCheckClassPath(paths);
@@ -93,7 +93,7 @@ class ClassDumper {
     checkArgument(
         unreadableFiles.isEmpty(), "Some jar files are not readable: %s", unreadableFiles);
 
-    return new ClassDumper(jarPaths, extensionClassLoader, mapJarToClasses(jarPaths));
+    return new ClassDumper(jarPaths, extensionClassLoader, mapJarToClassFileNames(jarPaths));
   }
 
   private ClassDumper(
@@ -103,8 +103,8 @@ class ClassDumper {
     this.inputClassPath = ImmutableList.copyOf(inputClassPath);
     this.classRepository = createClassRepository(inputClassPath);
     this.extensionClassLoader = extensionClassLoader;
-    this.jarFileToClasses = ImmutableSetMultimap.copyOf(jarToClasses);
-    this.classToJarFiles = ImmutableListMultimap.copyOf(jarToClasses.inverse());
+    this.jarFileToClassFileNames = ImmutableSetMultimap.copyOf(jarToClasses);
+    this.classFileNameToJarFiles = ImmutableListMultimap.copyOf(jarToClasses.inverse());
   }
 
   /**
@@ -136,12 +136,12 @@ class ClassDumper {
   }
 
   /**
-   * Returns class names defined in the jar file.
+   * Returns class file names defined in the jar file.
    *
    * @param jarPath absolute path to the jar file
    */
   ImmutableSet<String> classesDefinedInJar(Path jarPath) {
-    return jarFileToClasses.get(jarPath);
+    return jarFileToClassFileNames.get(jarPath);
   }
 
   /**
@@ -326,16 +326,16 @@ class ClassDumper {
   }
 
   /**
-   * Returns mapping from jar files to the names of the classes they define.
+   * Returns mapping from jar files to class file names they contain.
    *
    * @param jars absolute paths to jar files
    */
   @VisibleForTesting
-  static ImmutableSetMultimap<Path, String> mapJarToClasses(List<Path> jars) throws IOException {
+  static ImmutableSetMultimap<Path, String> mapJarToClassFileNames(List<Path> jars) throws IOException {
     ImmutableSetMultimap.Builder<Path, String> pathToClasses = ImmutableSetMultimap.builder();
     for (Path jar : jars) {
-      for (String className : listClassFileNames(jar)) {
-        pathToClasses.put(jar, className);
+      for (String classFileName : listClassFileNames(jar)) {
+        pathToClasses.put(jar, classFileName);
       }
     }
     return pathToClasses.build();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -63,7 +63,6 @@ import org.apache.bcel.generic.MethodGen;
 import org.apache.bcel.generic.ObjectType;
 import org.apache.bcel.generic.Type;
 import org.apache.bcel.util.ClassPath;
-import org.apache.bcel.util.Repository;
 
 /**
  * Class to read symbol references in Java class files and to verify the availability of references
@@ -72,12 +71,12 @@ import org.apache.bcel.util.Repository;
 class ClassDumper {
 
   private final ImmutableList<Path> inputClassPath;
-  private final Repository classRepository;
+  private final FixedSizeClassPathRepository classRepository;
   private final ClassLoader extensionClassLoader;
   private final ImmutableSetMultimap<Path, String> jarFileToClassFileNames;
   private final ImmutableListMultimap<String, Path> classFileNameToJarFiles;
 
-  private static Repository createClassRepository(List<Path> paths) {
+  private static FixedSizeClassPathRepository createClassRepository(List<Path> paths) {
     ClassPath classPath = new LinkageCheckClassPath(paths);
     return new FixedSizeClassPathRepository(classPath);
   }
@@ -322,7 +321,7 @@ class ClassDumper {
     // However, it required the superclass of a target class to be loadable too; otherwise
     // ClassNotFoundException was raised. It was inconvenient because we only wanted to know the
     // location of the target class, and sometimes the superclass is unavailable.
-    return Iterables.getFirst(classToJarFiles.get(className), null);
+    return Iterables.getFirst(classFileNameToJarFiles.get(className), null);
   }
 
   /**
@@ -331,7 +330,8 @@ class ClassDumper {
    * @param jars absolute paths to jar files
    */
   @VisibleForTesting
-  static ImmutableSetMultimap<Path, String> mapJarToClassFileNames(List<Path> jars) throws IOException {
+  static ImmutableSetMultimap<Path, String> mapJarToClassFileNames(List<Path> jars)
+      throws IOException {
     ImmutableSetMultimap.Builder<Path, String> pathToClasses = ImmutableSetMultimap.builder();
     for (Path jar : jars) {
       for (String classFileName : listClassFileNames(jar)) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -321,7 +321,18 @@ class ClassDumper {
     // However, it required the superclass of a target class to be loadable too; otherwise
     // ClassNotFoundException was raised. It was inconvenient because we only wanted to know the
     // location of the target class, and sometimes the superclass is unavailable.
-    return Iterables.getFirst(classFileNameToJarFiles.get(className), null);
+    Path path = Iterables.getFirst(classFileNameToJarFiles.get(className), null);
+    if (path != null) {
+      return path;
+    }
+
+    // Some classes have framework-specific prefix such as "WEB-INF.classes.AppWidgetset" in its
+    // class file name.
+    String specialLocation = classRepository.getSpecialLocation(className);
+    if (specialLocation == null) {
+      return null;
+    }
+    return Iterables.getFirst(classFileNameToJarFiles.get(specialLocation), null);
   }
 
   /**

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FixedSizeClassPathRepository.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FixedSizeClassPathRepository.java
@@ -112,4 +112,13 @@ final class FixedSizeClassPathRepository extends ClassPathRepository {
   public void clear() {
     loadedClass.invalidateAll();
   }
+
+  /**
+   * Returns the special location for {@code className}. Null if no special location is known.
+   *
+   * @see #classFileNames
+   */
+  String getSpecialLocation(String className) {
+    return classFileNames.get(className);
+  }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -224,6 +224,7 @@ public class ClassDumperTest {
 
   @Test
   public void testFindClassLocation_prefixedClassName() throws URISyntaxException, IOException {
+    // This JAR file contains com.google.firestore.v1beta1.FirestoreGrpc under BOOT-INF/classes.
     Path path = absolutePathOfResource("testdata/dummy-boot-inf-prefix.jar");
     ClassDumper classDumper = ClassDumper.create(ImmutableList.of(path));
     classDumper.findSymbolReferences();
@@ -346,5 +347,4 @@ public class ClassDumperTest {
             new ClassFile(
                 sisuGuicePath, "com.google.inject.internal.InjectorImpl$BindingsMultimap"));
   }
-
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -199,7 +199,7 @@ public class ClassDumperTest {
     Path gsonJar = paths.get(0);
 
     ImmutableSetMultimap<Path, String> pathToClasses = ClassDumper
-        .mapJarToClasses(paths.subList(0, 1));
+        .mapJarToClassFileNames(paths.subList(0, 1));
     ImmutableSet<String> classesInGsonJar = pathToClasses.get(gsonJar);
     // Dollar character ($) is a valid character for a class name, not just for nested ones.
     Truth.assertThat(classesInGsonJar).contains("com.google.gson.internal.$Gson$Preconditions");

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -223,6 +223,18 @@ public class ClassDumperTest {
   }
 
   @Test
+  public void testFindClassLocation_prefixedClassName() throws URISyntaxException, IOException {
+    Path path = absolutePathOfResource("testdata/dummy-boot-inf-prefix.jar");
+    ClassDumper classDumper = ClassDumper.create(ImmutableList.of(path));
+    classDumper.findSymbolReferences();
+
+    Path classLocation =
+        classDumper.findClassLocation("com.google.firestore.v1beta1.FirestoreGrpc");
+
+    Assert.assertEquals(path, classLocation);
+  }
+
+  @Test
   public void testIsSystemClass() throws URISyntaxException, IOException {
     ClassDumper classDumper =
         ClassDumper.create(ImmutableList.of(absolutePathOfResource("testdata/guava-23.5-jre.jar")));
@@ -334,4 +346,5 @@ public class ClassDumperTest {
             new ClassFile(
                 sisuGuicePath, "com.google.inject.internal.InjectorImpl$BindingsMultimap"));
   }
+
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -198,8 +198,8 @@ public class ClassDumperTest {
     List<Path> paths = ClassPathBuilder.artifactsToClasspath(ImmutableList.of(grpcArtifact));
     Path gsonJar = paths.get(0);
 
-    ImmutableSetMultimap<Path, String> pathToClasses = ClassDumper
-        .mapJarToClassFileNames(paths.subList(0, 1));
+    ImmutableSetMultimap<Path, String> pathToClasses =
+        ClassDumper.mapJarToClassFileNames(paths.subList(0, 1));
     ImmutableSet<String> classesInGsonJar = pathToClasses.get(gsonJar);
     // Dollar character ($) is a valid character for a class name, not just for nested ones.
     Truth.assertThat(classesInGsonJar).contains("com.google.gson.internal.$Gson$Preconditions");


### PR DESCRIPTION
Fixes #837 .

ClassDumper.findClassLocation was not able to find JAR file if the class name and class file name are different. For example in #837, AppWidgetset  has class name "AppWidgetset" but class file name "WEB-INF.classes.AppWidgetset" with WAR-specific prefix.

This PR fixes such case, leveraging `FixedSizeClassPathRepository.classFileNames`.