### PR TITLE
Setting generateBackupPoms=false

### DIFF
--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -61,7 +61,7 @@ fi
 git checkout -b ${VERSION}-${SUFFIX}
 
 # Updates the pom.xml with the version to release.
-mvn versions:set versions:commit -DnewVersion=${VERSION}
+mvn versions:set versions:commit -DnewVersion=${VERSION} -DgenerateBackupPoms=false
 
 # Tags a new commit for this release.
 git commit -am "preparing release ${VERSION}-${SUFFIX}"
@@ -73,7 +73,7 @@ NEXT_SNAPSHOT=${NEXT_VERSION}
 if [[ "${NEXT_SNAPSHOT}" != *-SNAPSHOT ]]; then
   NEXT_SNAPSHOT=${NEXT_SNAPSHOT}-SNAPSHOT
 fi
-mvn versions:set versions:commit -DnewVersion=${NEXT_SNAPSHOT}
+mvn versions:set versions:commit -DnewVersion=${NEXT_SNAPSHOT} -DgenerateBackupPoms=false
 
 # Commits this next snapshot version.
 git commit -am "${NEXT_SNAPSHOT}"


### PR DESCRIPTION
Fixes #953 

As per Versions Maven plugin documentation https://www.mojohaus.org/versions-maven-plugin/set-mojo.html, setting `generateBackupPoms` as false.

Confirmed prepare_release.sh does not create '*.versionsBackup' files any more:

```
suztomo@suxtomo24:~/cloud-opensource-java$ ./scripts/prepare_release.sh dependencies 1.0.1
===== RELEASE SETUP SCRIPT =====
Switched to a new branch '1.0.1-dependencies'
...
remote: Create a pull request for '1.0.1-dependencies' on GitHub by visiting:
remote:      https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/new/1.0.1-dependencies
remote: 
To https://github.com/GoogleCloudPlatform/cloud-opensource-java.git
 * [new branch]        1.0.1-dependencies -> 1.0.1-dependencies
Branch '1.0.1-dependencies' set up to track remote branch '1.0.1-dependencies' from 'origin'.
File a PR for the new release branch:
https://github.com/GoogleCloudPlatform/cloud-opensource-java/compare/1.0.1-dependencies
suztomo@suxtomo24:~/cloud-opensource-java$ find . -name '*.versionsBackup'
suztomo@suxtomo24:~/cloud-opensource-java$
```


