### PR TITLE
testReadBom_path not to use boms/cloud-oss-bom/pom.xml

### DIFF
--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/TestHelper.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/TestHelper.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.opensource.classpath;
 
 import java.net.URISyntaxException;
-import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -28,6 +27,6 @@ public class TestHelper {
 
   /** Returns an absolute path of {@code resourceName}. */
   public static Path absolutePathOfResource(String resourceName) throws URISyntaxException {
-    return Paths.get(URLClassLoader.getSystemResource(resourceName).toURI()).toAbsolutePath();
+    return Paths.get(ClassLoader.getSystemResource(resourceName).toURI()).toAbsolutePath();
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/TestHelper.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/TestHelper.java
@@ -22,12 +22,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /** Utility used among tests. */
-class TestHelper {
+public class TestHelper {
 
   private TestHelper() {}
 
   /** Returns an absolute path of {@code resourceName}. */
-  static Path absolutePathOfResource(String resourceName) throws URISyntaxException {
+  public static Path absolutePathOfResource(String resourceName) throws URISyntaxException {
     return Paths.get(URLClassLoader.getSystemResource(resourceName).toURI()).toAbsolutePath();
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtilityTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtilityTest.java
@@ -71,8 +71,7 @@ public class RepositoryUtilityTest {
     Bom expectedBom = RepositoryUtility.readBom(expectedBomCoordinates);
     ImmutableList<Artifact> expectedArtifacts = expectedBom.getManagedDependencies();
 
-    Truth.assertThat(bomFromFile.getCoordinates())
-        .isEqualTo(expectedBomCoordinates);
+    Truth.assertThat(bomFromFile.getCoordinates()).isEqualTo(expectedBomCoordinates);
     Truth.assertThat(artifactsFromFile)
         .comparingElementsUsing(
             transforming(

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtilityTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtilityTest.java
@@ -64,15 +64,14 @@ public class RepositoryUtilityTest {
       throws MavenRepositoryException, ArtifactDescriptorException, URISyntaxException {
     Path pomFile = absolutePathOfResource("libraries-bom-2.7.0.pom");
     Bom bomFromFile = RepositoryUtility.readBom(pomFile);
+    ImmutableList<Artifact> artifactsFromFile = bomFromFile.getManagedDependencies();
 
     // Compare the result with readBom(String coordinates)
     Bom expectedBom = RepositoryUtility.readBom("com.google.cloud:libraries-bom:2.7.0");
     ImmutableList<Artifact> expectedArtifacts = expectedBom.getManagedDependencies();
 
-    ImmutableList<Artifact> artifactsFromFile = bomFromFile.getManagedDependencies();
-
-    Assert.assertEquals("com.google.cloud:libraries-bom:2.7.0", bomFromFile.getCoordinates());
-    Truth.assertThat(artifactsFromFile).hasSize(221);
+    Truth.assertThat(bomFromFile.getCoordinates())
+        .isEqualTo("com.google.cloud:libraries-bom:2.7.0");
     Truth.assertThat(artifactsFromFile)
         .comparingElementsUsing(
             transforming(

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtilityTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtilityTest.java
@@ -67,11 +67,12 @@ public class RepositoryUtilityTest {
     ImmutableList<Artifact> artifactsFromFile = bomFromFile.getManagedDependencies();
 
     // Compare the result with readBom(String coordinates)
-    Bom expectedBom = RepositoryUtility.readBom("com.google.cloud:libraries-bom:2.7.0");
+    String expectedBomCoordinates = "com.google.cloud:libraries-bom:2.7.0";
+    Bom expectedBom = RepositoryUtility.readBom(expectedBomCoordinates);
     ImmutableList<Artifact> expectedArtifacts = expectedBom.getManagedDependencies();
 
     Truth.assertThat(bomFromFile.getCoordinates())
-        .isEqualTo("com.google.cloud:libraries-bom:2.7.0");
+        .isEqualTo(expectedBomCoordinates);
     Truth.assertThat(artifactsFromFile)
         .comparingElementsUsing(
             transforming(

--- a/dependencies/src/test/resources/libraries-bom-2.7.0.pom
+++ b/dependencies/src/test/resources/libraries-bom-2.7.0.pom
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file is copied from com.google.cloud:libraries-bom:2.7.0 for RepositoryUtilityTest -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.google.cloud</groupId>
+  <artifactId>libraries-bom</artifactId>
+  <version>2.7.0</version>
+  <packaging>pom</packaging>
+
+  <name>Google Cloud Platform Supported Libraries</name>
+  <description>A compatible set of Google Cloud open source libraries.</description>
+  <url>https://github.com/GoogleCloudPlatform/cloud-opensource-java#google-library-bom</url>
+  <organization>
+    <name>Google LLC</name>
+    <url>https://cloud.google.com</url>
+  </organization>
+  <inceptionYear>2019</inceptionYear>
+  <developers>
+    <developer>
+      <name>Elliotte Rusty Harold</name>
+    </developer>
+  </developers>
+
+  <issueManagement>
+    <url>https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues</url>
+  </issueManagement>
+  <scm>
+    <connection>scm:git:git@github.com:GoogleCloudPlatform/cloud-opensource-java.git</connection>
+    <developerConnection>scm:git:git@github.com:GoogleCloudPlatform/cloud-opensource-java.git
+    </developerConnection>
+    <url>https://github.com/GoogleCloudPlatform/cloud-opensource-java/boms/cloud-oss-bom</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <guava.version>28.1-android</guava.version>
+    <google.cloud.java.version>0.116.0-alpha</google.cloud.java.version>
+    <io.grpc.version>1.24.0</io.grpc.version>
+    <protobuf.version>3.10.0</protobuf.version>
+    <http.version>1.32.1</http.version>
+  </properties>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava-bom</artifactId>
+        <version>${guava.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- protobufs from https://github.com/protocolbuffers/protobuf/tree/master/java -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-bom</artifactId>
+        <version>${protobuf.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- google-http-java-client from https://github.com/googleapis/google-http-java-client -->
+     <dependency>
+       <groupId>com.google.http-client</groupId>
+       <artifactId>google-http-client</artifactId>
+       <version>${http.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-android</artifactId>
+        <version>${http.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-apache</artifactId>
+        <version>2.1.2</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-appengine</artifactId>
+        <version>${http.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-gson</artifactId>
+        <version>${http.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-jackson2</artifactId>
+        <version>${http.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-protobuf</artifactId>
+        <version>${http.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-test</artifactId>
+        <version>${http.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-xml</artifactId>
+        <version>${http.version}</version>
+      </dependency>
+
+      <!-- GRPC; specifically https://github.com/grpc/grpc-java -->
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-alts</artifactId>
+        <version>${io.grpc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-auth</artifactId>
+        <version>${io.grpc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-context</artifactId>
+        <version>${io.grpc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-core</artifactId>
+        <version>${io.grpc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-grpclb</artifactId>
+        <version>${io.grpc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-netty</artifactId>
+        <version>${io.grpc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-netty-shaded</artifactId>
+        <version>${io.grpc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-okhttp</artifactId>
+        <version>${io.grpc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-protobuf</artifactId>
+        <version>${io.grpc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-stub</artifactId>
+        <version>${io.grpc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-testing</artifactId>
+        <version>${io.grpc.version}</version>
+      </dependency>
+
+      <!-- google-cloud-java from https://github.com/googleapis/google-cloud-java -->
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bom</artifactId>
+        <version>${google.cloud.java.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+</project>


### PR DESCRIPTION
Follow-up of https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/966/files#r336968467 . With this PR, testReadBom_path does not get affected by the change in `boms/cloud-oss-bom/pom.xml`.

#978 "Document exact versions of the libraries covered by the BOM" still stands as a separate issue.

