### PR TITLE
use paragraph for multiline list items

### DIFF
--- a/docs/JLBP-1.md
+++ b/docs/JLBP-1.md
@@ -16,6 +16,7 @@ Some specific notes about minimizing dependencies:
 - Use the smallest scope possible. For example, AutoValue doesn't
   need to use `compile` scope, and can instead use `compile-only`,
   since it doesn't need to appear on the classpath of consumers.
+  
   - Libraries used only for testing should have `test` scope
     (for example junit, mockito, and truth).
 
@@ -25,13 +26,14 @@ Some specific notes about minimizing dependencies:
   dependencies are pulled in, consider a different direct dependency.
   Alternatively, if the functionality you need is small, reimplement
   it in your own library.
+
   - Maven: Run `mvn dependency:tree` (after running
     `mvn install -DskipTests` to build the library).
   - Gradle: Run `./gradlew dependencies`
 
 - Prefer JDK classes where available. For example, XOM and JDOM
-  are very convenient and far easier to use than DOM. However, most 
-  uses of these libraries can be satisfied with the `org.w3c.dom` 
+  are very convenient and far easier to use than DOM. However, most
+  uses of these libraries can be satisfied with the `org.w3c.dom`
   or other packages bundled with the JDK at some cost in development
   time.
 
@@ -42,7 +44,7 @@ Some specific notes about minimizing dependencies:
   Do not allow different team members to choose different libraries.
 
 - If you can reasonably reimplement functionality instead of adding
-  another dependency, do so. For example, if the only classes you're 
-  using from Guava are `Preconditions` and `Strings`, it's not 
-  worth adding a dependency on Guava. You can easily reimplement 
+  another dependency, do so. For example, if the only classes you're
+  using from Guava are `Preconditions` and `Strings`, it's not
+  worth adding a dependency on Guava. You can easily reimplement
   any method in those classes.  


### PR DESCRIPTION
@garrettjonesgoogle as discussed, I'm breaking these up into individual PRs

cf. https://googlecloudplatform.github.io/cloud-opensource-java/JLBP-1.html

I think this one is a clear win for legibility. I've left the sentence fragments as simple list items, and added a paragraph for the longer multisentence blocks of text.