### PR TITLE
Upgrading BCEL to 6.4.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.apache.bcel</groupId>
       <artifactId>bcel</artifactId>
-      <version>6.3.1</version>
+      <version>6.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/settings.xml
+++ b/settings.xml
@@ -19,14 +19,15 @@
     xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                           https://maven.apache.org/xsd/settings-1.0.0.xsd">
   <mirrors>
-    <!-- Google's Maven Central mirror for Americas
+    <!-- Google's Maven Central mirror for Americas is outdated as of September 25th, 2019
      https://cloudplatform.googleblog.com/2015/11/faster-builds-for-Java-developers-with-Maven-Central-mirror.html
-     -->
+
     <mirror>
       <id>google-maven-central</id>
       <name>GCS Maven Central mirror</name>
       <url>https://maven-central.storage-download.googleapis.com/repos/central/data/</url>
       <mirrorOf>central</mirrorOf>
     </mirror>
+    -->
   </mirrors>
 </settings>

--- a/settings.xml
+++ b/settings.xml
@@ -19,7 +19,8 @@
     xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                           https://maven.apache.org/xsd/settings-1.0.0.xsd">
   <mirrors>
-    <!-- Google's Maven Central mirror for Americas is outdated as of September 25th, 2019
+    <!-- Google's Maven Central mirror for Americas is missing new artifacts, such as BCEL 6.4.0
+      as of September 25th, 2019
      https://cloudplatform.googleblog.com/2015/11/faster-builds-for-Java-developers-with-Maven-Central-mirror.html
 
     <mirror>


### PR DESCRIPTION
BCEL 6.4.0 is released today.

The latest BCEL is not available in maven-central.storage-download.googleapis.com. Commenting out the mirror setting until the problem is fixed.
