### PR TITLE
Removed version range query from Linkage Monitor

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -353,7 +353,7 @@ public final class RepositoryUtility {
   }
 
   /** Returns the highest version for {@code groupId:artifactId} in {@code repositorySystem}. */
-  public static String findHighestVersion(
+  static String findHighestVersion(
       RepositorySystem repositorySystem,
       RepositorySystemSession session,
       String groupId,

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.File;
@@ -353,6 +354,7 @@ public final class RepositoryUtility {
   }
 
   /** Returns the highest version for {@code groupId:artifactId} in {@code repositorySystem}. */
+  @VisibleForTesting
   static String findHighestVersion(
       RepositorySystem repositorySystem,
       RepositorySystemSession session,

--- a/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
+++ b/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.dependencies.linkagemonitor;
 
 import static com.google.cloud.tools.opensource.dependencies.Artifacts.toCoordinates;
-import static com.google.cloud.tools.opensource.dependencies.RepositoryUtility.CENTRAL;
 import static com.google.common.collect.Iterables.skip;
 import static com.google.common.truth.Correspondence.transforming;
 import static com.google.common.truth.Truth.assertWithMessage;
@@ -50,14 +49,9 @@ import org.apache.maven.model.Model;
 import org.apache.maven.model.building.ModelBuildingException;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.resolution.ArtifactDescriptorException;
-import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
-import org.eclipse.aether.resolution.ArtifactResult;
-import org.eclipse.aether.resolution.VersionRangeResolutionException;
-import org.eclipse.aether.version.InvalidVersionSpecificationException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -70,12 +64,6 @@ public class LinkageMonitorTest {
     system = RepositoryUtility.newRepositorySystem();
 
     session = RepositoryUtility.newSession(system);
-  }
-
-  private ArtifactResult resolveArtifact(String coordinates) throws ArtifactResolutionException {
-    Artifact protobufJavaArtifact = new DefaultArtifact(coordinates);
-    return system.resolveArtifact(
-        session, new ArtifactRequest(protobufJavaArtifact, ImmutableList.of(CENTRAL), null));
   }
 
   @Test
@@ -196,8 +184,7 @@ public class LinkageMonitorTest {
 
   @Test
   public void testBuildModelWithSnapshotBom_BomSnapshotUpdate()
-      throws ModelBuildingException, ArtifactResolutionException,
-          InvalidVersionSpecificationException, VersionRangeResolutionException {
+      throws ModelBuildingException, ArtifactResolutionException {
     // Linkage Monitor should update a BOM in Google Cloud Libraries BOM when it's available local
     // repository. This test case simulates the issue below where
     // google-cloud-bom:0.106.0-alpha-SNAPSHOT should provide gax:1.48.0.
@@ -235,7 +222,7 @@ public class LinkageMonitorTest {
   }
 
   @Test
-  public void testFindLocalArtifacts_currentDirectory() throws ModelBuildingException {
+  public void testFindLocalArtifacts_currentDirectory() {
     // Current working directory of linkage-monitor should have one linkage monitor artifact
     ImmutableMap<String, String> localArtifacts =
         LinkageMonitor.findLocalArtifacts(system, session, Paths.get("."));
@@ -245,7 +232,7 @@ public class LinkageMonitorTest {
   }
 
   @Test
-  public void testFindLocalArtifacts_parentDirectory() throws ModelBuildingException {
+  public void testFindLocalArtifacts_RootDirectory() {
     // Root of cloud-opensource-java has more than 10 pom.xml files
     ImmutableMap<String, String> localArtifacts =
         LinkageMonitor.findLocalArtifacts(system, session, Paths.get(".."));

--- a/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
+++ b/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
@@ -25,10 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
+
 import com.google.cloud.tools.opensource.classpath.ClassFile;
 import com.google.cloud.tools.opensource.classpath.ClassSymbol;
 import com.google.cloud.tools.opensource.classpath.ErrorType;
@@ -37,71 +34,42 @@ import com.google.cloud.tools.opensource.classpath.SymbolProblem;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.Bom;
 import com.google.cloud.tools.opensource.dependencies.DependencyPath;
-import com.google.cloud.tools.opensource.dependencies.MavenRepositoryException;
 import com.google.cloud.tools.opensource.dependencies.RepositoryUtility;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
-import java.io.IOException;
-import java.nio.file.Files;
+import com.google.common.truth.Truth;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
-import com.google.common.io.MoreFiles;
-import com.google.common.io.RecursiveDeleteOption;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.building.ModelBuildingException;
-import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
-import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.resolution.ArtifactDescriptorException;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
-import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionRangeResolutionException;
-import org.eclipse.aether.resolution.VersionRangeResult;
-import org.eclipse.aether.util.version.GenericVersionScheme;
 import org.eclipse.aether.version.InvalidVersionSpecificationException;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class LinkageMonitorTest {
   private RepositorySystem system;
-  private RepositorySystem spySystem;
-  private Path localEmptyRepositoryPath;
-  private DefaultRepositorySystemSession session;
-  private GenericVersionScheme versionScheme = new GenericVersionScheme();
+  private RepositorySystemSession session;
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     system = RepositoryUtility.newRepositorySystem();
 
-    // If possible, spy object should be avoided. But Maven is tightly coupled with RepositorySystem
-    // and thus normal mock objects on RepositorySystem would make the test even complicated.
-    // https://static.javadoc.io/org.mockito/mockito-core/3.0.0/org/mockito/Mockito.html#spy-T-
-    spySystem = spy(system);
-
-    // This session uses an empty directory as Maven local repository so that the test result
-    // is not affected by other Maven artifacts installed locally.
-    session = MavenRepositorySystemUtils.newSession();
-    localEmptyRepositoryPath = Files.createTempDirectory("LinkageMonitorTest").toAbsolutePath();
-    LocalRepository localRepository = new LocalRepository(localEmptyRepositoryPath.toString());
-    session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, localRepository));
-    session.setReadOnly();
-  }
-
-  @After
-  public void cleanup() throws IOException {
-    MoreFiles.deleteRecursively(localEmptyRepositoryPath, RecursiveDeleteOption.ALLOW_INSECURE);
+    session = RepositoryUtility.newSession(system);
   }
 
   private ArtifactResult resolveArtifact(String coordinates) throws ArtifactResolutionException {
@@ -111,68 +79,16 @@ public class LinkageMonitorTest {
   }
 
   @Test
-  public void testFindSnapshotVersion()
-      throws MavenRepositoryException, ModelBuildingException, ArtifactResolutionException {
-    // This version of Guava should be found locally because this module uses it.
-    Bom snapshotBom =
-        LinkageMonitor.copyWithSnapshot(
-            system,
-            session,
-            new Bom(
-                "com.google.guava:guava-bom:27.1-android",
-                ImmutableList.of(new DefaultArtifact("com.google.guava:guava:27.1-android"))));
-    assertNotNull(snapshotBom);
-  }
-
-  @Test
-  public void testFindSnapshotVersionBom()
-      throws MavenRepositoryException, ModelBuildingException, ArtifactResolutionException {
-    // This version of Guava should be found locally because this module uses it.
-    Bom snapshotBom =
-        LinkageMonitor.copyWithSnapshot(
-            system,
-            session,
-            new Bom(
-                "com.google.cloud:libraries-bom:pom:2.2.1",
-                ImmutableList.of(new DefaultArtifact("com.google.guava:guava:27.1-android"))));
-    assertNotNull(snapshotBom);
-  }
-
-  @Test
   public void testBomSnapshot()
-      throws VersionRangeResolutionException, MavenRepositoryException,
-          InvalidVersionSpecificationException, ModelBuildingException, ArtifactResolutionException,
-          ArtifactDescriptorException, IOException {
-    VersionRangeResult protobufSnapshotVersionResult =
-        new VersionRangeResult(new VersionRangeRequest());
-
-    protobufSnapshotVersionResult.setVersions(
-        ImmutableList.of(
-            versionScheme.parseVersion("3.6.0"),
-            versionScheme.parseVersion("3.7.0"),
-            versionScheme.parseVersion("3.8.0-SNAPSHOT")));
-
-    // invocation for protobuf-java to return 3.8.0-SNAPSHOT
-    doReturn(protobufSnapshotVersionResult)
-        .when(spySystem)
-        .resolveVersionRange(
-            any(RepositorySystemSession.class),
-            argThat(request -> "protobuf-java".equals(request.getArtifact().getArtifactId())));
-
-    ArtifactResult protobufJavaResult = resolveArtifact("com.google.protobuf:protobuf-java:3.8.0");
-
-    Artifact protobufJavaSnapshotArtifact =
-        new DefaultArtifact("com.google.protobuf:protobuf-java:3.8.0-SNAPSHOT")
-            .setFile(protobufJavaResult.getArtifact().getFile());
-
-    doReturn(protobufJavaResult.setArtifact(protobufJavaSnapshotArtifact))
-        .when(spySystem)
-        .resolveArtifact(
-            any(RepositorySystemSession.class),
-            argThat(request -> "protobuf-java".equals(request.getArtifact().getArtifactId())));
+      throws ModelBuildingException, ArtifactResolutionException, ArtifactDescriptorException {
 
     Bom bom = RepositoryUtility.readBom("com.google.cloud:libraries-bom:1.2.0");
-    Bom snapshotBom = LinkageMonitor.copyWithSnapshot(spySystem, session, bom);
+    Bom snapshotBom =
+        LinkageMonitor.copyWithSnapshot(
+            system,
+            session,
+            bom,
+            ImmutableMap.of("com.google.protobuf:protobuf-java", "3.8.0-SNAPSHOT"));
 
     assertWithMessage(
             "The first element of the SNAPSHOT BOM should be the same as the original BOM")
@@ -247,10 +163,10 @@ public class LinkageMonitorTest {
 
   @Test
   public void testBuildModelWithSnapshotBom_noSnapshotUpdate()
-      throws MavenRepositoryException, ModelBuildingException, ArtifactResolutionException {
+      throws ModelBuildingException, ArtifactResolutionException {
     Model model =
         LinkageMonitor.buildModelWithSnapshotBom(
-            system, session, "com.google.cloud:libraries-bom:2.2.1");
+            system, session, "com.google.cloud:libraries-bom:2.2.1", ImmutableMap.of());
     List<Dependency> dependencies = model.getDependencyManagement().getDependencies();
 
     assertEquals(
@@ -266,10 +182,11 @@ public class LinkageMonitorTest {
 
   @Test
   public void testBuildModelWithSnapshotBom_invalidCoordinates()
-      throws MavenRepositoryException, ModelBuildingException, ArtifactResolutionException {
+      throws ModelBuildingException, ArtifactResolutionException {
     for (String invalidCoordinates : ImmutableList.of("a.b.c:d", "a:b:c:d:e:1", "a::c:0.1")) {
       try {
-        LinkageMonitor.buildModelWithSnapshotBom(system, session, invalidCoordinates);
+        LinkageMonitor.buildModelWithSnapshotBom(
+            system, session, invalidCoordinates, ImmutableMap.of());
         fail("The method should invalidate coordinates: " + invalidCoordinates);
       } catch (IllegalArgumentException ex) {
         // pass
@@ -279,39 +196,19 @@ public class LinkageMonitorTest {
 
   @Test
   public void testBuildModelWithSnapshotBom_BomSnapshotUpdate()
-      throws MavenRepositoryException, ModelBuildingException, ArtifactResolutionException,
+      throws ModelBuildingException, ArtifactResolutionException,
           InvalidVersionSpecificationException, VersionRangeResolutionException {
     // Linkage Monitor should update a BOM in Google Cloud Libraries BOM when it's available local
     // repository. This test case simulates the issue below where
     // google-cloud-bom:0.106.0-alpha-SNAPSHOT should provide gax:1.48.0.
     // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/853
-
-    VersionRangeResult googleCloudBomVersionRangeResult =
-        new VersionRangeResult(new VersionRangeRequest());
-    googleCloudBomVersionRangeResult.setVersions(
-        ImmutableList.of(
-            versionScheme.parseVersion("0.106.0-alpha"),
-            versionScheme.parseVersion("0.106.0-alpha-SNAPSHOT")));
-
-    doReturn(googleCloudBomVersionRangeResult)
-        .when(spySystem)
-        .resolveVersionRange(
-            any(RepositorySystemSession.class),
-            argThat(request -> "google-cloud-bom".equals(request.getArtifact().getArtifactId())));
-
-    ArtifactResult googleCloudBomResult =
-        resolveArtifact("com.google.cloud:google-cloud-bom:pom:0.106.0-alpha");
-
-    doReturn(googleCloudBomResult)
-        .when(spySystem)
-        .resolveArtifact(
-            any(RepositorySystemSession.class),
-            argThat(request -> "google-cloud-bom".equals(request.getArtifact().getArtifactId())));
-
     // Libraries-bom:2.2.1 has google-cloud-bom:0.91.0-alpha, which has gax:1.44.0
     Model model =
         LinkageMonitor.buildModelWithSnapshotBom(
-            spySystem, session, "com.google.cloud:libraries-bom:2.2.1");
+            system,
+            session,
+            "com.google.cloud:libraries-bom:2.2.1",
+            ImmutableMap.of("com.google.cloud:google-cloud-bom", "0.106.0-alpha"));
     List<Dependency> dependencies = model.getDependencyManagement().getDependencies();
 
     // Google-cloud-bom:0.106.0 has new artifacts such as google-cloud-gameservices
@@ -328,12 +225,35 @@ public class LinkageMonitorTest {
 
   @Test
   public void testBuildModelWithSnapshotBom_JdkVersionActivation()
-      throws MavenRepositoryException, ModelBuildingException, ArtifactResolutionException {
+      throws ModelBuildingException, ArtifactResolutionException {
     // google-cloud-core-parent's parent google-cloud-shared-config uses JDK version to activate
     // a profile. Without JDK system property, this throws ModelBuildingException.
     Model model =
         LinkageMonitor.buildModelWithSnapshotBom(
-            spySystem, session, "com.google.cloud:google-cloud-core-parent:1.91.0");
+            system, session, "com.google.cloud:google-cloud-core-parent:1.91.0", ImmutableMap.of());
     assertNotNull(model);
+  }
+
+  @Test
+  public void testFindLocalArtifacts_currentDirectory() throws ModelBuildingException {
+    // Current working directory of linkage-monitor should have one linkage monitor artifact
+    ImmutableMap<String, String> localArtifacts =
+        LinkageMonitor.findLocalArtifacts(system, session, Paths.get("."));
+
+    Truth.assertThat(localArtifacts).hasSize(1);
+    Truth.assertThat(localArtifacts).containsKey("com.google.cloud.tools:linkage-monitor");
+  }
+
+  @Test
+  public void testFindLocalArtifacts_parentDirectory() throws ModelBuildingException {
+    // Root of cloud-opensource-java has more than 10 pom.xml files
+    ImmutableMap<String, String> localArtifacts =
+        LinkageMonitor.findLocalArtifacts(system, session, Paths.get(".."));
+    Truth.assertThat(localArtifacts.size()).isGreaterThan(10);
+
+    Truth.assertThat(localArtifacts).containsKey("com.google.cloud.tools:linkage-monitor");
+    Truth.assertThat(localArtifacts)
+        .containsAtLeast(
+            "com.google.cloud.tools.opensource:no-such-method-error-example", "1.0-SNAPSHOT");
   }
 }


### PR DESCRIPTION
Fixes #1020 .

With this PR, Linkage Monitor checks current working directory rather than Maven repository. The directory where the tool runs matters; there should not be any `cd` after `mvn install` before Linkage Monitor runs:

- google-cloud-java: OK: https://github.com/googleapis/google-cloud-java/blob/master/.kokoro/linkage-monitor.sh#L33
- google-http-client: OK: https://github.com/googleapis/google-http-java-client/blob/master/.kokoro/linkage-monitor.sh#L33
- protobuf: OK: https://github.com/protocolbuffers/protobuf/blob/master/tests.sh#L271