### PR TITLE
Specialcase jdk.vm.ci

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -46,7 +46,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>28.1-android</guava.version>
     <google.cloud.java.version>0.102.0-alpha</google.cloud.java.version>
-    <io.grpc.version>1.22.1</io.grpc.version>
+    <io.grpc.version>1.23.0</io.grpc.version>
     <protobuf.version>3.10.0</protobuf.version>
     <http.version>1.32.1</http.version>
   </properties>

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -46,7 +46,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>28.1-android</guava.version>
     <google.cloud.java.version>0.102.0-alpha</google.cloud.java.version>
-    <io.grpc.version>1.23.0</io.grpc.version>
+    <io.grpc.version>1.22.1</io.grpc.version>
     <protobuf.version>3.10.0</protobuf.version>
     <http.version>1.32.1</http.version>
   </properties>

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -161,11 +161,10 @@ public class LinkageChecker {
         });
 
     // Filter classes in whitelist
-    SetMultimap<SymbolProblem, ClassFile> filteredMap = Multimaps
-        .filterEntries(problemToClass.build(), LinkageChecker::problemFilter);
+    SetMultimap<SymbolProblem, ClassFile> filteredMap =
+        Multimaps.filterEntries(problemToClass.build(), LinkageChecker::problemFilter);
     return ImmutableSetMultimap.copyOf(filteredMap);
   }
-
 
   /**
    * Returns true if the linkage error {@code entry} should be reported. False if it should be

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -173,15 +173,20 @@ public class LinkageChecker {
   private static boolean problemFilter(Map.Entry<SymbolProblem, ClassFile> entry) {
     ClassFile classFile = entry.getValue();
     SymbolProblem symbolProblem = entry.getKey();
-    if (SOURCE_CLASSES_TO_SUPPRESS.contains(classFile.getClassName())) {
+    String sourceClassName = classFile.getClassName();
+    if (SOURCE_CLASSES_TO_SUPPRESS.contains(sourceClassName)) {
       return false;
     }
 
-    // GraalVM-related library depends on Java Compiler Interface (JVMCI) that only exists in
+    // GraalVM-related libraries depend on Java Compiler Interface (JVMCI) that only exists in
     // special JDK. https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/929
-    if (symbolProblem.getSymbol().getClassName().startsWith("jdk.vm.ci")) {
+    if (symbolProblem.getSymbol().getClassName().startsWith("jdk.vm.ci")
+        && (sourceClassName.startsWith("com.oracle.svm")
+            || sourceClassName.startsWith("com.oracle.graal")
+            || sourceClassName.startsWith("org.graalvm"))) {
       return false;
     }
+
     return true;
   }
 


### PR DESCRIPTION
Fixes #929 

@elharo Although we discussed about checking the source to "jdk.vm.ci" packages, LinkageChecker does not know Maven artifacts. It only know class names. This would make the specialcasing a bit complex if we check the sources. And thus this PR only checks the missing symbol package.