### PR TITLE
DependencyGraphBuilder to Respect Exclusion in Dependency

### DIFF
--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -214,20 +214,31 @@ public class DashboardTest {
             "106 target classes causing linkage errors referenced from 516 source classes.");
 
     Nodes dependencyPaths = details.query("//p[@class='linkage-check-dependency-paths']");
-    Node dependencyPathMessageOnProblem = dependencyPaths.get(dependencyPaths.size() - 2);
+    Node dependencyPathMessageOnProblem = dependencyPaths.get(dependencyPaths.size() - 4);
     Assert.assertEquals(
-        "The following path contains guava-jdk5-17.0.jar:",
+        "The following paths contain guava-jdk5-13.0.jar:",
         trimAndCollapseWhiteSpace(dependencyPathMessageOnProblem.getValue()));
 
-    Node dependencyPathMessageOnSource = dependencyPaths.get(dependencyPaths.size() - 1);
+    Node dependencyPathMessageOnSource = dependencyPaths.get(dependencyPaths.size() - 3);
     Assert.assertEquals(
         "The following paths contain guava-27.1-android.jar:",
         trimAndCollapseWhiteSpace(dependencyPathMessageOnSource.getValue()));
     int dependencyPathListSize =
         details.query("//ul[@class='linkage-check-dependency-paths']/li").size();
+
+    Nodes nodesWithPathsSummary = details.query("//p[@class='linkage-check-dependency-paths']");
     Truth.assertWithMessage("The dashboard should not show repetitive dependency paths")
-        .that(dependencyPathListSize)
-        .isLessThan(100);
+        .that(nodesWithPathsSummary)
+        .comparingElementsUsing(
+            Correspondence.<Node, String>transforming(
+                node -> trimAndCollapseWhiteSpace(node.getValue()), "has text"))
+        .contains(
+            "Dependency path 'commons-logging:commons-logging > javax.servlet:servlet-api' exists"
+                + " in all 1337 dependency paths. Example path:"
+                + " com.google.http-client:google-http-client:1.29.1 (compile) /"
+                + " org.apache.httpcomponents:httpclient:4.5.5 (compile) /"
+                + " commons-logging:commons-logging:1.2 (compile) / javax.servlet:servlet-api:2.3"
+                + " (provided, optional)");
   }
 
   @Test

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -311,7 +311,6 @@ public class DependencyGraphBuilder {
         graph.addPath(path);
 
         if (resolveFullDependency && !"system".equals(dependencyNode.getDependency().getScope())) {
-          Artifact dependencyNodeArtifact = dependencyNode.getArtifact();
           try {
             boolean includeProvidedScope =
                 graphTraversalOption == GraphTraversalOption.FULL_DEPENDENCY_WITH_PROVIDED;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -61,7 +61,7 @@ public class DependencyGraphBuilder {
     detectOsProperties().forEach(System::setProperty);
   }
 
-  // caching cuts time by about a factor of 4.
+  // caching cuts time by about a factor of 4. Dependency class's equality includes exclusions.
   private static final Map<Dependency, DependencyNode> cacheWithProvidedScope = new HashMap<>();
   private static final Map<Dependency, DependencyNode> cacheWithoutProvidedScope = new HashMap<>();
 
@@ -130,6 +130,8 @@ public class DependencyGraphBuilder {
         includeProvidedScope ? cacheWithProvidedScope : cacheWithoutProvidedScope;
     Dependency cacheKey = null;
     if (dependencyNodes.size() == 1) {
+      // Cache is only needed for a single artifact resolution. A call with multiple dependencyNodes
+      // will not come again in our usage.
       cacheKey = dependencyNodes.get(0).getDependency();
       if (cache.containsKey(cacheKey)) {
         return cache.get(cacheKey);

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -201,48 +201,4 @@ public class ClassPathBuilderTest {
     List<Path> paths = ClassPathBuilder.artifactsToClasspath(ImmutableList.of(jamonApiArtifact));
     Truth.assertThat(paths).isNotEmpty();
   }
-
-  @Test
-  public void testArtifactToClasspath_reportAggregatedRepositoryException()
-      throws RepositoryException {
-    // jamon has transitive dependency to jmxtools, which does not exist in Maven central
-    Artifact jamonApiArtifact = new DefaultArtifact("com.jamonapi:jamon:2.81");
-    try {
-      ClassPathBuilder.artifactsToClasspath(ImmutableList.of(jamonApiArtifact));
-      Assert.fail();
-    } catch (AggregatedRepositoryException ex) {
-      Assert.assertEquals(
-          "com.google.cloud.tools.opensource.dependencies.AggregatedRepositoryException: "
-              + ex.getMessage(),
-          ex.toString());
-      Assert.assertEquals("There were failure(s) in dependency resolution\n"
-          + "com.jamonapi:jamon:jar:2.81 (compile) / log4j:log4j:jar:1.2.15 (provided) /"
-          + " javax.jms:jms:jar:1.1 (compile): org.eclipse.aether.resolution.DependencyResolutionException: "
-          + "The following artifacts could not be resolved: javax.jms:jms:jar:1.1, "
-          + "com.sun.jdmk:jmxtools:jar:1.2.1, com.sun.jmx:jmxri:jar:1.2.1: "
-          + "Could not transfer artifact javax.jms:jms:jar:1.1 from/to java.net "
-          + "(https://maven-repository.dev.java.net/nonav/repository): "
-          + "Cannot access https://maven-repository.dev.java.net/nonav/repository with type "
-          + "legacy using the available connector factories: BasicRepositoryConnectorFactory\n"
-          + "com.jamonapi:jamon:jar:2.81 (compile) / log4j:log4j:jar:1.2.15 (provided) / "
-          + "com.sun.jdmk:jmxtools:jar:1.2.1 (compile): "
-          + "org.eclipse.aether.resolution.DependencyResolutionException: "
-          + "The following artifacts could not be resolved: javax.jms:jms:jar:1.1, "
-          + "com.sun.jdmk:jmxtools:jar:1.2.1, com.sun.jmx:jmxri:jar:1.2.1: Could not transfer "
-          + "artifact javax.jms:jms:jar:1.1 from/to java.net "
-          + "(https://maven-repository.dev.java.net/nonav/repository): "
-          + "Cannot access https://maven-repository.dev.java.net/nonav/repository with "
-          + "type legacy using the available connector factories: BasicRepositoryConnectorFactory\n"
-          + "com.jamonapi:jamon:jar:2.81 (compile) / log4j:log4j:jar:1.2.15 (provided) / "
-          + "com.sun.jmx:jmxri:jar:1.2.1 (compile):"
-          + " org.eclipse.aether.resolution.DependencyResolutionException: "
-          + "The following artifacts could not be resolved: javax.jms:jms:jar:1.1, "
-          + "com.sun.jdmk:jmxtools:jar:1.2.1, com.sun.jmx:jmxri:jar:1.2.1: Could not transfer "
-          + "artifact javax.jms:jms:jar:1.1 from/to java.net "
-          + "(https://maven-repository.dev.java.net/nonav/repository): Cannot access "
-          + "https://maven-repository.dev.java.net/nonav/repository with type legacy using "
-          + "the available connector factories: BasicRepositoryConnectorFactory\n",
-          ex.getMessage());
-    }
-  }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -140,7 +140,7 @@ public class DependencyGraphBuilderTest {
         .comparingElementsUsing(
             Correspondence.<DependencyPath, String>transforming(
                 dependencyPath -> Artifacts.makeKey(dependencyPath.getLeaf()),
-                "dependency path with its leaf's groupID and artifactID"))
+                "has a leaf with groupID and artifactID"))
         .doesNotContain("com.google.protobuf:protobuf-lite");
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -130,17 +130,17 @@ public class DependencyGraphBuilderTest {
   public void testSetDetectedOsSystemProperties_grpcProtobufExclusion() throws RepositoryException {
     // Grpc-protobuf depends on grpc-protobuf-lite with protobuf-lite exclusion.
     // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1056
-    Artifact nettyArtifact = new DefaultArtifact("io.grpc:grpc-protobuf:1.25.0");
+    Artifact grpcProtobuf = new DefaultArtifact("io.grpc:grpc-protobuf:1.25.0");
 
     DependencyGraph dependencyGraph =
-        DependencyGraphBuilder.getStaticLinkageCheckDependencyGraph(
-            ImmutableList.of(nettyArtifact));
+        DependencyGraphBuilder.getStaticLinkageCheckDependencyGraph(ImmutableList.of(grpcProtobuf));
 
+    Correspondence<DependencyPath, String> pathToArtifactKey =
+        Correspondence.transforming(
+            dependencyPath -> Artifacts.makeKey(dependencyPath.getLeaf()),
+            "has a leaf with groupID and artifactID");
     Truth.assertThat(dependencyGraph.list())
-        .comparingElementsUsing(
-            Correspondence.<DependencyPath, String>transforming(
-                dependencyPath -> Artifacts.makeKey(dependencyPath.getLeaf()),
-                "has a leaf with groupID and artifactID"))
+        .comparingElementsUsing(pathToArtifactKey)
         .doesNotContain("com.google.protobuf:protobuf-lite");
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -60,7 +60,7 @@ public class DependencyGraphBuilderTest {
 
     // This method should find Guava multiple times.
     int guavaCount = countGuava(graph);
-    Assert.assertEquals(31, guavaCount);
+    Assert.assertEquals(30, guavaCount);
   }
 
   private static int countGuava(DependencyGraph graph) {

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
@@ -16,18 +16,16 @@
 
 package com.google.cloud.tools.opensource.dependencies;
 
+import com.google.common.truth.Correspondence;
+import com.google.common.truth.Truth;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.google.common.truth.Correspondence;
-import com.google.common.truth.Truth;
 
 /**
  *  Tests against actual artifacts in Maven central.

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.opensource.dependencies;
 
-import com.google.common.truth.Correspondence;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +26,7 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.google.common.truth.Correspondence;
 import com.google.common.truth.Truth;
 
 /**

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
@@ -16,11 +16,11 @@
 
 package com.google.cloud.tools.opensource.dependencies;
 
+import com.google.common.truth.Correspondence;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -42,34 +42,33 @@ public class DependencyGraphIntegrationTest {
 
     DependencyGraph graph = DependencyGraphBuilder.getCompleteDependencies(core);
     List<Update> updates = graph.findUpdates();
-    List<String> strings = updates.stream().map(e -> e.toString()).collect(Collectors.toList());
 
-    // ordering not working yet
-    // TODO get order working
-    Truth.assertThat(strings).containsExactly("com.google.guava:guava:20.0 needs to "
-        + "upgrade com.google.code.findbugs:jsr305:1.3.9 to 3.0.2",
-        "com.google.http-client:google-http-client:1.23.0 needs to "
-        + "upgrade com.google.code.findbugs:jsr305:1.3.9 to 3.0.2",
-        "com.google.api:api-common:1.6.0 needs to "
-        + "upgrade com.google.code.findbugs:jsr305:3.0.0 to 3.0.2",
-        "com.google.api.grpc:proto-google-common-protos:1.12.0 needs to "
-        + "upgrade com.google.protobuf:protobuf-java:3.5.1 to 3.6.0",
-        "com.google.api.grpc:proto-google-iam-v1:0.12.0 needs to "
-        + "upgrade com.google.protobuf:protobuf-java:3.5.1 to 3.6.0",
-        "com.google.api.grpc:proto-google-iam-v1:0.12.0 needs to "
-        + "upgrade com.google.api.grpc:proto-google-common-protos:1.11.0 to 1.12.0",
-        "com.google.api.grpc:proto-google-iam-v1:0.12.0 needs to "
-        + "upgrade com.google.api:api-common:1.5.0 to 1.6.0",
-        "com.google.api:api-common:1.6.0 needs to "
-        + "upgrade com.google.guava:guava:19.0 to 20.0",
-        "com.google.auth:google-auth-library-oauth2-http:0.9.1 needs to "
-        + "upgrade com.google.guava:guava:19.0 to 20.0",
-        "com.google.protobuf:protobuf-java-util:3.6.0 needs to "
-        + "upgrade com.google.guava:guava:19.0 to 20.0",
-        "com.google.auth:google-auth-library-oauth2-http:0.9.1 needs to "
-        + "upgrade com.google.http-client:google-http-client:1.19.0 to 1.23.0",
-        "com.google.http-client:google-http-client-jackson2:1.19.0 needs to "
-        + "upgrade com.google.http-client:google-http-client:1.19.0 to 1.23.0");
+    Truth.assertThat(updates)
+        .comparingElementsUsing(Correspondence.transforming(Update::toString, "has message"))
+        .containsExactly(
+            "com.google.api.grpc:proto-google-iam-v1:0.12.0 needs to "
+                + "upgrade com.google.api.grpc:proto-google-common-protos:1.11.0 to 1.12.0",
+            "com.google.api.grpc:proto-google-iam-v1:0.12.0 needs to "
+                + "upgrade com.google.api:api-common:1.5.0 to 1.6.0",
+            "com.google.guava:guava:20.0 needs to "
+                + "upgrade com.google.code.findbugs:jsr305:1.3.9 to 3.0.2",
+            "com.google.api:api-common:1.6.0 needs to "
+                + "upgrade com.google.code.findbugs:jsr305:3.0.0 to 3.0.2",
+            "com.google.api:api-common:1.6.0 needs to "
+                + "upgrade com.google.guava:guava:19.0 to 20.0",
+            "com.google.protobuf:protobuf-java-util:3.6.0 needs to "
+                + "upgrade com.google.guava:guava:19.0 to 20.0",
+            "com.google.auth:google-auth-library-oauth2-http:0.9.1 needs to "
+                + "upgrade com.google.guava:guava:19.0 to 20.0",
+            "com.google.auth:google-auth-library-oauth2-http:0.9.1 needs to "
+                + "upgrade com.google.http-client:google-http-client:1.19.0 to 1.23.0",
+            "com.google.http-client:google-http-client-jackson2:1.19.0 needs to "
+                + "upgrade com.google.http-client:google-http-client:1.19.0 to 1.23.0",
+            "com.google.api.grpc:proto-google-common-protos:1.12.0 needs to "
+                + "upgrade com.google.protobuf:protobuf-java:3.5.1 to 3.6.0",
+            "com.google.api.grpc:proto-google-iam-v1:0.12.0 needs to "
+                + "upgrade com.google.protobuf:protobuf-java:3.5.1 to 3.6.0")
+        .inOrder();
   }
 
   // Beam has a more complex dependency graph that hits some corner cases.


### PR DESCRIPTION
Fixes #799 .
Fixes #1056 . With this PR, The dashboard stops showing the protobuf-lite linkage errors.

DependencyGraphBuilder to use DependencyNode, which has exclusions information as well as Artifact.

# Difference in the Dashboard

The number of the upper bounds errors decreased. The number of artifacts failing to converge decreased.

![image](https://user-images.githubusercontent.com/28604/70647654-73274380-1c17-11ea-8eec-2af01e80193a.png)




## Difference in dependency convergence. Example in grpc-alts:
![image](https://user-images.githubusercontent.com/28604/70646879-d2845400-1c15-11ea-999c-6caf6833faad.png)

## New Linkage Errors

Because Netty's dependency on `com.oracle.substratevm:svm` excludes unnecessary artifacts ([link](https://search.maven.org/artifact/io.netty/netty-common/4.1.42.Final/jar)), the dashboard now shows these missing classes as linkage errors. 

![image](https://user-images.githubusercontent.com/28604/70647188-61916c00-1c16-11ea-86d4-df4983f00f30.png)

I ran LinkageCheckerMain of this snapshot version against Apache Beam and did not see problem caused by exclusions. 