### PR TITLE
Report errors on unimplemented methods on abstract classes

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -40,7 +40,6 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.logging.Logger;
-import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.FieldOrMethod;
 import org.apache.bcel.classfile.JavaClass;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.logging.Logger;
+import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.FieldOrMethod;
 import org.apache.bcel.classfile.JavaClass;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -148,6 +148,14 @@ public class LinkageChecker {
               if (classSymbol instanceof SuperClassSymbol) {
                 ImmutableList<SymbolProblem> problems =
                     findAbstractParentProblems(classFile, (SuperClassSymbol) classSymbol);
+                if (!problems.isEmpty()) {
+                  String superClassName = classSymbol.getClassName();
+                  Path superClassLocation = classDumper.findClassLocation(superClassName);
+                  ClassFile superClassFile = new ClassFile(superClassLocation, superClassName);
+                  for (SymbolProblem problem : problems) {
+                    problemToClass.put(problem, superClassFile);
+                  }
+                }
               }
               findSymbolProblem(classFile, classSymbol)
                   .ifPresent(problem -> problemToClass.put(problem, classFile.topLevelClassFile()));

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -1002,7 +1002,7 @@ public class LinkageCheckerTest {
   @Test
   public void testFindSymbolProblems_unimplementedAbstractMethod()
       throws RepositoryException, IOException {
-    // Non-abstract NioEventLoopGroup class extends NioEventLoopGroup.
+    // Non-abstract NioEventLoopGroup class extends MultithreadEventLoopGroup.
     // Abstract MultithreadEventLoopGroup class extends MultithreadEventExecutorGroup
     // Abstract MultithreadEventExecutorGroup class has abstract newChild method.
     // Netty version discrepancy between 4.0 and 4.1 causes AbstractMethodError.

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -991,9 +991,12 @@ public class LinkageCheckerTest {
     // CContext$Directives interface. But this should not be reported as an error because the
     // interface has default implementation for the methods.
     String unexpectedClass = "com.oracle.svm.core.LibCHelperDirectives";
-    assertFalse(
-        symbolProblems.keySet().stream()
-            .anyMatch(problem -> problem.getSymbol().getClassName().equals(unexpectedClass)));
+    Truth.assertThat(symbolProblems.keySet())
+        .comparingElementsUsing(
+            Correspondence.transforming(
+                (SymbolProblem problem) -> problem.getSymbol().getClassName(),
+                "has symbol problem on class"))
+        .doesNotContain(unexpectedClass);
   }
 
   @Test
@@ -1045,7 +1048,7 @@ public class LinkageCheckerTest {
 
     // com.oracle.svm.core.genscavenge.PinnedAllocatorImpl extends an abstract class
     // com.oracle.svm.core.heap.PinnedAllocator. The superclass has native methods, such as
-    // newInstance. These native methods should not be reported as unimplemented methods.
+    // "newInstance". These native methods should not be reported as unimplemented methods.
     String unexpectedClass = "com.oracle.svm.core.genscavenge.PinnedAllocatorImpl";
     Truth.assertThat(symbolProblems.keySet())
         .comparingElementsUsing(


### PR DESCRIPTION
Fixes #1052 .

This found new linkage error in our BOM:

![image](https://user-images.githubusercontent.com/28604/70175702-37373000-16a5-11ea-9930-46d18e2e728a.png)

com.google.protobuf:protobuf-java:3.11.0 is in our BOM.
protobuf-lite:3.0.1 is at io.grpc:grpc-protobuf:jar:1.25.0 > io.grpc:grpc-protobuf-lite:jar:1.25.0 > com.google.protobuf:protobuf-lite:jar:3.0.1

