### PR TITLE
ClassDumper to handle the case of missing outer class

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -541,7 +541,13 @@ class ClassDumper {
 
       String outerClassName = outerClassName(sourceJavaClass);
       if (outerClassName != null) {
-        return catchesLinkageError(outerClassName);
+        try {
+          return catchesLinkageError(outerClassName);
+        } catch (ClassFormatException ex) {
+          // When the outer class of an inner class does not exist in the class path, we cannot
+          // say that the classes catch linkage errors.
+          return false;
+        }
       } else {
         // The source class does not have a method that catches NoClassDefFoundError
         return false;


### PR DESCRIPTION
Fixes #1092 

With this change, the missing TypeToken is reported as below, rather than aborting with the exception.

```
Class com.google.common.reflect.TypeToken is not found;
  referenced by 6 class files
    org.apache.curator.shaded.com.google.common.eventbus.SubscriberRegistry (curator-client-4.2.0.jar)
    org.apache.curator.shaded.com.google.common.reflect.Element (curator-client-4.2.0.jar)
    org.apache.curator.shaded.com.google.common.reflect.ImmutableTypeToInstanceMap (curator-client-4.2.0.jar)
    org.apache.curator.shaded.com.google.common.reflect.Invokable (curator-client-4.2.0.jar)
    org.apache.curator.shaded.com.google.common.reflect.MutableTypeToInstanceMap (curator-client-4.2.0.jar)
    org.apache.curator.shaded.com.google.common.reflect.TypeToken (curator-client-4.2.0.jar)
```