### PR TITLE
MaximumlinakgeErrorsTest to automatically check with the latest version of the BOM

### DIFF
--- a/boms/integration-tests/src/test/java/com/google/cloud/MaximumLinkageErrorsTest.java
+++ b/boms/integration-tests/src/test/java/com/google/cloud/MaximumLinkageErrorsTest.java
@@ -43,6 +43,7 @@ public class MaximumLinkageErrorsTest {
   @Test
   public void testMaximumLinkageErrors()
       throws IOException, MavenRepositoryException, RepositoryException {
+    // Not using RepositoryUtility.findLatestCoordinates, which may return a snapshot version
     String version = findLatestNonSnapshotVersion();
     String baselineCoordinates = "com.google.cloud:libraries-bom:" + version;
     Bom baseline = RepositoryUtility.readBom(baselineCoordinates);

--- a/boms/integration-tests/src/test/java/com/google/cloud/MaximumLinkageErrorsTest.java
+++ b/boms/integration-tests/src/test/java/com/google/cloud/MaximumLinkageErrorsTest.java
@@ -17,8 +17,6 @@
 
 package com.google.cloud;
 
-import static com.google.cloud.tools.opensource.dependencies.RepositoryUtility.newRepositorySystem;
-
 import com.google.cloud.tools.opensource.classpath.ClassFile;
 import com.google.cloud.tools.opensource.classpath.LinkageChecker;
 import com.google.cloud.tools.opensource.classpath.SymbolProblem;
@@ -88,7 +86,8 @@ public class MaximumLinkageErrorsTest {
 
   private String findLatestNonSnapshotVersion() throws MavenRepositoryException {
     ImmutableList<String> versions =
-        RepositoryUtility.findVersions(newRepositorySystem(), "com.google.cloud", "libraries-bom");
+        RepositoryUtility.findVersions(
+            RepositoryUtility.newRepositorySystem(), "com.google.cloud", "libraries-bom");
     ImmutableList<String> versionsLatestFirst = versions.reverse();
     Optional<String> highestNonsnapshotVersion =
         versionsLatestFirst.stream().filter(version -> !version.contains("SNAPSHOT")).findFirst();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -366,11 +366,14 @@ public final class RepositoryUtility {
 
   /**
    * Returns list of versions available for {@code groupId:artifactId} in {@code repositorySystem}.
+   * The returned list is in ascending order with regard to {@link
+   * org.eclipse.aether.util.version.GenericVersionScheme}.
    */
   public static ImmutableList<String> findVersions(
       RepositorySystem repositorySystem, String groupId, String artifactId)
       throws MavenRepositoryException {
     RepositorySystemSession session = RepositoryUtility.newSession(repositorySystem);
+    // getVersions returns a list in ascending order
     return findVersionRange(repositorySystem, session, groupId, artifactId).getVersions().stream()
         .map(version -> version.toString())
         .collect(toImmutableList());

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -367,7 +367,7 @@ public final class RepositoryUtility {
   /**
    * Returns list of versions available for {@code groupId:artifactId} in {@code repositorySystem}.
    * The returned list is in ascending order with regard to {@link
-   * org.eclipse.aether.util.version.GenericVersionScheme}.
+   * org.eclipse.aether.util.version.GenericVersionScheme}; the highest version comes at last.
    */
   public static ImmutableList<String> findVersions(
       RepositorySystem repositorySystem, String groupId, String artifactId)


### PR DESCRIPTION
Followup of https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/993#pullrequestreview-307249115. With this PR, we no longer need to update the version number of this test.

Example output:
```
java.lang.AssertionError: Baseline BOM: com.google.cloud:libraries-bom:2.7.0
Newly introduced problems:
Class android.util.JsonToken is not found
Class android.util.JsonReader is not found
Class android.util.JsonWriter is not found
Class org.junit.rules.TestRule is not found
Class org.junit.runners.model.MultipleFailureException is not found
Class com.google.inject.Provider is not found
Class com.google.inject.util.Providers is not found
Class com.google.appengine.repackaged.com.google.common.html.HtmlEscapers is not found
```