### PR TITLE
use at least one paragraph on each JLBP, not just lists

### DIFF
--- a/docs/JLBP-1.md
+++ b/docs/JLBP-1.md
@@ -25,13 +25,15 @@ Some specific notes about minimizing dependencies:
   dependencies are pulled in, consider a different direct dependency.
   Alternatively, if the functionality you need is small, reimplement
   it in your own library.
+
   - Maven: Run `mvn dependency:tree` (after running
     `mvn install -DskipTests` to build the library).
+    
   - Gradle: Run `./gradlew dependencies`
 
 - Prefer JDK classes where available. For example, XOM and JDOM
-  are very convenient and far easier to use than DOM. However, most 
-  uses of these libraries can be satisfied with the `org.w3c.dom` 
+  are very convenient and far easier to use than DOM. However, most
+  uses of these libraries can be satisfied with the `org.w3c.dom`
   or other packages bundled with the JDK at some cost in development
   time.
 
@@ -42,7 +44,7 @@ Some specific notes about minimizing dependencies:
   Do not allow different team members to choose different libraries.
 
 - If you can reasonably reimplement functionality instead of adding
-  another dependency, do so. For example, if the only classes you're 
-  using from Guava are `Preconditions` and `Strings`, it's not 
-  worth adding a dependency on Guava. You can easily reimplement 
+  another dependency, do so. For example, if the only classes you're
+  using from Guava are `Preconditions` and `Strings`, it's not
+  worth adding a dependency on Guava. You can easily reimplement
   any method in those classes.  

--- a/docs/JLBP-10.md
+++ b/docs/JLBP-10.md
@@ -22,8 +22,11 @@ One thing to keep in mind is that many consumers are highly resistant to
 accepting breaking changes for various reasons:
 
 - They might have low test coverage, making it costly to verify correctness.
+
 - They might not have enough developers and time to do dependency upgrade work.
+
 - They might have a high risk aversion.
+
 - They might have put your major version on their own surface and they don't
   want to force a breaking change on their own users for a long period.
 

--- a/docs/JLBP-11.md
+++ b/docs/JLBP-11.md
@@ -1,11 +1,14 @@
 # [JLBP-11] Stay up to date with compatible dependencies
 
-- Recommendation: Release no later than 6 weeks after any of your dependencies
-  releases a version that is higher than the one your library depends on.
-  - Time is an important factor (not just how many versions behind) because
-    having the ecosystem generally up to date at each point in time results in
-    ecosystem "snapshots" that are more consistent, and more likely to have
-    compatibility across the board.
-- If your library does not have the investment necessary to keep up to date with
-  dependencies, advise consumers to move to a library that is kept more up to
-  date.
+Recommendation: Release a new version of your library 
+no later than 6 weeks after any of your dependencies
+releases a version that is higher than the one your library depends on.
+
+Time is an important factor (not just how many versions behind) because
+having the ecosystem generally up to date at each point in time results in
+ecosystem "snapshots" that are more consistent, and more likely to have
+compatibility across the board.
+
+If your library does not have the investment necessary to keep 
+dependencies up to date, advise consumers to move to a library that is 
+kept more up to date.

--- a/docs/JLBP-12.md
+++ b/docs/JLBP-12.md
@@ -1,19 +1,25 @@
 # [JLBP-12] Make level of support and API stability clear
 
-- Clearly document the lifecycle status (and corresponding level of support)
+Clearly document the lifecycle status (and corresponding level of support)
   of the library. Examples include:
+
   - Incubating (no support expected)
   - Stable (SLOs in place to handle issues)
   - Maintenance (only bugs will be addressed)
   - Deprecated / Abandoned / Inactive (no work is expected)
-- Clearly state the API and behavioral stability clients can expect from the
+
+Clearly state the API and behavioral stability clients can expect from the
+
   library surface. Example statements:
   - This API is stable and suitable for production use, aside from packages,
     classes, and methods marked internal or unstable.
+
   - This API is beta and will not experience an API or behavior breaking change
     unless a bug or design flaw is uncovered.
+
   - This API is in development. Anything may change at any time. Stable products
     should not depend on it.
-- Document a feedback mechanism. For example:
+
+Document a feedback mechanism. For example:
   - File an issue at https://github.com/...
   - Send email to dev@fooproject.example.com

--- a/docs/JLBP-13.md
+++ b/docs/JLBP-13.md
@@ -1,11 +1,14 @@
 # [JLBP-13] Quickly remove references to deprecated features in dependencies
 
-- This best practice refers to code that *uses* deprecated functionality from
-  another library or the JDK, not to the deprecated functionality itself.
-  - It does not apply to usage of deprecated features within a library.
-- The earlier you remove usages of external deprecated functionality, the
-  more versions of your product will work with your dependency once the
-  deprecated features are fully deleted or hidden in the dependency.
+This best practice refers to code that *uses* deprecated functionality from
+another library or the JDK, not to the deprecated functionality itself.
+
+It does not apply to usage of deprecated features within a library.
+
+The earlier you remove usages of external deprecated functionality, the
+more versions of your product will work with your dependency once the
+deprecated features are fully deleted or hidden in the dependency.
+
   - For example, api-common-java 1.6.0 refers to `Futures.transform(ListenableFuture, Function)`
     in Guava, which was deprecated in 19.0 and removed in 26.0. In
     api-common-java 1.7, the code was changed to instead call

--- a/docs/JLBP-14.md
+++ b/docs/JLBP-14.md
@@ -17,13 +17,13 @@ releases new versions), which can break your library unexpectedly.
     is pushed to Maven Central, it will be picked up by downstream dependencies
     automatically. This can be used a by a malicious actor with release privileges
     to slip new malicious code into projects without proper review. [A version
-    of this attack has been used in the node.js ecosystem to steal 
-    Bitcoins](https://www.theregister.co.uk/2018/11/26/npm_repo_bitcoin_stealer/). 
+    of this attack has been used in the node.js ecosystem to steal
+    Bitcoins](https://www.theregister.co.uk/2018/11/26/npm_repo_bitcoin_stealer/).
 
   Thus, always specify a single version instead of a version range for dependencies.
 
 Single-element version ranges ("hard requirements") have a much different
 impact, and this rule does not apply to them.
 
-[The Maven POM Reference]()]https://maven.apache.org/pom.html#Dependency_Version_Requirement_Specification)
+[The Maven POM Reference](https://maven.apache.org/pom.html#Dependency_Version_Requirement_Specification)
 contains more information.

--- a/docs/JLBP-14.md
+++ b/docs/JLBP-14.md
@@ -1,9 +1,9 @@
 # [JLBP-14] Do not use version ranges
 
-- If the pom.xml of your library specifies a version range instead of a
-  single version for any particular dependency, builds at different points
-  in time can see different versions of that dependency (as your dependency
-  releases new versions), which can break your library unexpectedly.
+If the pom.xml of your library specifies a version range instead of a
+single version for any particular dependency, builds at different points
+in time can see different versions of that dependency (as your dependency
+releases new versions), which can break your library unexpectedly.
 
   - Version ranges cause builds to be non-reproducible. Builds of the
     same code with the same compiler on different machines at different
@@ -22,8 +22,8 @@
 
   Thus, always specify a single version instead of a version range for dependencies.
 
-- Single-element version ranges ("hard requirements") have a much different
-  impact, and this rule does not apply to them.
+Single-element version ranges ("hard requirements") have a much different
+impact, and this rule does not apply to them.
 
-- See https://maven.apache.org/pom.html#Dependency_Version_Requirement_Specification
-    for more information.
+[The Maven POM Reference]()]https://maven.apache.org/pom.html#Dependency_Version_Requirement_Specification)
+contains more information.

--- a/docs/JLBP-15.md
+++ b/docs/JLBP-15.md
@@ -5,12 +5,14 @@
 - A BOM is a `pom.xml` file that has a `<dependencyManagement>` section that
   lists all the modules of a project. It can omit the `<modules>` section, and
   it has no `<dependencies>` section. It also has `<packaging>pom</packaging>`.
+
   - Documentation is available at
     https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html
     .
   - All of the modules of the project should be included. Otherwise, a consumer
     who depends on an unspecified module must specify and upgrade the version of
     that module, defeating the purpose of the BOM.
+
 - The purpose of a BOM is to enable consumers of a library to select a
   consistent set of versions for artifacts released by a single project. When
   imported, a BOM operates as a filter. It does not cause any modules to be
@@ -19,8 +21,10 @@
 - If all modules in a project have the same version, use that version for the
   BOM. Example: grpc-bom v1.15.0 would specify grpc-auth v1.15.0, gprc-core
   v1.15.0, etc.
+
 - A BOM is not necessary for projects that only have one module, since there is
   no consistency problem in that case.
+
 - See the details specific to each build system in the sections below.
 
 ### Libraries using Maven
@@ -42,10 +46,12 @@
 
 - A Gradle project can either maintain a pom.xml and release it using a
   specially configured module or generate the `pom.xml` file.
+
 - Example of maintaining a `pom.xml` file: gax-java -
   [build.gradle](https://github.com/googleapis/gax-java/blob/master/gax-bom/build.gradle)
   and
   [pom.xml](https://github.com/googleapis/gax-java/blob/master/gax-bom/pom.xml).
+  
 - There is not yet an example of a project that generates a `pom.xml` file.
   - Note: This approach has a limitation that the BOM cannot include any
     classifiers in the dependency specifications.

--- a/docs/JLBP-16.md
+++ b/docs/JLBP-16.md
@@ -6,23 +6,28 @@ For multi-module projects, this best practice assumes you have already applied
 ### Achieving upper version alignment
 
 - Upper version alignment is defined in the [glossary](glossary.md).
+
 - Upper version alignment increases the likelihood that consumers' build systems
   select the right versions of direct and transitive dependencies, reducing the
   number of conflicts.
+
 - As noted in the definition, to fix a version misalignment caused by a shorter
   path to a version of a dependency that is not the upper bound in the
   dependency tree, a direct dependency needs to be added so that Maven consumers
   select the correct version.
+
 - See the details specific to each build system in the sections below.
 
 ### Maven
 
 - Use `requireUpperBoundDeps` enforcement to ensure that you are using the
   highest version of each dependency in your dependency tree.
+
 - To ensure that dependencies between modules in the project are consistent,
   have the parent POM import the library's own BOM into its
   `<dependencyManagement>` section.
   - [Example import in google-cloud-java](https://github.com/GoogleCloudPlatform/google-cloud-java/blob/36409f5b1df89609eaef92d09cebea97931339bd/google-cloud-clients/pom.xml#L174).
+
 - To ensure that usage of dependencies is consistent, for any direct
   dependencies that have a BOM of their own, import those BOMs in a
   `<dependencyManagement>` section.
@@ -33,22 +38,29 @@ For multi-module projects, this best practice assumes you have already applied
       declarations in dependencyManagement take precedence over all BOM
       imports. (Order between BOMs matters - the earliest import of a dependency
       takes precedence over later imports of the same dependency.)
+
 - For direct dependencies that don't have a BOM (for example, Joda-Time), make
   sure only one pom.xml defines the version, so that the library doesn't
   accidentally depend on different versions in different modules.
+
   - The first option is to specify dependency versions in the
     `<dependencyManagement>` section of the parent POM. Use this option by
     default because it is the most structured.
+
     - When declaring a dependency anywhere in the project, omit the version
       number so that the version from the parent's `<dependencyManagement>`
       section takes effect.
+
   - The second option is to use version properties in the parent that are
     referenced by child modules.
+
     - When declaring a dependency anywhere in the project, use the Maven
       property declared in the parent.
+
 - For any transitive dependency that fails a `requireUpperBoundDeps` check, add
   the dependency as a direct dependency so that the path to the correct version
   is shorter, leading Maven to select it instead of the wrong version.
+  
 - Have each module POM inherit from the parent POM of the library so that the
   parent's `<dependencyManagement>` section is used.
 

--- a/docs/JLBP-17.md
+++ b/docs/JLBP-17.md
@@ -10,32 +10,42 @@ Perform the rollout in this manner:
 
 1. Decide whether to introduce the incompatibility in a single release or
    make the change in two phases.
+
    - The two-phase approach is described in [JLBP-7: Make breaking transitions
      easy](JLBP-7.md).
+
    - If the feature is used by stable code in other libraries, you must use the
      two-phase approach, except for the types of changes where this is
      impossible (see below).
+
    - If the code does not appear to be used in other libraries, an in-place
-     breakage may be ok.
+     breakage may be OK.
+
    - If the feature is used by unstable code or stable code having little usage
      itself, prefer two phases if possible, with in-place breakage only if a
      two-phase rollout is judged to be too costly.
+
    - Some types of changes cannot be done using a two-phase approach, for
      example, making classes or methods `final` or adding methods to interfaces
      without a default implementation. Minimize these types of changes.
+
 2. Make sure that consuming libraries are prepared for the breakage.
+
    - In the case of in-place breakage, submit pull requests to the
      consuming libraries that switch from the old surface to the new surface,
      and add "[DO NOT SUBMIT]" to the title of the pull request.
+
      - These PRs of course will not pass CI, but the author should at
        least verify that the code builds locally before requesting a review.
      - The author should make sure that any code-level concerns of the library
        owners have been addressed before proceeding with the rollout (step 3) so
        that the rollout can proceed efficiently.
+
    - To use the two-phase approach, mark the undesired surface as
      `@Deprecated` and release. Make sure that all consuming libraries
      have removed their references to the deprecated functionality. This invokes
      [JLBP-13](JLBP-13.md) for consuming libraries.
+
 3. Release the incompatible version and make sure that the version propagates up
    the dependency tree as quickly as possible. In the case of in-place breakage,
    update the provisionally-approved PRs with published dependency versions,

--- a/docs/JLBP-18.md
+++ b/docs/JLBP-18.md
@@ -12,18 +12,24 @@ There are a number of problems with shading:
 
 - It can cause considerable size bloat. If it is applied at multiple layers,
   it can have a massive accumulating effect.
+
 - Users cannot upgrade dependencies shaded by other libraries (which means
   security fixes to a transitive dependency need to wait for the shading library
   to also roll in the security fix).
+
 - Shading cannot be performed on types used in a library's own public API as return
   types or method arguments.
+
 - Service entries under `META-INF/services` can easily be messed up. They need
   special effort to be merged because the entries are located in the same place
   for every jar.
+
 - Shading doesn't relocate JNI code.
+
 - Shaders either don't support classes loaded by reflection or they replace all
   strings matching selected packages in the bytecode, leading to the corruption
   of some constants.
+
 - It is easy to accidentally fail to relocate classes or other files, resulting in
   an artifact that overlaps classes and files with the original dependency
   (creating the situation described in [JLBP-5](JLBP-5.md) ).
@@ -40,12 +46,18 @@ you need to read the source code. Make sure you do all of the following:
 
 - Add a test to make sure that all classes and other files copied into your jar
   from your dependencies are relocated.
+
   - Other files include configuration files (for example `log4j.properties`).
+
 - Promote transitive dependencies that are not relocated to direct
   dependencies.
+
 - Make sure no dependencies that appear on your own library surface are
   relocated.
+
 - Make sure that all service files are merged correctly.
+
 - Make sure to relocate JNI library names.
+
 - Confirm that the licenses of the dependencies that you are shading are
   compatible with being re-released within your artifact.

--- a/docs/JLBP-2.md
+++ b/docs/JLBP-2.md
@@ -1,15 +1,15 @@
 # [JLBP-2] Minimize API surface
 
-- Avoid exposing types from your dependencies.
+Avoid exposing types from your dependencies.
 
-  - Method arguments and return values from public methods should be standard Java 
+  - Method arguments and return values from public methods should be standard Java
     types such as `java.time.LocalDate` or classes defined in the library itself,
     not third party types such as `org.joda.time.LocalDate`.
 
   - Your own public types should not be subclasses or implementations of types
     in third party libraries.  
 
-  - If a third party type on the surface of your API changes or is removed, 
+  - If a third party type on the surface of your API changes or is removed,
     you either have to break your own API or remain with an older,
     unsupported version of the library that is likely to cause diamond dependency
     problems. Historically this was a big problem for libraries that exposed Guava types
@@ -17,30 +17,29 @@
     every 6 months.
 
   - A type you've exposed on your own API surface cannot be shaded. This removes
-    one of the available techniques for resolving diamond dependency conflicts. 
+    one of the available techniques for resolving diamond dependency conflicts.
 
-- Use package-protected classes and methods for internal APIs that should not be used by consumers.
+Use package-protected classes and methods for internal APIs that should not be used by consumers.
 
-- Do not mark methods and classes public by default. Assume non-public until a need is 
-  known.<sup id='a1'>[1](#item15)</sup>
+Do not mark methods and classes public by default. Assume non-public until a need is
+known.<sup id='a1'>[1](#item15)</sup>
 
-- Design for inheritance or prohibit it. That is, mark classes final unless there is a clear
-  reason for them to be subclassed. Mark methods in non-final classes final unless they
-  are meant to be overridden.<sup id='a2'>[2](#item19)</sup>
+Design for inheritance or prohibit it. That is, mark classes final unless there is a clear
+reason for them to be subclassed. Mark methods in non-final classes final unless they
+are meant to be overridden.<sup id='a2'>[2](#item19)</sup>
 
-- Prefer fewer packages over more packages to avoid
-  unnecessarily publicizing internal details,
-  since any dependency across package boundaries needs to be
-  public. (We may revisit this when we can rely on
-  the new module system in Java 11 or later.) 
+Prefer fewer packages over more packages to avoid
+unnecessarily publicizing internal details,
+since any dependency across package boundaries needs to be
+public. (We may revisit this when we can rely on
+the new module system in Java 11 or later.)
 
-- If you absolutely must create public classes that clients should not depend on,
-  one of the superpackages that contains these classes should be named `internal`.
-  For example, `com.foo.utilities.internal.xml`. 
+If you absolutely must create public classes that clients should not depend on,
+one of the superpackages that contains these classes should be named `internal`.
+For example, `com.foo.utilities.internal.xml`. 
 
 <b id="item15">1</b> Bloch, Joshua. "Item 15: Minimize the accessibility of classes and members."
 Effective Java, 3rd Edition. Boston: Addison-Wesley, 2018. p. 73[↩](#a1)
 
-<b id="item19">2</b> Bloch, Joshua. "Item 19: Design and document for inheritance or else 
+<b id="item19">2</b> Bloch, Joshua. "Item 19: Design and document for inheritance or else
 prohibit it." Effective Java, 3rd Edition. Boston: Addison-Wesley, 2018. p. 93[↩](#a2)
-

--- a/docs/JLBP-3.md
+++ b/docs/JLBP-3.md
@@ -1,39 +1,51 @@
 # [JLBP-3] Use Semantic Versioning
 
-Definition of semantic versioning (SemVer): https://semver.org
+Definition of semantic versioning (SemVer): [https://semver.org](https://semver.org)
 
-- For the purpose of semantic versioning, the stable surface of a library
-  serves as its public API.
-- Annotations can mark features (classes, methods, etc.) as unstable, 
-  and thus not part of the public API, such that semantic versioning rules do not apply. 
+For the purpose of semantic versioning, the stable surface of a library
+serves as its public API.
+
+Annotations can mark features (classes, methods, etc.) as unstable,
+and thus not part of the public API, such that semantic versioning rules do not apply.
+
   - Examples of annotations:
     - Guava uses `@Beta`
     - grpc-java uses `@ExperimentalApi`
     - Google-cloud-java uses `@BetaApi`, `@InternalApi`, and `@InternalExtensionOnly`
+
   - Library documentation should point users to a tool (or tools) that can
     help them detect when they are using features marked with these
     annotations.
+
   - Even though semantic versioning rules don't apply to unstable features, it is
     recommended to bump a library's minor version if unstable features have
     surface breakages.
-- Tools are available to help identify accidental incompatibilities within a
-  major version. Examples:
+
+Tools are available to help identify accidental incompatibilities within a
+major version. Examples:
+
   - [Java API Compliance Checker](https://lvc.github.io/japi-compliance-checker/)
   - [Clirr Maven Plugin](http://www.mojohaus.org/clirr-maven-plugin/)
   - [Java API Tracker: Compatibility report for grpc-core](
     https://abi-laboratory.pro/index.php?view=timeline&lang=java&l=grpc-core)
-- Examples of breaking changes to a public API that require a new major
-  version:
+
+Examples of breaking changes to a public API that require a new major version:
+
   - Upgrading to an incompatible dependency that is exposed through a
     library's public API. For dependencies that follow semantic versioning, this happens
     when a dependency is bumped to a higher major version.
+
   - Changing a method signature
+
   - Removing a method (deprecated or not)
-- Examples of additions that require a new minor version:
+
+Examples of additions that require a new minor version:
+
   - Upgrading a dependency to a new minor version (compatible, but new
     features) that is exposed through a library's public API
   - Adding a new class
   - Adding a new method
-- Special case: Maintainers do not have to increment a library's major version when
-  a release is only to drop the support of an end-of-life Java version that is not widely used by
-  the consumers of the library.
+
+Special case: Maintainers do not have to increment a library's major version when
+a release is only to drop the support of an end-of-life Java version that is not widely used by
+the consumers of the library.

--- a/docs/JLBP-4.md
+++ b/docs/JLBP-4.md
@@ -1,37 +1,37 @@
 # [JLBP-4] Avoid dependencies on unstable libraries and features
 
-- Unstable libraries allow breaking changes to their
-  public APIs within the same major version. For libraries following semantic
-  versioning, this means libraries with a 0.x.y version. (See [JLBP-3](JLBP-3.md) 
-  for more details on semantic versioning.)
-  
-- Features that are not part of the public API of a
-  stable library are called *unstable*. To mark a feature as unstable and 
-  not part of the public API, use an annotation such as `@Beta`. (See
-  [JLBP-3](JLBP-3.md) for more details on annotating unstable features.)
+Unstable libraries allow breaking changes to their
+public APIs within the same major version. For libraries following semantic
+versioning, this means libraries with a 0.x.y version. (See [JLBP-3](JLBP-3.md)
+for more details on semantic versioning.)
 
-- If your library depends on an unstable library or feature which
-  experiences a breaking change between versions, your library is locked to
-  a specific version of that dependency.
+Features that are not part of the public API of a
+stable library are called *unstable*. To mark a feature as unstable and
+not part of the public API, use an annotation such as `@Beta`. (See
+[JLBP-3](JLBP-3.md) for more details on annotating unstable features.)
+
+If your library depends on an unstable library or feature which
+experiences a breaking change between versions, your library is locked to
+a specific version of that dependency.
 
   - If you expose the unstable feature on your library's surface, then your
     library's current major version is permanently locked to the version
     you initially exposed, and you won't be able to upgrade without making a
     breaking change to your users.
-  
+
   - If you only use the unstable feature in your implementation, then each minor
     or patch version of your library requires a very specific version of
     your dependency, and it is unsafe for your users to upgrade your
     library on its own, creating opportunities for hard-to-diagnose runtime
     conflicts for users.
 
-- Given the consequences of depending on unstable features in dependencies,
-  avoid doing so.
+Given the consequences of depending on unstable features in dependencies,
+avoid doing so.
 
-  - Depending on unstable features between submodules of a single library is
-    acceptable, provided that users can easily force their build system to use
-    compatible versions of the submodules. Some strategies for library owners
-    include:
-    
-    - Using the same version number for all submodules in a library
-    - Providing a [BOM](http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies)
+Depending on unstable features between submodules of a single library is
+acceptable, provided that users can easily force their build system to use
+compatible versions of the submodules. Some strategies for library owners
+include:
+
+  - Using the same version number for all submodules in a library
+  - Providing a [BOM](http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies)

--- a/docs/JLBP-5.md
+++ b/docs/JLBP-5.md
@@ -27,6 +27,7 @@ Example 2: There are multiple artifacts that provide classes under
   `javax.servlet` (`javax.servlet:javax.servlet-api:3.1.0` and
   `javax.servlet:servlet-api:2.5` at least). The correct choice
   depends on the runtime.
+  
   - The only type of library that should depend on `servlet-api` is
     one used exclusively in servlet applications. In this case,
     the `servlet-api` dependency should have `provided` scope. Other libraries should
@@ -38,7 +39,7 @@ Example 2: There are multiple artifacts that provide classes under
 In Java 9 and later overlapping classes become compile-time and runtime errors when
 named modules are used. It is critical, especially in Java 9 and later,
 to remove all but one of the artifacts that contain overlapping classes from the classpath.
-Generally this requires changing the POMs of multiple Maven artifacts so they no 
+Generally this requires changing the POMs of multiple Maven artifacts so they no
 longer include any dependencies on the artifacts you need to remove from your
 project's classpath.
 

--- a/docs/JLBP-6.md
+++ b/docs/JLBP-6.md
@@ -11,6 +11,7 @@ repository system, library B needs two identifiers to find classes in library A:
    Maven or Gradle) selects exactly one version to put on
    the classpath. Different build systems use different rules for selecting
    from multiple versions.
+
 2. The fully-qualified class names of the classes in library A. These classes
    generally share a Java package (the package as defined in `package`
    statements, for example `package com.google.common.collect`). The classpath,
@@ -29,6 +30,7 @@ Recommendations:
   1. If the new library surface is delivered under a new Java package, either
      use a different Maven ID (different group ID or artifact ID) or bundle the
      old and new packages together under the original Maven ID.
+
   2. If the breaking change is made in-place and the Java package is kept the
      same, use the same Maven ID (same group ID and same artifact ID).
 
@@ -48,30 +50,38 @@ Recommendations:
 
   - Corollary 1: Once you have published under a particular Maven ID, you are
     stuck with it until you rename your Java package.
+
   - Corollary 2: Don't fork an artifact owned by someone else and publish
     classes with the same fully-qualified classnames.
 
 Consider the following renaming scenario:
 
 - The Maven coordinates start as `g1:a1:1.0.0`
+
   - With no rename of the Maven ID, the new major version's Maven coordinates
     are `g1:a1:2.0.0`. (Only one of the versions will be present on the
     classpath even if both are in the dependency tree.)
+
   - With a rename of the Maven ID, the new major version's Maven coordinates are
     `g2:a2:2.0.0`. (Both versions can be present on the classpath.)
+
 - The Java package starts as `com.google.a1`
+
   - With no rename, the new major version's Java package is still
     `com.google.a1`.
+
   - With a rename, the new major version's Java package is `com.google.a2`.
 
 Given this scenario, here are the possible combinations of renamings:
 
 - **Don't rename Java package**:
+
   - **Case 1: Don't rename Maven ID**. This approach can result in diamond
     dependency conflicts because different branches of a dependency tree can
     depend on different major versions, and the build system (Maven or Gradle)
     will only choose one of them to use. Users are forced to change their code
     between versions, but only for library surface that was changed.
+    
   - **Case 2: Rename Maven ID**. Users can easily pull in both the old jar
     (`g1:a1:1.0.0`) and the new jar (`g2:a2:2.0.0`) into their classpath
     accidentally through transitive dependencies because Maven artifact
@@ -79,7 +89,9 @@ Given this scenario, here are the possible combinations of renamings:
     "overlapping classes" since they have classes with the same fully-qualified
     path. This can lead to runtime exceptions such as`NoSuchMethodDefError`
     and can be a compile-time error in Java 9 and later. **NEVER DO THIS**.
+
 - **Rename Java package**:
+
   - **Case 3: Don't rename Maven ID**. The classes from `g1:a1:1.0.0` and
     `g1:a1:2.0.0` could technically be used together, but since they share the
     Maven group ID and artifact ID, only one jar can be pulled in.
@@ -87,6 +99,7 @@ Given this scenario, here are the possible combinations of renamings:
     It is strictly better to either also rename the Maven ID (case 4)
     or to keep the Maven ID and also bundle the old package (case 5), so that
     the major versions can be used side by side.
+
   - **Case 4: Rename Maven ID**. The two major versions can be used side by
     side, allowing users to incrementally transition from the old to the new
     version, or even use them side by side indefinitely if
@@ -97,6 +110,7 @@ Given this scenario, here are the possible combinations of renamings:
     there are consuming libraries that have not also created new major versions
     that can accept new types from this library. This approach is essentially
     like creating a new library.
+
   - **Case 5: Bundle old and new in the existing Maven ID**. Like case 4, the
     two versions can be used side by side. The impact is the same as case 4,
     except with the slight drawback that the user's class space is polluted with

--- a/docs/JLBP-7.md
+++ b/docs/JLBP-7.md
@@ -15,6 +15,7 @@ features:
 
 1. Mark old methods/classes as `@Deprecated` at the same time as adding new
    methods/classes. This is a "stepping stone" release.
+
 2. Delete the deprecated methods/classes. This should wait until major consumers
    have stopped using the deprecated functionality, where major consumers means
    consumers with high usage or consumers that are deep in the dependency tree.

--- a/docs/JLBP-8.md
+++ b/docs/JLBP-8.md
@@ -21,13 +21,15 @@ value to having a stable surface than there is to having a surface with zero
 deprecated methods.
 
 To avoid getting stuck in the first place, do not evangelize your pre-1.0 library
-or suggest that other teams and projects depend on it. 
+or suggest that other teams and projects depend on it.
 
 - Be very clear with any teams and projects you work with that the library is unstable
   and should only be adopted if they are prepared to upgrade their own product regularly.
-- Add an [unstable or experimental badge](https://github.com/badges/stability-badges) 
+
+- Add an [unstable or experimental badge](https://github.com/badges/stability-badges)
   to your Github `README.md`.
+  
 - Consider not pushing a pre-1.0 artifact to the Central repository.
 
 Once the API is stable and has reached 1.0 is the time to seek customers,
-not before. 
+not before.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,25 +17,41 @@ list is open-ended, so new ones may be added from time to time.
   cloud-opensource-java.
 
 - [JLBP-1](JLBP-1.md): Minimize dependencies
+
 - [JLBP-2](JLBP-2.md): Minimize API surface
+
 - [JLBP-3](JLBP-3.md): Use semantic versioning
+
 - [JLBP-4](JLBP-4.md): Avoid dependencies on unstable libraries and features
+
 - [JLBP-5](JLBP-5.md): Avoid dependencies that overlap classes with other
   dependencies
+
 - [JLBP-6](JLBP-6.md): Rename artifacts and packages together
 - [JLBP-7](JLBP-7.md): Make breaking transitions easy
+
 - [JLBP-8](JLBP-8.md): Advance widely used functionality to a stable version
+
 - [JLBP-9](JLBP-9.md): Support the minimum Java version of your consumers
+
 - [JLBP-10](JLBP-10.md): Maintain API stability as long as needed for consumers
+
 - [JLBP-11](JLBP-11.md): Stay up to date with compatible dependencies
+
 - [JLBP-12](JLBP-12.md): Make level of support and API stability clear
+
 - [JLBP-13](JLBP-13.md): Quickly remove references to deprecated features in
    dependencies
 - [JLBP-14](JLBP-14.md): Do not use version ranges
+
 - [JLBP-15](JLBP-15.md): Produce a BOM for multi-module projects
+
 - [JLBP-16](JLBP-16.md): Ensure upper version alignment of dependencies for
   consumers
 - [JLBP-17](JLBP-17.md): Coordinate rollout of breaking changes
+
 - [JLBP-18](JLBP-18.md): Only shade dependencies as a last resort
+
 - [JLBP-19](JLBP-19.md): Place each package in only one module
+
 - [JLBP-20](JLBP-20.md): Give each jar a module name


### PR DESCRIPTION
@garrettjonesgoogle I also added blank lines between list items to make Kramdown (part of Jekyll/github pages include p elements inside its li elements.) That is, this is going to turn a lot of

```
<ul>
<li>Lorem ipsum</li>
</ul>
```

into 

```
<ul>
<li><p>Lorem ipsum</p></li>
</ul>
```
