### PR TITLE
Class to represent errors in Maven artifact

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
@@ -17,6 +17,7 @@ package com.google.cloud.tools.opensource.dependencies;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.eclipse.aether.artifact.Artifact;
@@ -37,5 +38,9 @@ public abstract class ArtifactProblem {
   protected ArtifactProblem(Artifact artifact, List<DependencyNode> dependencyPath) {
     this.artifact = checkNotNull(artifact);
     this.dependencyPath = ImmutableList.copyOf(dependencyPath);
+  }
+
+  protected String getPath() {
+    return Joiner.on(" > ").join(dependencyPath);
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
@@ -90,7 +90,7 @@ public final class ArtifactProblem {
   }
 
   private enum Type {
-    /** When the JAR file of the artifact contains one or more invalid class files. */
+    /** When the JAR file of the artifact contains invalid class files. */
     INVALID_CLASS_FILE,
     /** When the artifact is unresolvable. */
     UNRESOLVABLE_ARTIFACT,

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
@@ -27,39 +27,23 @@ import org.eclipse.aether.graph.DependencyNode;
 /** Problem in a Maven artifact. */
 public final class ArtifactProblem {
 
+  /** The Maven artifact that has the problem. */
   private final Artifact artifact;
 
-  private final ImmutableList<DependencyNode> dependencyPath;
-
+  /** The type of the problem in the artifact. */
   private final Type type;
 
+  /**
+   * The dependency path to the artifact from the root of the dependency tree. An empty list if the
+   * path is unknown.
+   */
+  private final ImmutableList<DependencyNode> dependencyPath;
+
+  /**
+   * The list of invalid class files if type is {@link Type#INVALID_CLASS_FILE}; otherwise an empty
+   * list.
+   */
   private final ImmutableList<String> classFileNames;
-
-  /** The artifact that has the problem. */
-  private Artifact getArtifact() {
-    return artifact;
-  }
-
-  /**
-   * Returns the dependency path to the artifact in the root of the dependency tree. An empty list
-   * if dependency path is unknown.
-   */
-  private ImmutableList<DependencyNode> getDependencyPath() {
-    return dependencyPath;
-  }
-
-  /** Returns the type of the problem in the artifact. */
-  private Type getType() {
-    return type;
-  }
-
-  /**
-   * Returns the list of invalid class files if type is {@link Type#INVALID_CLASS_FILE}; otherwise
-   * an empty list.
-   */
-  private ImmutableList<String> getClassFileNames() {
-    return classFileNames;
-  }
 
   /**
    * Returns the problem describing the artifact at the leaf of {@code dependencyPath} is not
@@ -106,7 +90,9 @@ public final class ArtifactProblem {
   }
 
   private enum Type {
+    /** When the JAR file of the artifact contains one or more invalid class files. */
     INVALID_CLASS_FILE,
+    /** When the artifact is unresolvable. */
     UNRESOLVABLE_ARTIFACT,
   }
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.tools.opensource.dependencies;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.graph.DependencyNode;
+
+/** Problem in a Maven artifact. */
+public final class ArtifactProblem {
+
+  private final Artifact artifact;
+
+  private final ImmutableList<DependencyNode> dependencyPath;
+
+  private final Type type;
+
+  private final ImmutableList<String> classFileNames;
+
+  /** The artifact that has the problem. */
+  private Artifact getArtifact() {
+    return artifact;
+  }
+
+  /**
+   * Returns the dependency path to the artifact in the root of the dependency tree. An empty list
+   * if dependency path is unknown.
+   */
+  private ImmutableList<DependencyNode> getDependencyPath() {
+    return dependencyPath;
+  }
+
+  /** Returns the type of the problem in the artifact. */
+  private Type getType() {
+    return type;
+  }
+
+  /**
+   * Returns the list of invalid class files if type is {@link Type#INVALID_CLASS_FILE}; otherwise
+   * an empty list.
+   */
+  private ImmutableList<String> getClassFileNames() {
+    return classFileNames;
+  }
+
+  /**
+   * Returns the problem describing the artifact at the leaf of {@code dependencyPath} is not
+   * resolvable by Maven.
+   */
+  public static ArtifactProblem unresolvableArtifact(List<DependencyNode> dependencyPath) {
+    checkNotNull(dependencyPath);
+    checkArgument(dependencyPath.size() > 0, "dependencyPath should not be empty");
+
+    DependencyNode lastElement = dependencyPath.get(dependencyPath.size() - 1);
+    return new ArtifactProblem(
+        Type.UNRESOLVABLE_ARTIFACT, lastElement.getArtifact(), dependencyPath, ImmutableList.of());
+  }
+
+  /**
+   * Returns the problem describing the artifact is not resolvable by Maven. This method is used
+   * when the dependency path to the artifact in the dependency tree is unknown.
+   */
+  public static ArtifactProblem unresolvableArtifactUnknownDependencyPath(Artifact artifact) {
+    return new ArtifactProblem(
+        Type.UNRESOLVABLE_ARTIFACT, artifact, ImmutableList.of(), ImmutableList.of());
+  }
+
+  /** Returns the problems describing the artifact contains invalid class files. */
+  public static ArtifactProblem invalidClassFileInArtifact(
+      List<DependencyNode> dependencyPath, List<String> classFileNames) {
+    checkNotNull(dependencyPath);
+    checkArgument(!dependencyPath.isEmpty(), "dependencyPath should not be empty");
+
+    DependencyNode lastElement = dependencyPath.get(dependencyPath.size() - 1);
+    return new ArtifactProblem(
+        Type.INVALID_CLASS_FILE, lastElement.getArtifact(), dependencyPath, classFileNames);
+  }
+
+  private ArtifactProblem(
+      Type type,
+      Artifact artifact,
+      @Nullable List<DependencyNode> dependencyPath,
+      List<String> classFileNames) {
+    this.type = checkNotNull(type);
+    this.artifact = checkNotNull(artifact);
+    this.dependencyPath = ImmutableList.copyOf(dependencyPath);
+    this.classFileNames = ImmutableList.copyOf(classFileNames);
+  }
+
+  private enum Type {
+    INVALID_CLASS_FILE,
+    UNRESOLVABLE_ARTIFACT,
+  }
+
+  @Override
+  public String toString() {
+    switch (type) {
+      case UNRESOLVABLE_ARTIFACT:
+        if (dependencyPath.isEmpty()) {
+          return artifact + " was not resolved. Dependency path is unknown.";
+        } else {
+          return artifact + " was not resolved. Dependency path: " + dependencyPath;
+        }
+      case INVALID_CLASS_FILE:
+        int classFileCount = classFileNames.size();
+
+        String classFileDescription;
+        if (classFileCount == 1) {
+          classFileDescription = "an invalid class file " + classFileNames.get(0) + ".";
+        } else {
+          classFileDescription =
+              classFileCount + " invalid class files (example: " + classFileNames.get(0) + ").";
+        }
+        return artifact
+            + " contains "
+            + classFileDescription
+            + " Dependency path: "
+            + dependencyPath;
+    }
+    throw new IllegalStateException("Unexpected type " + type + " to describe artifact problem");
+  }
+}

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
@@ -15,112 +15,27 @@
  */
 package com.google.cloud.tools.opensource.dependencies;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
-import javax.annotation.Nullable;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.graph.DependencyNode;
 
-/** Problem in a Maven artifact. */
-public final class ArtifactProblem {
+/** Problem in a Maven artifact in a dependency tree. */
+public abstract class ArtifactProblem {
 
   /** The Maven artifact that has the problem. */
-  private final Artifact artifact;
-
-  /** The type of the problem in the artifact. */
-  private final Type type;
+  protected final Artifact artifact;
 
   /**
    * The dependency path to the artifact from the root of the dependency tree. An empty list if the
    * path is unknown.
    */
-  private final ImmutableList<DependencyNode> dependencyPath;
+  protected final ImmutableList<DependencyNode> dependencyPath;
 
-  /**
-   * The list of invalid class files if type is {@link Type#INVALID_CLASS_FILE}; otherwise an empty
-   * list.
-   */
-  private final ImmutableList<String> classFileNames;
-
-  /**
-   * Returns the problem describing the artifact at the leaf of {@code dependencyPath} is not
-   * resolvable by Maven.
-   */
-  public static ArtifactProblem unresolvableArtifact(List<DependencyNode> dependencyPath) {
-    checkNotNull(dependencyPath);
-    checkArgument(dependencyPath.size() > 0, "dependencyPath should not be empty");
-
-    DependencyNode lastElement = dependencyPath.get(dependencyPath.size() - 1);
-    return new ArtifactProblem(
-        Type.UNRESOLVABLE_ARTIFACT, lastElement.getArtifact(), dependencyPath, ImmutableList.of());
-  }
-
-  /**
-   * Returns the problem describing the artifact is not resolvable by Maven. This method is used
-   * when the dependency path to the artifact in the dependency tree is unknown.
-   */
-  public static ArtifactProblem unresolvableArtifactUnknownDependencyPath(Artifact artifact) {
-    return new ArtifactProblem(
-        Type.UNRESOLVABLE_ARTIFACT, artifact, ImmutableList.of(), ImmutableList.of());
-  }
-
-  /** Returns the problems describing the artifact contains invalid class files. */
-  public static ArtifactProblem invalidClassFileInArtifact(
-      List<DependencyNode> dependencyPath, List<String> classFileNames) {
-    checkNotNull(dependencyPath);
-    checkArgument(!dependencyPath.isEmpty(), "dependencyPath should not be empty");
-
-    DependencyNode lastElement = dependencyPath.get(dependencyPath.size() - 1);
-    return new ArtifactProblem(
-        Type.INVALID_CLASS_FILE, lastElement.getArtifact(), dependencyPath, classFileNames);
-  }
-
-  private ArtifactProblem(
-      Type type,
-      Artifact artifact,
-      @Nullable List<DependencyNode> dependencyPath,
-      List<String> classFileNames) {
-    this.type = checkNotNull(type);
+  protected ArtifactProblem(Artifact artifact, List<DependencyNode> dependencyPath) {
     this.artifact = checkNotNull(artifact);
     this.dependencyPath = ImmutableList.copyOf(dependencyPath);
-    this.classFileNames = ImmutableList.copyOf(classFileNames);
-  }
-
-  private enum Type {
-    /** When the JAR file of the artifact contains invalid class files. */
-    INVALID_CLASS_FILE,
-    /** When the artifact is unresolvable. */
-    UNRESOLVABLE_ARTIFACT,
-  }
-
-  @Override
-  public String toString() {
-    switch (type) {
-      case UNRESOLVABLE_ARTIFACT:
-        if (dependencyPath.isEmpty()) {
-          return artifact + " was not resolved. Dependency path is unknown.";
-        } else {
-          return artifact + " was not resolved. Dependency path: " + dependencyPath;
-        }
-      case INVALID_CLASS_FILE:
-        int classFileCount = classFileNames.size();
-
-        String classFileDescription;
-        if (classFileCount == 1) {
-          classFileDescription = "an invalid class file " + classFileNames.get(0) + ".";
-        } else {
-          classFileDescription =
-              classFileCount + " invalid class files (example: " + classFileNames.get(0) + ").";
-        }
-        return artifact
-            + " contains "
-            + classFileDescription
-            + " Dependency path: "
-            + dependencyPath;
-    }
-    throw new IllegalStateException("Unexpected type " + type + " to describe artifact problem");
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.google.cloud.tools.opensource.dependencies;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/InvalidClassFileProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/InvalidClassFileProblem.java
@@ -29,7 +29,7 @@ public final class InvalidClassFileProblem extends ArtifactProblem {
 
   InvalidClassFileProblem(List<DependencyNode> dependencyPath, List<String> classFileNames) {
     super(dependencyPath.get(dependencyPath.size() - 1).getArtifact(), dependencyPath);
-    checkArgument(!classFileNames.isEmpty(), "ClassFileNames should not be empty");
+    checkArgument(!classFileNames.isEmpty(), "ClassFileNames cannot be empty");
     this.classFileNames = ImmutableList.copyOf(classFileNames);
   }
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/InvalidClassFileProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/InvalidClassFileProblem.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.dependencies;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.eclipse.aether.graph.DependencyNode;
+
+/** Problem describing a Maven artifact containing invalid class files. */
+public final class InvalidClassFileProblem extends ArtifactProblem {
+  /** The invalid class file names. Never empty. */
+  private final ImmutableList<String> classFileNames;
+
+  InvalidClassFileProblem(List<DependencyNode> dependencyPath, List<String> classFileNames) {
+    super(dependencyPath.get(dependencyPath.size() - 1).getArtifact(), dependencyPath);
+    checkArgument(!classFileNames.isEmpty(), "ClassFileNames should not be empty");
+    this.classFileNames = ImmutableList.copyOf(classFileNames);
+  }
+
+  @Override
+  public String toString() {
+    int classFileCount = classFileNames.size();
+
+    String classFileDescription;
+    if (classFileCount == 1) {
+      classFileDescription = "an invalid class file " + classFileNames.get(0) + ".";
+    } else {
+      classFileDescription =
+          classFileCount + " invalid class files (example: " + classFileNames.get(0) + ").";
+    }
+    return artifact + " contains " + classFileDescription + " Dependency path: " + dependencyPath;
+  }
+}

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/InvalidClassFileProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/InvalidClassFileProblem.java
@@ -44,6 +44,6 @@ public final class InvalidClassFileProblem extends ArtifactProblem {
       classFileDescription =
           classFileCount + " invalid class files (example: " + classFileNames.get(0) + ").";
     }
-    return artifact + " contains " + classFileDescription + " Dependency path: " + dependencyPath;
+    return artifact + " contains " + classFileDescription + " Dependency path: " + getPath();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/UnresolvableArtifactProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/UnresolvableArtifactProblem.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.dependencies;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.graph.DependencyNode;
+
+/** Problem describing unresolvable Maven artifact in a dependency tree. */
+public final class UnresolvableArtifactProblem extends ArtifactProblem {
+
+  /**
+   * Maven cannot resolve {@code artifact} in a dependency tree.
+   *
+   * <p>Prefer {@link #UnresolvableArtifactProblem(List)} when the dependency path to the artifact,
+   * because it gives a more detailed error message.
+   */
+  public UnresolvableArtifactProblem(Artifact artifact) {
+    super(artifact, ImmutableList.of());
+  }
+
+  /**
+   * Maven cannot resolve the artifact at the leaf of {@code dependencyPath} in a dependency tree.
+   */
+  public UnresolvableArtifactProblem(List<DependencyNode> dependencyPath) {
+    super(dependencyPath.get(dependencyPath.size() - 1).getArtifact(), dependencyPath);
+  }
+
+  @Override
+  public String toString() {
+    if (dependencyPath.isEmpty()) {
+      return artifact + " was not resolved. Dependency path is unknown.";
+    } else {
+      return artifact + " was not resolved. Dependency path: " + dependencyPath;
+    }
+  }
+}

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/UnresolvableArtifactProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/UnresolvableArtifactProblem.java
@@ -46,7 +46,7 @@ public final class UnresolvableArtifactProblem extends ArtifactProblem {
     if (dependencyPath.isEmpty()) {
       return artifact + " was not resolved. Dependency path is unknown.";
     } else {
-      return artifact + " was not resolved. Dependency path: " + dependencyPath;
+      return artifact + " was not resolved. Dependency path: " + getPath();
     }
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/UnresolvableArtifactProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/UnresolvableArtifactProblem.java
@@ -25,17 +25,18 @@ import org.eclipse.aether.graph.DependencyNode;
 public final class UnresolvableArtifactProblem extends ArtifactProblem {
 
   /**
-   * Maven cannot resolve {@code artifact} in a dependency tree.
+   * Problem when Maven cannot resolve {@code artifact} in a dependency tree.
    *
-   * <p>Prefer {@link #UnresolvableArtifactProblem(List)} when the dependency path to the artifact,
-   * because it gives a more detailed error message.
+   * <p>Prefer {@link #UnresolvableArtifactProblem(List)} when the dependency path to the artifact
+   * is available, because it gives a more detailed error message.
    */
   public UnresolvableArtifactProblem(Artifact artifact) {
     super(artifact, ImmutableList.of());
   }
 
   /**
-   * Maven cannot resolve the artifact at the leaf of {@code dependencyPath} in a dependency tree.
+   * Problem when Maven cannot resolve the artifact at the leaf of {@code dependencyPath} in a
+   * dependency tree.
    */
   public UnresolvableArtifactProblem(List<DependencyNode> dependencyPath) {
     super(dependencyPath.get(dependencyPath.size() - 1).getArtifact(), dependencyPath);

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ArtifactProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ArtifactProblemTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.tools.opensource.classpath;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.cloud.tools.opensource.dependencies.ArtifactProblem;
+import com.google.common.collect.ImmutableList;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.DependencyNode;
+import org.junit.Test;
+
+public class ArtifactProblemTest {
+  private Artifact artifactA = new DefaultArtifact("foo:a:1.0.0");
+  private DependencyNode nodeA = new DefaultDependencyNode(artifactA);
+  private Artifact artifactB = new DefaultArtifact("foo:b:1.0.0");
+  private DependencyNode nodeB = new DefaultDependencyNode(artifactA);
+  private Artifact artifactC = new DefaultArtifact("foo:b:1.0.0");
+  private DependencyNode nodeC = new DefaultDependencyNode(artifactA);
+
+  @Test
+  public void testToString_oneInvalidClassFileInArtifact() {
+    ArtifactProblem problemOneClass =
+        ArtifactProblem.invalidClassFileInArtifact(
+            ImmutableList.of(nodeA, nodeB, nodeC), ImmutableList.of("foo.bar.Class"));
+
+    assertEquals(
+        "foo:a:jar:1.0.0 contains an invalid class file foo.bar.Class. "
+            + "Dependency path: [foo:a:jar:1.0.0, foo:a:jar:1.0.0, foo:a:jar:1.0.0]",
+        problemOneClass.toString());
+  }
+
+  @Test
+  public void testToString_invalidClassFilesInArtifact() {
+    ArtifactProblem problemTwoClasses =
+        ArtifactProblem.invalidClassFileInArtifact(
+            ImmutableList.of(nodeA, nodeB, nodeC),
+            ImmutableList.of("foo.bar.Class1", "foo.bar.Class2"));
+
+    assertEquals(
+        "foo:a:jar:1.0.0 contains 2 invalid class files (example: foo.bar.Class1). "
+            + "Dependency path: [foo:a:jar:1.0.0, foo:a:jar:1.0.0, foo:a:jar:1.0.0]",
+        problemTwoClasses.toString());
+  }
+
+  @Test
+  public void testToString_unresolvableArtifactWithoutDependencyPath() {
+    ArtifactProblem problem = ArtifactProblem.unresolvableArtifactUnknownDependencyPath(artifactA);
+
+    assertEquals(
+        "foo:a:jar:1.0.0 was not resolved. Dependency path is unknown.", problem.toString());
+  }
+
+  @Test
+  public void testToString_unresolvableArtifact() {
+    ArtifactProblem problem =
+        ArtifactProblem.unresolvableArtifact(ImmutableList.of(nodeA, nodeB, nodeC));
+
+    assertEquals(
+        "foo:a:jar:1.0.0 was not resolved. Dependency path: [foo:a:jar:1.0.0, "
+            + "foo:a:jar:1.0.0, foo:a:jar:1.0.0]",
+        problem.toString());
+  }
+}

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/InvalidClassFileProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/InvalidClassFileProblemTest.java
@@ -68,6 +68,7 @@ public class InvalidClassFileProblemTest {
       fail("The constructor should invalidate empty classFileNames");
     } catch (IllegalArgumentException ex) {
       // pass
+      assertEquals("ClassFileNames cannot be empty", ex.getMessage());
     }
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/InvalidClassFileProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/InvalidClassFileProblemTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.google.cloud.tools.opensource.dependencies;
 
 import static org.junit.Assert.assertEquals;

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/InvalidClassFileProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/InvalidClassFileProblemTest.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.tools.opensource.classpath;
+package com.google.cloud.tools.opensource.dependencies;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
-import com.google.cloud.tools.opensource.dependencies.ArtifactProblem;
 import com.google.common.collect.ImmutableList;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -25,18 +25,18 @@ import org.eclipse.aether.graph.DefaultDependencyNode;
 import org.eclipse.aether.graph.DependencyNode;
 import org.junit.Test;
 
-public class ArtifactProblemTest {
+public class InvalidClassFileProblemTest {
   private Artifact artifactA = new DefaultArtifact("foo:a:1.0.0");
   private DependencyNode nodeA = new DefaultDependencyNode(artifactA);
   private Artifact artifactB = new DefaultArtifact("foo:b:1.0.0");
   private DependencyNode nodeB = new DefaultDependencyNode(artifactA);
-  private Artifact artifactC = new DefaultArtifact("foo:b:1.0.0");
+  private Artifact artifactC = new DefaultArtifact("foo:c:1.0.0");
   private DependencyNode nodeC = new DefaultDependencyNode(artifactA);
 
   @Test
   public void testToString_oneInvalidClassFileInArtifact() {
-    ArtifactProblem problemOneClass =
-        ArtifactProblem.invalidClassFileInArtifact(
+    InvalidClassFileProblem problemOneClass =
+        new InvalidClassFileProblem(
             ImmutableList.of(nodeA, nodeB, nodeC), ImmutableList.of("foo.bar.Class"));
 
     assertEquals(
@@ -47,8 +47,8 @@ public class ArtifactProblemTest {
 
   @Test
   public void testToString_invalidClassFilesInArtifact() {
-    ArtifactProblem problemTwoClasses =
-        ArtifactProblem.invalidClassFileInArtifact(
+    InvalidClassFileProblem problemTwoClasses =
+        new InvalidClassFileProblem(
             ImmutableList.of(nodeA, nodeB, nodeC),
             ImmutableList.of("foo.bar.Class1", "foo.bar.Class2"));
 
@@ -59,21 +59,14 @@ public class ArtifactProblemTest {
   }
 
   @Test
-  public void testToString_unresolvableArtifactWithoutDependencyPath() {
-    ArtifactProblem problem = ArtifactProblem.unresolvableArtifactUnknownDependencyPath(artifactA);
-
-    assertEquals(
-        "foo:a:jar:1.0.0 was not resolved. Dependency path is unknown.", problem.toString());
-  }
-
-  @Test
-  public void testToString_unresolvableArtifact() {
-    ArtifactProblem problem =
-        ArtifactProblem.unresolvableArtifact(ImmutableList.of(nodeA, nodeB, nodeC));
-
-    assertEquals(
-        "foo:a:jar:1.0.0 was not resolved. Dependency path: [foo:a:jar:1.0.0, "
-            + "foo:a:jar:1.0.0, foo:a:jar:1.0.0]",
-        problem.toString());
+  public void testInvalidInput_emptyClassFileNames() {
+    try {
+      new InvalidClassFileProblem(
+          ImmutableList.of(nodeA, nodeB, nodeC),
+          ImmutableList.of());
+      fail("The constructor should invalidate empty classFileNames");
+    } catch (IllegalArgumentException ex) {
+      // pass
+    }
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/InvalidClassFileProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/InvalidClassFileProblemTest.java
@@ -22,16 +22,17 @@ import com.google.common.collect.ImmutableList;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
 import org.junit.Test;
 
 public class InvalidClassFileProblemTest {
   private Artifact artifactA = new DefaultArtifact("foo:a:1.0.0");
-  private DependencyNode nodeA = new DefaultDependencyNode(artifactA);
+  private DependencyNode nodeA = new DefaultDependencyNode(new Dependency(artifactA, "compile"));
   private Artifact artifactB = new DefaultArtifact("foo:b:1.0.0");
-  private DependencyNode nodeB = new DefaultDependencyNode(artifactA);
+  private DependencyNode nodeB = new DefaultDependencyNode(new Dependency(artifactB, "provided"));
   private Artifact artifactC = new DefaultArtifact("foo:c:1.0.0");
-  private DependencyNode nodeC = new DefaultDependencyNode(artifactA);
+  private DependencyNode nodeC = new DefaultDependencyNode(new Dependency(artifactC, "runtime"));
 
   @Test
   public void testToString_oneInvalidClassFileInArtifact() {
@@ -40,8 +41,9 @@ public class InvalidClassFileProblemTest {
             ImmutableList.of(nodeA, nodeB, nodeC), ImmutableList.of("foo.bar.Class"));
 
     assertEquals(
-        "foo:a:jar:1.0.0 contains an invalid class file foo.bar.Class. "
-            + "Dependency path: [foo:a:jar:1.0.0, foo:a:jar:1.0.0, foo:a:jar:1.0.0]",
+        "foo:c:jar:1.0.0 contains an invalid class file foo.bar.Class. "
+            + "Dependency path: "
+            + "foo:a:jar:1.0.0 (compile) > foo:b:jar:1.0.0 (provided) > foo:c:jar:1.0.0 (runtime)",
         problemOneClass.toString());
   }
 
@@ -53,17 +55,16 @@ public class InvalidClassFileProblemTest {
             ImmutableList.of("foo.bar.Class1", "foo.bar.Class2"));
 
     assertEquals(
-        "foo:a:jar:1.0.0 contains 2 invalid class files (example: foo.bar.Class1). "
-            + "Dependency path: [foo:a:jar:1.0.0, foo:a:jar:1.0.0, foo:a:jar:1.0.0]",
+        "foo:c:jar:1.0.0 contains 2 invalid class files (example: foo.bar.Class1). "
+            + "Dependency path: "
+            + "foo:a:jar:1.0.0 (compile) > foo:b:jar:1.0.0 (provided) > foo:c:jar:1.0.0 (runtime)",
         problemTwoClasses.toString());
   }
 
   @Test
   public void testInvalidInput_emptyClassFileNames() {
     try {
-      new InvalidClassFileProblem(
-          ImmutableList.of(nodeA, nodeB, nodeC),
-          ImmutableList.of());
+      new InvalidClassFileProblem(ImmutableList.of(nodeA, nodeB, nodeC), ImmutableList.of());
       fail("The constructor should invalidate empty classFileNames");
     } catch (IllegalArgumentException ex) {
       // pass

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/UnresolvableArtifactProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/UnresolvableArtifactProblemTest.java
@@ -21,16 +21,17 @@ import com.google.common.collect.ImmutableList;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
 import org.junit.Test;
 
 public class UnresolvableArtifactProblemTest {
   private Artifact artifactA = new DefaultArtifact("foo:a:1.0.0");
-  private DependencyNode nodeA = new DefaultDependencyNode(artifactA);
+  private DependencyNode nodeA = new DefaultDependencyNode(new Dependency(artifactA, "compile"));
   private Artifact artifactB = new DefaultArtifact("foo:b:1.0.0");
-  private DependencyNode nodeB = new DefaultDependencyNode(artifactA);
+  private DependencyNode nodeB = new DefaultDependencyNode(new Dependency(artifactB, "provided"));
   private Artifact artifactC = new DefaultArtifact("foo:c:1.0.0");
-  private DependencyNode nodeC = new DefaultDependencyNode(artifactA);
+  private DependencyNode nodeC = new DefaultDependencyNode(new Dependency(artifactC, "runtime"));
 
   @Test
   public void testToString_unresolvableArtifactWithoutDependencyPath() {
@@ -46,8 +47,8 @@ public class UnresolvableArtifactProblemTest {
         new UnresolvableArtifactProblem(ImmutableList.of(nodeA, nodeB, nodeC));
 
     assertEquals(
-        "foo:a:jar:1.0.0 was not resolved. Dependency path: [foo:a:jar:1.0.0, "
-            + "foo:a:jar:1.0.0, foo:a:jar:1.0.0]",
+        "foo:c:jar:1.0.0 was not resolved. Dependency path: "
+            + "foo:a:jar:1.0.0 (compile) > foo:b:jar:1.0.0 (provided) > foo:c:jar:1.0.0 (runtime)",
         problem.toString());
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/UnresolvableArtifactProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/UnresolvableArtifactProblemTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.google.cloud.tools.opensource.dependencies;
 
 import static org.junit.Assert.assertEquals;

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/UnresolvableArtifactProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/UnresolvableArtifactProblemTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.tools.opensource.dependencies;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.DependencyNode;
+import org.junit.Test;
+
+public class UnresolvableArtifactProblemTest {
+  private Artifact artifactA = new DefaultArtifact("foo:a:1.0.0");
+  private DependencyNode nodeA = new DefaultDependencyNode(artifactA);
+  private Artifact artifactB = new DefaultArtifact("foo:b:1.0.0");
+  private DependencyNode nodeB = new DefaultDependencyNode(artifactA);
+  private Artifact artifactC = new DefaultArtifact("foo:c:1.0.0");
+  private DependencyNode nodeC = new DefaultDependencyNode(artifactA);
+
+  @Test
+  public void testToString_unresolvableArtifactWithoutDependencyPath() {
+    UnresolvableArtifactProblem problem = new UnresolvableArtifactProblem(artifactA);
+
+    assertEquals(
+        "foo:a:jar:1.0.0 was not resolved. Dependency path is unknown.", problem.toString());
+  }
+
+  @Test
+  public void testToString_unresolvableArtifact() {
+    UnresolvableArtifactProblem problem =
+        new UnresolvableArtifactProblem(ImmutableList.of(nodeA, nodeB, nodeC));
+
+    assertEquals(
+        "foo:a:jar:1.0.0 was not resolved. Dependency path: [foo:a:jar:1.0.0, "
+            + "foo:a:jar:1.0.0, foo:a:jar:1.0.0]",
+        problem.toString());
+  }
+}

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -92,7 +92,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
    */
   private DependencySection dependencySection = DependencySection.DEPENDENCIES;
 
-  private List<ArtifactProblem> artifactProblems = new ArrayList<>();
+  private final List<ArtifactProblem> artifactProblems = new ArrayList<>();
 
   /**
    * Set to true to suppress linkage errors unreachable from the classes in the direct dependencies.

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -294,7 +294,6 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
       if (cause instanceof ArtifactTransferException) {
         ArtifactTransferException artifactException = (ArtifactTransferException) cause;
         Artifact artifact = artifactException.getArtifact();
-        String pathsToArtifact = findPaths(dependencyGraph, artifact);
         List<DependencyNode> firstArtifactPath =
             Iterables.getFirst(findArtifactPaths(dependencyGraph, artifact), ImmutableList.of());
         if (firstArtifactPath.isEmpty()) {
@@ -352,17 +351,6 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
     } catch (RepositoryException ex) {
       throw new EnforcerRuleException("Failed to collect dependency " + ex.getMessage(), ex);
     }
-  }
-
-  private static String findPaths(DependencyNode root, Artifact artifact) {
-    ImmutableList<List<DependencyNode>> dependencyPaths = findArtifactPaths(root, artifact);
-
-    ImmutableList<String> paths =
-        dependencyPaths.stream()
-            .map(path -> Joiner.on(" > ").join(path))
-            .collect(toImmutableList());
-    // Joining one or more paths from root to the artifact
-    return Joiner.on("\n").join(paths);
   }
 
   private static ImmutableList<List<DependencyNode>> findArtifactPaths(

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -230,7 +230,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
       throw new EnforcerRuleException("Unable to lookup an expression " + ex.getMessage(), ex);
     } finally {
       for (ArtifactProblem problem : artifactProblems) {
-        // This is warn because having an unresolvable Maven artifact should not cause build
+        // This is not error because having an unresolvable Maven artifact should not cause build
         // failures as long as there is no linkage errors.
         logger.warn(problem.toString());
       }

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -464,10 +464,10 @@ public class LinkageCheckerRuleTest {
       verify(mockLog)
           .warn(
               "aopalliance:aopalliance:jar:1.0 was not resolved. "
-              + "Dependency path: [com.google.guava:guava:jar:28.0-android, "
-              + "org.apache.maven:maven-core:jar:3.5.2 (compile), "
-              + "com.google.inject:guice:jar:no_aop:4.0 (compile), "
-              + "aopalliance:aopalliance:jar:1.0 (compile)]");
+                  + "Dependency path: [com.google.guava:guava:jar:28.0-android, "
+                  + "org.apache.maven:maven-core:jar:3.5.2 (compile), "
+                  + "com.google.inject:guice:jar:no_aop:4.0 (compile), "
+                  + "aopalliance:aopalliance:jar:1.0 (compile)]");
     }
   }
 

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -462,11 +462,12 @@ public class LinkageCheckerRuleTest {
       fail("The rule should throw EnforcerRuleException upon dependency resolution exception");
     } catch (EnforcerRuleException e) {
       verify(mockLog)
-          .error(
-              "Paths to the missing artifact: com.google.guava:guava:jar:28.0-android > "
-                  + "org.apache.maven:maven-core:jar:3.5.2 (compile) > "
-                  + "com.google.inject:guice:jar:no_aop:4.0 (compile) > "
-                  + "aopalliance:aopalliance:jar:1.0 (compile)");
+          .warn(
+              "aopalliance:aopalliance:jar:1.0 was not resolved. "
+              + "Dependency path: [com.google.guava:guava:jar:28.0-android, "
+              + "org.apache.maven:maven-core:jar:3.5.2 (compile), "
+              + "com.google.inject:guice:jar:no_aop:4.0 (compile), "
+              + "aopalliance:aopalliance:jar:1.0 (compile)]");
     }
   }
 
@@ -517,7 +518,7 @@ public class LinkageCheckerRuleTest {
 
   @Test
   public void testArtifactTransferError_missingArtifactNotInGraph()
-      throws URISyntaxException, DependencyResolutionException {
+      throws URISyntaxException, DependencyResolutionException, EnforcerRuleException {
     // Creating a dummy tree
     //   com.google.foo:project
     //     +- com.google.foo:child1 (provided)
@@ -550,13 +551,9 @@ public class LinkageCheckerRuleTest {
 
     when(mockProjectDependenciesResolver.resolve(any())).thenThrow(exception);
 
-    try {
-      rule.execute(mockRuleHelper);
-      fail("The rule should throw EnforcerRuleException upon DependencyResolutionException");
-    } catch (EnforcerRuleException ex) {
-      verify(mockLog)
-          .error("The transformed dependency graph does not contain the missing artifact");
-    }
+    rule.execute(mockRuleHelper);
+    verify(mockLog)
+        .warn("xerces:xerces-impl:jar:2.6.2 was not resolved. Dependency path is unknown.");
   }
 
   @Test

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -464,10 +464,10 @@ public class LinkageCheckerRuleTest {
       verify(mockLog)
           .warn(
               "aopalliance:aopalliance:jar:1.0 was not resolved. "
-                  + "Dependency path: [com.google.guava:guava:jar:28.0-android, "
-                  + "org.apache.maven:maven-core:jar:3.5.2 (compile), "
-                  + "com.google.inject:guice:jar:no_aop:4.0 (compile), "
-                  + "aopalliance:aopalliance:jar:1.0 (compile)]");
+                  + "Dependency path: com.google.guava:guava:jar:28.0-android > "
+                  + "org.apache.maven:maven-core:jar:3.5.2 (compile) > "
+                  + "com.google.inject:guice:jar:no_aop:4.0 (compile) > "
+                  + "aopalliance:aopalliance:jar:1.0 (compile)");
     }
   }
 


### PR DESCRIPTION
Fixes #1093

- Introducing ArtifactProblem class
- LinkageCheckerRule to use the class.

Once this PR is merged, I'll raise another PR to for DependencyGraphBuilder to use ArtifactProblem class.
