### PR TITLE
Simplify uses of Correspondence

### DIFF
--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -56,9 +56,7 @@ import org.junit.Test;
 public class DashboardTest {
 
   private static final Correspondence<Node, String> NODE_VALUES =
-      Correspondence.from((node, expected) ->
-          trimAndCollapseWhiteSpace(node.getValue())
-          .equals(expected), "has value equal to");
+      Correspondence.transforming(node -> trimAndCollapseWhiteSpace(node.getValue()), "has value");
 
   private static String trimAndCollapseWhiteSpace(String value) {
     return CharMatcher.whitespace().trimAndCollapseFrom(value, ' ');

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -50,11 +50,11 @@ import org.junit.Test;
 
 public class LinkageCheckerTest {
 
-  private static final Correspondence<SymbolProblem, String> HAS_SYMBOL_IN_CLASS = Correspondence
-      .transforming(
-      (SymbolProblem problem) -> problem.getSymbol().getClassName(),
-      "has symbol in class with name");
-  
+  private static final Correspondence<SymbolProblem, String> HAS_SYMBOL_IN_CLASS =
+      Correspondence.transforming(
+          (SymbolProblem problem) -> problem.getSymbol().getClassName(),
+          "has symbol in class with name");
+
   private Path guavaPath;
   private Path firestorePath;
 
@@ -997,8 +997,7 @@ public class LinkageCheckerTest {
     // interface has default implementation for the methods.
     String unexpectedClass = "com.oracle.svm.core.LibCHelperDirectives";
     Truth.assertThat(symbolProblems.keySet())
-        .comparingElementsUsing(
-            HAS_SYMBOL_IN_CLASS)
+        .comparingElementsUsing(HAS_SYMBOL_IN_CLASS)
         .doesNotContain(unexpectedClass);
   }
 
@@ -1032,9 +1031,7 @@ public class LinkageCheckerTest {
             false);
 
     Truth.assertThat(symbolProblems.keySet())
-        .comparingElementsUsing(
-            Correspondence.transforming(
-                SymbolProblem::getSymbol, "has symbol"))
+        .comparingElementsUsing(Correspondence.transforming(SymbolProblem::getSymbol, "has symbol"))
         .contains(expectedMethodSymbol);
   }
 
@@ -1053,8 +1050,7 @@ public class LinkageCheckerTest {
     // "newInstance". These native methods should not be reported as unimplemented methods.
     String unexpectedClass = "com.oracle.svm.core.genscavenge.PinnedAllocatorImpl";
     Truth.assertThat(symbolProblems.keySet())
-        .comparingElementsUsing(
-            HAS_SYMBOL_IN_CLASS)
+        .comparingElementsUsing(HAS_SYMBOL_IN_CLASS)
         .doesNotContain(unexpectedClass);
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -50,6 +50,11 @@ import org.junit.Test;
 
 public class LinkageCheckerTest {
 
+  private static final Correspondence<SymbolProblem, String> HAS_SYMBOL_PROBLEM_ON_CLASS = Correspondence
+      .transforming(
+      (SymbolProblem problem) -> problem.getSymbol().getClassName(),
+      "has symbol in class with name");
+  
   private Path guavaPath;
   private Path firestorePath;
 
@@ -993,9 +998,7 @@ public class LinkageCheckerTest {
     String unexpectedClass = "com.oracle.svm.core.LibCHelperDirectives";
     Truth.assertThat(symbolProblems.keySet())
         .comparingElementsUsing(
-            Correspondence.transforming(
-                (SymbolProblem problem) -> problem.getSymbol().getClassName(),
-                "has symbol problem on class"))
+            HAS_SYMBOL_PROBLEM_ON_CLASS)
         .doesNotContain(unexpectedClass);
   }
 
@@ -1021,7 +1024,7 @@ public class LinkageCheckerTest {
     ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems =
         linkageChecker.findSymbolProblems();
 
-    MethodSymbol expectedMethodSymbolError =
+    MethodSymbol expectedMethodSymbol =
         new MethodSymbol(
             "io.netty.channel.nio.NioEventLoopGroup",
             "newChild",
@@ -1031,9 +1034,8 @@ public class LinkageCheckerTest {
     Truth.assertThat(symbolProblems.keySet())
         .comparingElementsUsing(
             Correspondence.transforming(
-                (SymbolProblem problem) -> problem.getSymbol(),
-                "has symbol problem with method symbol"))
-        .contains(expectedMethodSymbolError);
+                SymbolProblem::getSymbol, "has symbol"))
+        .contains(expectedMethodSymbol);
   }
 
   @Test
@@ -1052,9 +1054,7 @@ public class LinkageCheckerTest {
     String unexpectedClass = "com.oracle.svm.core.genscavenge.PinnedAllocatorImpl";
     Truth.assertThat(symbolProblems.keySet())
         .comparingElementsUsing(
-            Correspondence.transforming(
-                (SymbolProblem problem) -> problem.getSymbol().getClassName(),
-                "has symbol problem on class"))
+            HAS_SYMBOL_PROBLEM_ON_CLASS)
         .doesNotContain(unexpectedClass);
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -50,7 +50,7 @@ import org.junit.Test;
 
 public class LinkageCheckerTest {
 
-  private static final Correspondence<SymbolProblem, String> HAS_SYMBOL_PROBLEM_ON_CLASS = Correspondence
+  private static final Correspondence<SymbolProblem, String> HAS_SYMBOL_IN_CLASS = Correspondence
       .transforming(
       (SymbolProblem problem) -> problem.getSymbol().getClassName(),
       "has symbol in class with name");
@@ -998,7 +998,7 @@ public class LinkageCheckerTest {
     String unexpectedClass = "com.oracle.svm.core.LibCHelperDirectives";
     Truth.assertThat(symbolProblems.keySet())
         .comparingElementsUsing(
-            HAS_SYMBOL_PROBLEM_ON_CLASS)
+            HAS_SYMBOL_IN_CLASS)
         .doesNotContain(unexpectedClass);
   }
 
@@ -1054,7 +1054,7 @@ public class LinkageCheckerTest {
     String unexpectedClass = "com.oracle.svm.core.genscavenge.PinnedAllocatorImpl";
     Truth.assertThat(symbolProblems.keySet())
         .comparingElementsUsing(
-            HAS_SYMBOL_PROBLEM_ON_CLASS)
+            HAS_SYMBOL_IN_CLASS)
         .doesNotContain(unexpectedClass);
   }
 }


### PR DESCRIPTION
A few minor simplifications, including extracting a constant and using `transforming()` instead of `from()`.