### PR TITLE
Linkage monitor error to include dependency path to problematic artifacts

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.opensource.dependencies;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +31,8 @@ public final class DependencyPath {
 
   private List<Artifact> path = new ArrayList<>();
 
-  void add(Artifact artifact) {
+  @VisibleForTesting
+  public void add(Artifact artifact) {
     path.add(artifact);
   }
   

--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -152,7 +153,7 @@ public class LinkageMonitor {
   static String messageForNewErrors(
       ImmutableSetMultimap<SymbolProblem, ClassFile> snapshotSymbolProblems,
       Set<SymbolProblem> baselineProblems,
-      LinkedListMultimap<Path, DependencyPath> jarToDependencyPaths) {
+      Multimap<Path, DependencyPath> jarToDependencyPaths) {
     Set<SymbolProblem> newProblems =
         Sets.difference(snapshotSymbolProblems.keySet(), baselineProblems);
     StringBuilder message =
@@ -170,9 +171,9 @@ public class LinkageMonitor {
     }
 
     for (Path problematicJar : problematicJars.build()) {
-      message.append(problematicJar.getFileName() + "is in path:");
+      message.append(problematicJar.getFileName() + " is at:\n");
       for (DependencyPath dependencyPath : jarToDependencyPaths.get(problematicJar)) {
-        message.append("  " + dependencyPath);
+        message.append("  " + dependencyPath + "\n");
       }
     }
 

--- a/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
+++ b/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
@@ -173,7 +173,7 @@ public class LinkageMonitorTest {
   private final SymbolProblem methodNotFoundProblem =
       new SymbolProblem(
           new MethodSymbol(
-              "io.grpc.protobuf.ProtoUtils.marshaller",
+              "io.grpc.protobuf.ProtoUtils",
               "marshaller",
               "(Lcom/google/protobuf/Message;)Lio/grpc/MethodDescriptor$Marshaller;",
               false),
@@ -201,7 +201,7 @@ public class LinkageMonitorTest {
             snapshotProblems, baselineProblems, ImmutableListMultimap.of(jar, dependencyPath));
     assertEquals(
         "Newly introduced problem:\n"
-            + "(bbb-1.2.3.jar) io.grpc.protobuf.ProtoUtils.marshaller's method"
+            + "(bbb-1.2.3.jar) io.grpc.protobuf.ProtoUtils's method"
             + " marshaller(com.google.protobuf.Message arg1) is not found\n"
             + "  referenced from com.abc.AAA (ccc-1.2.3.jar)\n"
             + "  referenced from com.abc.BBB (ccc-1.2.3.jar)\n"
@@ -217,7 +217,7 @@ public class LinkageMonitorTest {
     assertEquals(
         "The following problems in the baseline no longer appear in the snapshot:\n"
             + "  Class java.lang.Integer is not found\n"
-            + "  (bbb-1.2.3.jar) io.grpc.protobuf.ProtoUtils.marshaller's method "
+            + "  (bbb-1.2.3.jar) io.grpc.protobuf.ProtoUtils's method "
             + "marshaller(com.google.protobuf.Message arg1) is not found\n",
         message);
   }


### PR DESCRIPTION
Toward #981 . Option 2: "Show Path to the Problematic Artifact" in the issue description. Not showing scope (yet).

With this PR, when Linkage Monitor shows error, it tells the location of the problematic Maven artifact in the dependency tree.

Example case to show gwt-user-2.8.2.jar:
```
suztomo@suxtomo24:~/cloud-opensource-java/linkage-monitor$ java -jar target/linkage-monitor-1.0.1-SNAPSHOT-all-deps.jar   com.google.cloud:libraries-bom
BOM Coordinates: com.google.cloud:libraries-bom:2.7.1-SNAPSHOT
Newly introduced problems:
...
Class org.objectweb.asm.commons.Method is not found
  referenced from com.google.web.bindery.requestfactory.server.RequestFactoryJarExtractor (gwt-user-2.8.2.jar)
Class com.google.gwt.dev.util.Name$SourceOrBinaryName is not found
  referenced from com.google.web.bindery.requestfactory.server.RequestFactoryJarExtractor (gwt-user-2.8.2.jar)
Class org.hibernate.validator.engine.ConstraintViolationImpl is not found
  referenced from org.hibernate.validator.engine.ConstraintViolationImpl_CustomFieldSerializer (gwt-user-2.8.2.jar)
Class org.hibernate.validator.engine.PathImpl is not found
  referenced from org.hibernate.validator.engine.PathImpl_CustomFieldSerializer (gwt-user-2.8.2.jar)
gwt-user-2.8.2.jar is at:
  com.google.cloud:google-cloud-firestore:1.28.1-SNAPSHOT / com.google.truth:truth:1.0 / com.google.gwt:gwt-user:2.8.2

Exception in thread "main" com.google.cloud.tools.dependencies.linkagemonitor.LinkageMonitorException: Found 278 new linkage errors
	at com.google.cloud.tools.dependencies.linkagemonitor.LinkageMonitor.run(LinkageMonitor.java:137)
	at com.google.cloud.tools.dependencies.linkagemonitor.LinkageMonitor.main(LinkageMonitor.java:87)

```