### PR TITLE
Skip Maven artifact having the same groupId and artifactId as a parent in dependency path

### DIFF
--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
@@ -94,10 +94,10 @@ public class DependencyGraphIntegrationTest {
     DependencyGraph graph = DependencyGraphBuilder.getCompleteDependencies(jaxen);
 
     List<Update> updates = graph.findUpdates();
-    Truth.assertThat(updates).hasSize(5);
+    Truth.assertThat(updates).hasSize(3);
 
     List<DependencyPath> conflicts = graph.findConflicts();
-    Truth.assertThat(conflicts).hasSize(34);
+    Truth.assertThat(conflicts).hasSize(5);
 
     Map<String, String> versions = graph.getHighestVersionMap();
     Assert.assertEquals("2.6.2", versions.get("xerces:xercesImpl"));


### PR DESCRIPTION
DependencyGraphBuilder outputs the following SEVERE logs. However, Maven's dependency mediation always picks up the version closer to the root, the infinite recursion is not severe at all.

```
SEVERE: Infinite recursion resolving jaxen:jaxen:jar:1.1-beta-4 (compile). Likely cycle in 
[org.apache.beam:beam-sdks-java-extensions-sql-datacatalog:jar:2.19.0-SNAPSHOT (compile), 
org.apache.beam:beam-sdks-java-extensions-sql:jar:2.19.0-SNAPSHOT (provided), 
com.alibaba:fastjson:jar:1.2.49 (compile), org.springframework:spring-websocket:jar:4.3.7.RELEASE
 (provided?), org.springframework:spring-context:jar:4.3.7.RELEASE (compile), 
org.springframework:spring-aop:jar:4.3.7.RELEASE (compile), org.springframework:spring-beans:jar:4.3.7.RELEASE (compile), org.codehaus.groovy:groovy-all:jar:2.4.9 (compile?), 
org.codehaus.gpars:gpars:jar:1.2.1 (runtime?), org.codehaus.groovy:groovy-all:jar:2.1.9 (compile?), 
com.thoughtworks.xstream:xstream:jar:1.4.2 (compile?), xom:xom:jar:1.1 (compile?), 
jaxen:jaxen:jar:1.1-beta-8 (compile), dom4j:dom4j:jar:1.6.1 (compile), jaxen:jaxen:jar:1.1-beta-6 
(compile?), dom4j:dom4j:jar:1.5.2 (compile), jaxen:jaxen:jar:1.1-beta-4 (compile), 
dom4j:dom4j:jar:1.5.2 (compile)]
```

https://gist.github.com/suztomo/9c7723a2d126459bebfa2f52b5573757

This enhancement is DependencyGraphBuilder to skip artifact that has the same groupId and artifactId as one of parent in dependency path in the dependency tree.