### PR TITLE
Enforcer Rule to call DependencyGraphBuilder.requiredDependency to decide whether to abort

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -308,7 +308,7 @@ public class DependencyGraphBuilder {
               DependencyNode failedDependencyNode = artifactResult.getRequest().getDependencyNode();
               ExceptionAndPath failure =
                   ExceptionAndPath.create(parentNodes, failedDependencyNode, resolutionException);
-              if (isUnacceptableResolutionExceptionAt(failure.getPath())) {
+              if (isUnacceptableMissingDependency(failure.getPath())) {
                 resolutionFailures.add(failure);
               }
             }
@@ -316,7 +316,7 @@ public class DependencyGraphBuilder {
             DependencyNode failedDependencyNode = collectionException.getResult().getRoot();
             ExceptionAndPath failure =
                 ExceptionAndPath.create(parentNodes, failedDependencyNode, collectionException);
-            if (isUnacceptableResolutionExceptionAt(failure.getPath())) {
+            if (isUnacceptableMissingDependency(failure.getPath())) {
               resolutionFailures.add(failure);
             }
           }
@@ -340,7 +340,7 @@ public class DependencyGraphBuilder {
    * Returns true if {@code dependencyPath} does not contain {@code optional} dependency and the
    * path does not contain {@code scope:provided} dependency.
    */
-  public static boolean isUnacceptableResolutionExceptionAt(List<DependencyNode> dependencyPath) {
+  public static boolean isUnacceptableMissingDependency(List<DependencyNode> dependencyPath) {
     boolean hasOptionalParent =
         dependencyPath.stream()
             .filter(node -> node.getDependency() != null) // Root node does not have dependency

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -308,7 +308,7 @@ public class DependencyGraphBuilder {
               DependencyNode failedDependencyNode = artifactResult.getRequest().getDependencyNode();
               ExceptionAndPath failure =
                   ExceptionAndPath.create(parentNodes, failedDependencyNode, resolutionException);
-              if (isUnacceptableResolutionException(failure)) {
+              if (isUnacceptableResolutionExceptionAt(failure.getPath())) {
                 resolutionFailures.add(failure);
               }
             }
@@ -316,7 +316,7 @@ public class DependencyGraphBuilder {
             DependencyNode failedDependencyNode = collectionException.getResult().getRoot();
             ExceptionAndPath failure =
                 ExceptionAndPath.create(parentNodes, failedDependencyNode, collectionException);
-            if (isUnacceptableResolutionException(failure)) {
+            if (isUnacceptableResolutionExceptionAt(failure.getPath())) {
               resolutionFailures.add(failure);
             }
           }
@@ -337,19 +337,20 @@ public class DependencyGraphBuilder {
   }
 
   /**
-   * Returns true if {@code exceptionAndPath.getPath} does not contain {@code optional} dependency
-   * and the path does not contain {@code scope:provided} dependency.
+   * Returns true if {@code dependencyPath} does not contain {@code optional} dependency and the
+   * path does not contain {@code scope:provided} dependency.
    */
-  private static boolean isUnacceptableResolutionException(ExceptionAndPath exceptionAndPath) {
-    ImmutableList<DependencyNode> dependencyNodes = exceptionAndPath.getPath();
+  public static boolean isUnacceptableResolutionExceptionAt(List<DependencyNode> dependencyPath) {
     boolean hasOptionalParent =
-        dependencyNodes.stream().anyMatch(node -> node.getDependency().isOptional());
+        dependencyPath.stream()
+            .filter(node -> node.getDependency() != null) // Root node does not have dependency
+            .anyMatch(node -> node.getDependency().isOptional());
     if (!hasOptionalParent) {
       return true;
     }
     boolean hasProvidedParent =
-        dependencyNodes
-            .stream()
+        dependencyPath.stream()
+            .filter(node -> node.getDependency() != null)
             .anyMatch(node -> "provided".equals(node.getDependency().getScope()));
     return !hasProvidedParent;
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -308,7 +308,7 @@ public class DependencyGraphBuilder {
               DependencyNode failedDependencyNode = artifactResult.getRequest().getDependencyNode();
               ExceptionAndPath failure =
                   ExceptionAndPath.create(parentNodes, failedDependencyNode, resolutionException);
-              if (unacceptableMissingDependency(failure.getPath())) {
+              if (requiredDependency(failure.getPath())) {
                 resolutionFailures.add(failure);
               }
             }
@@ -316,7 +316,7 @@ public class DependencyGraphBuilder {
             DependencyNode failedDependencyNode = collectionException.getResult().getRoot();
             ExceptionAndPath failure =
                 ExceptionAndPath.create(parentNodes, failedDependencyNode, collectionException);
-            if (unacceptableMissingDependency(failure.getPath())) {
+            if (requiredDependency(failure.getPath())) {
               resolutionFailures.add(failure);
             }
           }
@@ -340,18 +340,18 @@ public class DependencyGraphBuilder {
    * Returns true if {@code dependencyPath} does not contain {@code optional} dependency and the
    * path does not contain {@code scope:provided} dependency.
    */
-  public static boolean unacceptableMissingDependency(List<DependencyNode> dependencyPath) {
-    boolean hasOptionalParent =
+  public static boolean requiredDependency(List<DependencyNode> dependencyPath) {
+    boolean hasOptional =
         dependencyPath.stream()
             .filter(node -> node.getDependency() != null) // Root node does not have dependency
             .anyMatch(node -> node.getDependency().isOptional());
-    if (!hasOptionalParent) {
+    if (!hasOptional) {
       return true;
     }
-    boolean hasProvidedParent =
+    boolean hasProvided =
         dependencyPath.stream()
             .filter(node -> node.getDependency() != null)
             .anyMatch(node -> "provided".equals(node.getDependency().getScope()));
-    return !hasProvidedParent;
+    return !hasProvided;
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -308,7 +308,7 @@ public class DependencyGraphBuilder {
               DependencyNode failedDependencyNode = artifactResult.getRequest().getDependencyNode();
               ExceptionAndPath failure =
                   ExceptionAndPath.create(parentNodes, failedDependencyNode, resolutionException);
-              if (isUnacceptableMissingDependency(failure.getPath())) {
+              if (unacceptableMissingDependency(failure.getPath())) {
                 resolutionFailures.add(failure);
               }
             }
@@ -316,7 +316,7 @@ public class DependencyGraphBuilder {
             DependencyNode failedDependencyNode = collectionException.getResult().getRoot();
             ExceptionAndPath failure =
                 ExceptionAndPath.create(parentNodes, failedDependencyNode, collectionException);
-            if (isUnacceptableMissingDependency(failure.getPath())) {
+            if (unacceptableMissingDependency(failure.getPath())) {
               resolutionFailures.add(failure);
             }
           }
@@ -340,7 +340,7 @@ public class DependencyGraphBuilder {
    * Returns true if {@code dependencyPath} does not contain {@code optional} dependency and the
    * path does not contain {@code scope:provided} dependency.
    */
-  public static boolean isUnacceptableMissingDependency(List<DependencyNode> dependencyPath) {
+  public static boolean unacceptableMissingDependency(List<DependencyNode> dependencyPath) {
     boolean hasOptionalParent =
         dependencyPath.stream()
             .filter(node -> node.getDependency() != null) // Root node does not have dependency

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -290,12 +290,12 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
       throws EnforcerRuleException {
     ImmutableList.Builder<Path> builder = ImmutableList.builder();
 
-    // The first item is the project's JAR file
+    // The root node must have the project's JAR file
     File rootFile = result.getDependencyGraph().getArtifact().getFile();
     if (rootFile == null) {
       throw new EnforcerRuleException(
           "The root project artifact is not associated with a file."
-              + " The linkage checker enforcer rule should be bound to the verify phase.");
+              + " The linkage checker enforcer rule should be bound to the 'verify' phase.");
     }
     builder.add(rootFile.toPath());
     // The rest are the dependencies

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -252,7 +252,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
    * Returns class path built from partial dependency graph of {@code resolutionException}.
    *
    * @throws EnforcerRuleException when {@code resolutionException} is invalidated by {@link
-   *     DependencyGraphBuilder#unacceptableMissingDependency(List)}
+   *     DependencyGraphBuilder#requiredDependency(List)}
    */
   private ImmutableList<Path> buildClasspathFromException(
       DependencyResolutionException resolutionException) throws EnforcerRuleException {
@@ -268,7 +268,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
         String pathsToArtifact = findPaths(root, artifact);
         ImmutableList<DependencyNode> firstArtifactPath =
             Iterables.getFirst(findArtifactPaths(root, artifact), null);
-        if (DependencyGraphBuilder.unacceptableMissingDependency(firstArtifactPath)) {
+        if (DependencyGraphBuilder.requiredDependency(firstArtifactPath)) {
           logger.error("Could not find artifact " + artifact);
           logger.error("Paths to the missing artifact: " + pathsToArtifact);
           throw new EnforcerRuleException(

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -252,7 +252,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
    * Returns class path built from partial dependency graph of {@code resolutionException}.
    *
    * @throws EnforcerRuleException when {@code resolutionException} is invalidated by {@link
-   *     DependencyGraphBuilder#isUnacceptableMissingDependency(List)}
+   *     DependencyGraphBuilder#unacceptableMissingDependency(List)}
    */
   private ImmutableList<Path> buildClasspathFromException(
       DependencyResolutionException resolutionException) throws EnforcerRuleException {
@@ -268,7 +268,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
         String pathsToArtifact = findPaths(root, artifact);
         ImmutableList<DependencyNode> firstArtifactPath =
             Iterables.getFirst(findArtifactPaths(root, artifact), null);
-        if (DependencyGraphBuilder.isUnacceptableMissingDependency(firstArtifactPath)) {
+        if (DependencyGraphBuilder.unacceptableMissingDependency(firstArtifactPath)) {
           logger.error("Could not find artifact " + artifact);
           logger.error("Paths to the missing artifact: " + pathsToArtifact);
           throw new EnforcerRuleException(

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -266,7 +266,8 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
         ArtifactTransferException artifactException = (ArtifactTransferException) cause;
         Artifact artifact = artifactException.getArtifact();
         String pathsToArtifact = findPaths(root, artifact);
-        ImmutableList<DependencyNode> firstArtifactPath = findFirstArtifactPath(root, artifact);
+        ImmutableList<DependencyNode> firstArtifactPath =
+            Iterables.getFirst(findArtifactPaths(root, artifact), null);
         if (DependencyGraphBuilder.isUnacceptableResolutionExceptionAt(firstArtifactPath)) {
           logger.error("Could not find artifact " + artifact);
           logger.error("Paths to the missing artifact: " + pathsToArtifact);
@@ -335,11 +336,6 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
             .collect(toImmutableList());
     // Joining one or more paths from root to the artifact
     return Joiner.on("\n").join(paths);
-  }
-
-  private static ImmutableList<DependencyNode> findFirstArtifactPath(
-      DependencyNode node, Artifact artifact) {
-    return Iterables.getFirst(findArtifactPaths(node, artifact), null);
   }
 
   private static ImmutableList<ImmutableList<DependencyNode>> findArtifactPaths(

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -267,7 +267,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
         Artifact artifact = artifactException.getArtifact();
         String pathsToArtifact = findPaths(root, artifact);
         ImmutableList<DependencyNode> firstArtifactPath =
-            Iterables.getFirst(findArtifactPaths(root, artifact), null);
+            Iterables.getFirst(findArtifactPaths(root, artifact), ImmutableList.of());
         if (DependencyGraphBuilder.requiredDependency(firstArtifactPath)) {
           logger.error("Could not find artifact " + artifact);
           logger.error("Paths to the missing artifact: " + pathsToArtifact);

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -300,6 +300,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
     builder.add(rootFile.toPath());
     // The rest are the dependencies
     for (Dependency dependency : result.getResolvedDependencies()) {
+      // Resolved dependencies are guaranteed to have file.
       builder.add(dependency.getArtifact().getFile().toPath());
     }
     return builder.build();

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -257,6 +257,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
   private ImmutableList<Path> buildClasspathFromException(
       DependencyResolutionException resolutionException) throws EnforcerRuleException {
     DependencyResolutionResult result = resolutionException.getResult();
+
     DependencyNode root = result.getDependencyGraph();
 
     for (Throwable cause = resolutionException.getCause();
@@ -283,8 +284,13 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
         break;
       }
     }
-    // The exception is acceptable enough to build a class path.
-    return buildClasspath(result);
+    if (result.getResolvedDependencies().isEmpty()) {
+      // Nothing is resolved. Probably failed at collection phase before resolve phase.
+      throw new EnforcerRuleException("Unable to collect dependencies", resolutionException);
+    } else {
+      // The exception is acceptable enough to build a class path.
+      return buildClasspath(result);
+    }
   }
 
   private ImmutableList<Path> buildClasspath(DependencyResolutionResult result)

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -252,7 +252,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
    * Returns class path built from partial dependency graph of {@code resolutionException}.
    *
    * @throws EnforcerRuleException when {@code resolutionException} is invalidated by {@link
-   *     DependencyGraphBuilder#isUnacceptableResolutionExceptionAt(List)}
+   *     DependencyGraphBuilder#isUnacceptableMissingDependency(List)}
    */
   private ImmutableList<Path> buildClasspathFromException(
       DependencyResolutionException resolutionException) throws EnforcerRuleException {
@@ -268,7 +268,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
         String pathsToArtifact = findPaths(root, artifact);
         ImmutableList<DependencyNode> firstArtifactPath =
             Iterables.getFirst(findArtifactPaths(root, artifact), null);
-        if (DependencyGraphBuilder.isUnacceptableResolutionExceptionAt(firstArtifactPath)) {
+        if (DependencyGraphBuilder.isUnacceptableMissingDependency(firstArtifactPath)) {
           logger.error("Could not find artifact " + artifact);
           logger.error("Paths to the missing artifact: " + pathsToArtifact);
           throw new EnforcerRuleException(

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -160,7 +160,6 @@ public class LinkageCheckerRuleTest {
     Traverser<DependencyNode> traverser = Traverser.forGraph(node -> node.getChildren());
 
     // DependencyResolutionResult.getDependencies returns depth-first order
-
     ImmutableList<Dependency> dummyDependencies =
         ImmutableList.copyOf(traverser.depthFirstPreOrder(rootNode)).stream()
             .map(DependencyNode::getDependency)
@@ -503,8 +502,8 @@ public class LinkageCheckerRuleTest {
 
     when(mockProjectDependenciesResolver.resolve(any())).thenThrow(exception);
 
-    // Should run Linkage Check without xerces-impl, without DependencyResolutionException, because
-    // the missing xerces-impl is under both provided and optional dependencies.
+    // Should not throw DependencyResolutionException, because the missing xerces-impl is under both
+    // provided and optional dependencies.
     rule.execute(mockRuleHelper);
   }
 }


### PR DESCRIPTION
Towards #833 .

@elharo 
As discussed, this PR makes class path generation more robust against missing artifacts whose paths contain provided and optional dependencies.