### PR TITLE
Skip corrupt class file in JAR rather than stopping

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -149,24 +149,19 @@ class ClassDumper {
   /**
    * Returns a map from classes to the symbol references they contain.
    */
-  SymbolReferenceMaps findSymbolReferences() {
+  SymbolReferenceMaps findSymbolReferences() throws IOException {
     SymbolReferenceMaps.Builder builder = new SymbolReferenceMaps.Builder();
 
     for (Path jar : inputClassPath) {
-      try {
-        for (JavaClass javaClass : listClasses(jar)) {
-          if (!isCompatibleClassFileVersion(javaClass)) {
-            continue;
-          }
-          String className = javaClass.getClassName();
-          // In listClasses(jar), ClassPathRepository creates JavaClass through the first JAR file
-          // that contains the class. It may be different from "jar" for an overlapping class.
-          ClassFile source = new ClassFile(findClassLocation(className), className);
-          builder.addAll(findSymbolReferences(source, javaClass));
+      for (JavaClass javaClass : listClasses(jar)) {
+        if (!isCompatibleClassFileVersion(javaClass)) {
+          continue;
         }
-      } catch (IOException ex) {
-        // For example, when a JAR file contains an unexpected lock file
-        logger.warning("Skipped JAR file " + jar + ": " + ex.getMessage());
+        String className = javaClass.getClassName();
+        // In listClasses(jar), ClassPathRepository creates JavaClass through the first JAR file
+        // that contains the class. It may be different from "jar" for an overlapping class.
+        ClassFile source = new ClassFile(findClassLocation(className), className);
+        builder.addAll(findSymbolReferences(source, javaClass));
       }
     }
 
@@ -390,6 +385,9 @@ class ClassDumper {
    */
   private ImmutableSet<JavaClass> listClasses(Path jar) throws IOException {
     ImmutableSet.Builder<JavaClass> javaClasses = ImmutableSet.builder();
+
+    ImmutableList.Builder<String> corruptedClassFileNames = ImmutableList.builder();
+
     for (String classFileName : listClassFileNames(jar)) {
       if (classFileName.startsWith("META-INF.versions.")) {
         // Linkage Checker does not support multi-release JAR (for Java 9+) yet
@@ -402,7 +400,7 @@ class ClassDumper {
         javaClasses.add(javaClass);
       } catch (ClassNotFoundException ex) {
         // We couldn't find the class in the jar file where we found it.
-        throw new IOException("Corrupt jar file " + jar + "; could not load " + classFileName, ex);
+        corruptedClassFileNames.add(classFileName);
       } catch (ClassFormatException ex) {
         // We couldn't load the class from the jar file where we found it.
         throw new IOException(
@@ -414,6 +412,19 @@ class ClassDumper {
                 + ex.getMessage(),
             ex);
       }
+    }
+
+    ImmutableList<String> corruptedFiles = corruptedClassFileNames.build();
+    int corruptedFileCount = corruptedFiles.size();
+    if (corruptedFileCount > 0) {
+      logger.warning(
+          "Corrupt files in "
+              + jar
+              + "; could not load "
+              + corruptedFiles.get(0)
+              + (corruptedFileCount > 1
+                  ? " and other " + (corruptedFileCount - 1) + " files"
+                  : ""));
     }
     return javaClasses.build();
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -401,16 +401,6 @@ class ClassDumper {
       } catch (ClassNotFoundException ex) {
         // We couldn't find the class in the jar file where we found it.
         corruptedClassFileNames.add(classFileName);
-      } catch (ClassFormatException ex) {
-        // We couldn't load the class from the jar file where we found it.
-        throw new IOException(
-            "Corrupt jar file "
-                + jar
-                + "; could not load "
-                + classFileName
-                + "; "
-                + ex.getMessage(),
-            ex);
       }
     }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -375,9 +375,17 @@ public class ClassDumperTest {
     Artifact kinesisClient = new DefaultArtifact("com.amazonaws:amazon-kinesis-client:1.13.0");
     List<Path> paths = ClassPathBuilder.artifactsToClasspath(ImmutableList.of(kinesisClient));
     ClassDumper classDumper = ClassDumper.create(paths);
+    Path kinesisJar = paths.get(0);
 
     // This should not raise IOException
     SymbolReferenceMaps symbolReferences = classDumper.findSymbolReferences();
     assertNotNull(symbolReferences);
+
+    Truth.assertWithMessage("Invalid files should not stop loading valid class files")
+        .that(symbolReferences.getClassToClassSymbols().keySet())
+        .comparingElementsUsing(
+            Correspondence.transforming(
+                (ClassFile classFile) -> classFile.getJar(), "is in the JAR file"))
+        .contains(kinesisJar);
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.opensource.classpath;
 
 import static com.google.cloud.tools.opensource.classpath.TestHelper.absolutePathOfResource;
+import static org.junit.Assert.assertNotNull;
 
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
@@ -313,7 +314,8 @@ public class ClassDumperTest {
             ImmutableList.of(absolutePathOfResource("testdata/conscrypt-openjdk-uber-1.4.2.jar")));
 
     try {
-      classDumper.isUnusedClassSymbolReference("org.conscrypt.Conscrypt", new ClassSymbol("dummy.NoSuchClass"));
+      classDumper.isUnusedClassSymbolReference(
+          "org.conscrypt.Conscrypt", new ClassSymbol("dummy.NoSuchClass"));
 
       Assert.fail("It should throw VerifyException when it cannot find a class symbol reference");
     } catch (VerifyException ex) {
@@ -363,5 +365,19 @@ public class ClassDumperTest {
         .doesNotContain(
             new ClassFile(
                 sisuGuicePath, "com.google.inject.internal.InjectorImpl$BindingsMultimap"));
+  }
+
+  @Test
+  public void testListClasses_unexpectedNonClassFile() throws RepositoryException, IOException {
+    // com.amazonaws:amazon-kinesis-client:1.13.0 contains an unexpected lock file
+    // /unison/com/e007f77498fd27177e2ea931a06dcf50/unison/tmp/amazonaws/services/kinesis/leases/impl/LeaseTaker.class
+    // https://github.com/awslabs/amazon-kinesis-client/issues/654
+    Artifact kinesisClient = new DefaultArtifact("com.amazonaws:amazon-kinesis-client:1.13.0");
+    List<Path> paths = ClassPathBuilder.artifactsToClasspath(ImmutableList.of(kinesisClient));
+    ClassDumper classDumper = ClassDumper.create(paths);
+
+    // This should not raise IOException
+    SymbolReferenceMaps symbolReferences = classDumper.findSymbolReferences();
+    assertNotNull(symbolReferences);
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -379,7 +379,6 @@ public class ClassDumperTest {
 
     // This should not raise IOException
     SymbolReferenceMaps symbolReferences = classDumper.findSymbolReferences();
-    assertNotNull(symbolReferences);
 
     Truth.assertWithMessage("Invalid files should not stop loading valid class files")
         .that(symbolReferences.getClassToClassSymbols().keySet())


### PR DESCRIPTION
Fixes #1048 .

Initially I thought outputting warning message per file but it turned out there are many of them (220) in the artifact. Now the implementation outputs one warning per JAR file:

```
Jan 07, 2020 1:33:51 PM com.google.cloud.tools.opensource.classpath.ClassDumper listClasses
WARNING: Corrupt jar file /usr/local/google/home/suztomo/.m2/repository/com/amazonaws/amazon-kinesis-client/1.13.0/amazon-kinesis-client-1.13.0.jar; could not load .unison.com.e007f77498fd27177e2ea931a06dcf50.unison.tmp.amazonaws.services.kinesis.leases.impl.LeaseTaker and other 219 files

```