### PR TITLE
Show dependency paths to the JAR files in Symbol Problems

### DIFF
--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -630,9 +630,9 @@ public class DashboardMain {
   private static String summaryMessage(
       int dependencyPathCount, List<String> coordinates, DependencyPath examplePath) {
     StringBuilder messageBuilder = new StringBuilder();
-    messageBuilder.append("Artifacts '");
+    messageBuilder.append("Dependency path '");
     messageBuilder.append(Joiner.on(" > ").join(coordinates));
-    messageBuilder.append("' exist in all " + dependencyPathCount + " dependency paths. ");
+    messageBuilder.append("' exists in all " + dependencyPathCount + " dependency paths. ");
     messageBuilder.append("Example path: ");
     messageBuilder.append(examplePath);
     return messageBuilder.toString();

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -24,7 +24,14 @@
     causing linkage errors referenced from
     ${pluralize(referenceCount, "source class", "source classes")}.
   </p>
+  <#assign jarsInProblem = {} >
   <#list problemsToClasses as symbolProblem, sourceClasses>
+    <#if (symbolProblem.getContainingClass())?? >
+      <!-- Freemarker's hash requires the key to be string.
+      https://freemarker.apache.org/docs/app_faq.html#faq_nonstring_keys -->
+      <#assign jarsInProblem = jarsInProblem
+        + { symbolProblem.getContainingClass().getJar().toString() :  symbolProblem.getContainingClass().getJar() } >
+    </#if>
     <p class="jar-linkage-report-cause">${symbolProblem?html}, referenced from ${
       pluralize(sourceClasses?size, "class", "classes")?html}
       <button onclick="toggleSourceClassListVisibility(this)"
@@ -52,6 +59,19 @@
         </#list>
     </ul>
   </#if>
+
+  <#list jarsInProblem?values as jarInProblem>
+    <#if dependencyPathRootCauses[jarInProblem]??>
+      <p class="linkage-check-dependency-paths">${dependencyPathRootCauses[jarInProblem]?html}</p>
+    <#else>
+      <ul class="linkage-check-dependency-paths">
+        <#list jarToDependencyPaths.get(jarInProblem) as dependencyPath >
+          <li>${dependencyPath}</li>
+        </#list>
+      </ul>
+    </#if>
+  </#list>
+
 </#macro>
 
 <#macro formatDependencyNode currentNode parent>

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -56,7 +56,7 @@
 <#macro showDependencyPath dependencyPathRootCauses jarToDependencyPaths jar>
   <#assign dependencyPaths = jarToDependencyPaths.get(jar) />
   <p class="linkage-check-dependency-paths">
-    The following ${plural(dependencyPaths?size, "path", "paths")}  contains ${jar.getFileName()?html}:
+    The following ${plural(dependencyPaths?size, "path contains", "paths contain")} ${jar.getFileName()?html}:
   </p>
 
   <#if dependencyPathRootCauses[jar]?? >

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -27,7 +27,7 @@
   <#assign jarsInProblem = {} >
   <#list problemsToClasses as symbolProblem, sourceClasses>
     <#if (symbolProblem.getContainingClass())?? >
-      <!-- Freemarker's hash requires the key to be string.
+      <!-- Freemarker's hash requires its keys to be string.
       https://freemarker.apache.org/docs/app_faq.html#faq_nonstring_keys -->
       <#assign jarsInProblem = jarsInProblem
         + { symbolProblem.getContainingClass().getJar().toString() :  symbolProblem.getContainingClass().getJar() } >
@@ -46,32 +46,29 @@
       </#list>
     </ul>
   </#list>
+  <#list jarsInProblem?values as jarInProblem>
+    <@showDependencyPath dependencyPathRootCauses jarToDependencyPaths jarInProblem />
+  </#list>
+  <@showDependencyPath dependencyPathRootCauses jarToDependencyPaths jar />
+
+</#macro>
+
+<#macro showDependencyPath dependencyPathRootCauses jarToDependencyPaths jar>
+  <#assign dependencyPaths = jarToDependencyPaths.get(jar) />
   <p class="linkage-check-dependency-paths">
-    The following paths to the jar file from the BOM are found in the dependency tree:
+    The following ${plural(dependencyPaths?size, "path", "paths")}  contains ${jar.getFileName()?html}:
   </p>
+
   <#if dependencyPathRootCauses[jar]?? >
     <p class="linkage-check-dependency-paths">${dependencyPathRootCauses[jar]?html}
     </p>
   <#else>
     <ul class="linkage-check-dependency-paths">
-        <#list jarToDependencyPaths.get(jar) as dependencyPath >
+        <#list dependencyPaths as dependencyPath >
           <li>${dependencyPath}</li>
         </#list>
     </ul>
   </#if>
-
-  <#list jarsInProblem?values as jarInProblem>
-    <#if dependencyPathRootCauses[jarInProblem]??>
-      <p class="linkage-check-dependency-paths">${dependencyPathRootCauses[jarInProblem]?html}</p>
-    <#else>
-      <ul class="linkage-check-dependency-paths">
-        <#list jarToDependencyPaths.get(jarInProblem) as dependencyPath >
-          <li>${dependencyPath}</li>
-        </#list>
-      </ul>
-    </#if>
-  </#list>
-
 </#macro>
 
 <#macro formatDependencyNode currentNode parent>

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -213,12 +213,16 @@ public class DashboardTest {
         .isEqualTo(
             "106 target classes causing linkage errors referenced from 516 source classes.");
 
-    Nodes dependencyPaths = details.query(
-        "//p[@class='linkage-check-dependency-paths'][position()=last()]");
-    Node dependencyPathMessage = dependencyPaths.get(0);
+    Nodes dependencyPaths = details.query("//p[@class='linkage-check-dependency-paths']");
+    Node dependencyPathMessageOnProblem = dependencyPaths.get(dependencyPaths.size() - 2);
     Assert.assertEquals(
-        "The following paths to the jar file from the BOM are found in the dependency tree:",
-        trimAndCollapseWhiteSpace(dependencyPathMessage.getValue()));
+        "The following path contains guava-jdk5-17.0.jar:",
+        trimAndCollapseWhiteSpace(dependencyPathMessageOnProblem.getValue()));
+
+    Node dependencyPathMessageOnSource = dependencyPaths.get(dependencyPaths.size() - 1);
+    Assert.assertEquals(
+        "The following paths contains guava-27.1-android.jar:",
+        trimAndCollapseWhiteSpace(dependencyPathMessageOnSource.getValue()));
     int dependencyPathListSize =
         details.query("//ul[@class='linkage-check-dependency-paths']/li").size();
     Truth.assertWithMessage("The dashboard should not show repetitive dependency paths")

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -221,7 +221,7 @@ public class DashboardTest {
 
     Node dependencyPathMessageOnSource = dependencyPaths.get(dependencyPaths.size() - 1);
     Assert.assertEquals(
-        "The following paths contains guava-27.1-android.jar:",
+        "The following paths contain guava-27.1-android.jar:",
         trimAndCollapseWhiteSpace(dependencyPathMessageOnSource.getValue()));
     int dependencyPathListSize =
         details.query("//ul[@class='linkage-check-dependency-paths']/li").size();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolProblem.java
@@ -65,7 +65,7 @@ public final class SymbolProblem {
    * method returns the outer class.
    */
   @Nullable
-  ClassFile getContainingClass() {
+  public ClassFile getContainingClass() {
     return containingClass;
   }
 


### PR DESCRIPTION
Fixes #1060. 

Screenshot:
![image](https://user-images.githubusercontent.com/28604/70472885-ec9b2680-1a9d-11ea-8e29-a7f1ba3cdca1.png)

The first example of servlet-api shows the benefit of showing an example path. Without the example, we cannot tell where commons-logging is coming from.

> The following paths contains servlet-api-2.3.jar:
> 
> Dependency path 'commons-logging:commons-logging > javax.servlet:servlet-api' exists in all 797 dependency paths. Example path: com.google.http-client:google-http-client:1.33.0 (compile) / org.apache.httpcomponents:httpclient:4.5.10 (compile) / commons-logging:commons-logging:1.2 (compile) / javax.servlet:servlet-api:2.3 (provided, optional)
