### PR TITLE
Prepare release for 0.3.0

### DIFF
--- a/boms/integration-tests/pom.xml
+++ b/boms/integration-tests/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>dependencies</artifactId>
-      <version>0.2.5-SNAPSHOT</version>
+      <version>0.3.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/boms/integration-tests/pom.xml
+++ b/boms/integration-tests/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>dependencies</artifactId>
-      <version>0.3.0</version>
+      <version>0.3.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>0.2.5-SNAPSHOT</version>
+    <version>0.3.0</version>
   </parent>
   <artifactId>dashboard</artifactId>
 

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
   <artifactId>dashboard</artifactId>
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>0.2.5-SNAPSHOT</version>
+    <version>0.3.0</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>linkage-checker-enforcer-rules</artifactId>

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>0.2.5-SNAPSHOT</version>
+    <version>0.3.0</version>
   </parent>
 
   <artifactId>linkage-checker-enforcer-rules</artifactId>

--- a/linkage-monitor/pom.xml
+++ b/linkage-monitor/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>linkage-monitor</artifactId>

--- a/linkage-monitor/pom.xml
+++ b/linkage-monitor/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>0.2.5-SNAPSHOT</version>
+    <version>0.3.0</version>
   </parent>
 
   <artifactId>linkage-monitor</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>dependencies-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.2.5-SNAPSHOT</version>
+  <version>0.3.0</version>
 
   <name>Cloud Tools Open Source Code Hygiene Tooling</name>
   <url>https://github.com/GoogleCloudPlatform/cloud-opensource-java/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>dependencies-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.3.0</version>
+  <version>0.3.1-SNAPSHOT</version>
 
   <name>Cloud Tools Open Source Code Hygiene Tooling</name>
   <url>https://github.com/GoogleCloudPlatform/cloud-opensource-java/</url>


### PR DESCRIPTION
The enforcer rule has become robust against dependency graph build failure.