### PR TITLE
LinkageCheckerMain to show artifact problems if any

### DIFF
--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -21,6 +21,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.cloud.tools.opensource.classpath.ClassFile;
 import com.google.cloud.tools.opensource.classpath.ClassPathBuilder;
+import com.google.cloud.tools.opensource.classpath.ClassPathResult;
 import com.google.cloud.tools.opensource.classpath.LinkageChecker;
 import com.google.cloud.tools.opensource.classpath.SymbolProblem;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
@@ -38,12 +39,12 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimaps;
@@ -183,8 +184,9 @@ public class DashboardMain {
 
     ImmutableList<Artifact> managedDependencies = bom.getManagedDependencies();
 
-    LinkedListMultimap<Path, DependencyPath> jarToDependencyPaths =
-        classPathBuilder.artifactsToDependencyPaths(managedDependencies);
+    ClassPathResult classPathResult = classPathBuilder.resolve(managedDependencies);
+    ImmutableListMultimap<Path, DependencyPath> jarToDependencyPaths =
+        classPathResult.getDependencyPaths();
     // LinkedListMultimap preserves the key order
     ImmutableList<Path> classpath = ImmutableList.copyOf(jarToDependencyPaths.keySet());
 
@@ -211,7 +213,7 @@ public class DashboardMain {
   private static Path generateHtml(
       Bom bom,
       ArtifactCache cache,
-      LinkedListMultimap<Path, DependencyPath> jarToDependencyPaths,
+      ImmutableListMultimap<Path, DependencyPath> jarToDependencyPaths,
       ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems)
       throws IOException, TemplateException, URISyntaxException {
 

--- a/dashboard/src/main/resources/templates/artifact_details.ftl
+++ b/dashboard/src/main/resources/templates/artifact_details.ftl
@@ -46,7 +46,7 @@
     <h2>Linkage Errors</h2>
 
     <#list symbolProblems as jar, problemsToClasses>
-      <@formatJarLinkageReport jar problemsToClasses jarToDependencyPaths dependencyPathRootCauses/>
+      <@formatJarLinkageReport jar problemsToClasses classPathResult dependencyPathRootCauses/>
     </#list>
 
     <hr />

--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -140,7 +140,7 @@
 
     <p id="linkage-errors-total">${totalLinkageErrorCount} linkage error(s)</p>
     <#list symbolProblems as jar, problemsToClasses>
-      <@formatJarLinkageReport jar problemsToClasses jarToDependencyPaths {} />
+      <@formatJarLinkageReport jar problemsToClasses classPathResult {} />
     </#list>
 
     <h2>Dependencies</h2>

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -8,7 +8,7 @@
   <#return plural?string(pluralNoun, singularNoun)>
 </#function>
 
-<#macro formatJarLinkageReport jar problemsWithClass jarToDependencyPaths dependencyPathRootCauses>
+<#macro formatJarLinkageReport jar problemsWithClass classPathResult dependencyPathRootCauses>
   <!-- problemsWithClass: ImmutableSetMultimap<SymbolProblem, String> converted to
     ImmutableMap<SymbolProblem, Collection<String>> to get key and set of values in Freemarker -->
   <#assign problemsToClasses = problemsWithClass.asMap() />
@@ -47,14 +47,14 @@
     </ul>
   </#list>
   <#list jarsInProblem?values as jarInProblem>
-    <@showDependencyPath dependencyPathRootCauses jarToDependencyPaths jarInProblem />
+    <@showDependencyPath dependencyPathRootCauses classPathResult jarInProblem />
   </#list>
-  <@showDependencyPath dependencyPathRootCauses jarToDependencyPaths jar />
+  <@showDependencyPath dependencyPathRootCauses classPathResult jar />
 
 </#macro>
 
-<#macro showDependencyPath dependencyPathRootCauses jarToDependencyPaths jar>
-  <#assign dependencyPaths = jarToDependencyPaths.get(jar) />
+<#macro showDependencyPath dependencyPathRootCauses classPathResult jar>
+  <#assign dependencyPaths = classPathResult.getDependencyPaths(jar) />
   <p class="linkage-check-dependency-paths">
     The following ${plural(dependencyPaths?size, "path contains", "paths contain")} ${jar.getFileName()?html}:
   </p>

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -16,9 +16,11 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
+import com.google.cloud.tools.opensource.classpath.ClassPathResult;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.Bom;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.io.MoreFiles;
@@ -46,7 +48,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 
 public class DashboardUnavailableArtifactTest {
 
@@ -86,7 +87,7 @@ public class DashboardUnavailableArtifactTest {
             outputDirectory,
             cache,
             ImmutableMap.of(),
-            LinkedListMultimap.create(),
+            new ClassPathResult(LinkedListMultimap.create(), ImmutableList.of()),
             bom);
 
     Assert.assertEquals(
@@ -133,7 +134,7 @@ public class DashboardUnavailableArtifactTest {
         table,
         null,
         ImmutableMap.of(),
-        LinkedListMultimap.create(),
+        new ClassPathResult(LinkedListMultimap.create(), ImmutableList.of()),
         bom);
 
     Path generatedHtml = outputDirectory.resolve("artifact_details.html");

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -16,17 +16,16 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
+import com.google.cloud.tools.opensource.classpath.ClassPathResult;
 import com.google.cloud.tools.opensource.classpath.ClassSymbol;
 import com.google.cloud.tools.opensource.classpath.ErrorType;
 import com.google.cloud.tools.opensource.classpath.SymbolProblem;
 import com.google.cloud.tools.opensource.dependencies.Bom;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
-import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.ListMultimap;
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
 import com.google.common.truth.Truth;
@@ -91,14 +90,13 @@ public class FreemarkerTest {
     
     List<ArtifactResults> table = ImmutableList.of(results1, results2);
     List<DependencyGraph> globalDependencies = ImmutableList.of();
-    ListMultimap<Path, DependencyPath> jarToDependencyPaths = LinkedListMultimap.create();
     DashboardMain.generateDashboard(
         configuration,
         outputDirectory,
         table,
         globalDependencies,
         symbolProblemTable,
-        jarToDependencyPaths,
+        new ClassPathResult(LinkedListMultimap.create(), ImmutableList.of()),
         new Bom("mock:artifact:1.6.7", null));
 
     Path dashboardHtml = outputDirectory.resolve("index.html");

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
@@ -52,23 +52,10 @@ public final class ClassPathBuilder {
   }
 
   /**
-   * Finds jar file paths for Maven artifacts and their transitive dependencies, using Maven's
-   * dependency mediation strategy.
-   *
-   * @param artifacts Maven artifacts to check
-   * @return list of absolute paths to jar files
-   * @throws RepositoryException when there is a problem retrieving jar files
-   */
-  public ImmutableList<Path> resolveClassPath(List<Artifact> artifacts) throws RepositoryException {
-    ClassPathResult result = resolve(artifacts);
-    return result.getClassPath();
-  }
-
-  /**
-   * Finds jar file paths and dependency paths for Maven artifacts and their transitive
-   * dependencies. When there are multiple versions of an artifact in the dependency tree, the
-   * closest to the root in breadth-first order is picked up. This 'pick closest' strategy follows
-   * Maven's dependency mediation.
+   * Finds jar file paths and dependency paths for Maven artifacts and their transitive dependencies
+   * to build a list of JAR files (class path). When there are multiple versions of an artifact in
+   * the dependency tree, the closest to the root in breadth-first order is picked up. This 'pick
+   * closest' strategy follows Maven's dependency mediation.
    *
    * @param artifacts Maven artifacts to check. They are treated as the root of the dependency tree.
    * @throws RepositoryException when there is a problem retrieving jar files

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathResult.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathResult.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.classpath;
+
+import com.google.cloud.tools.opensource.dependencies.DependencyPath;
+import com.google.cloud.tools.opensource.dependencies.UnresolvableArtifactProblem;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.LinkedListMultimap;
+import java.nio.file.Path;
+
+/** Result of class path resolution with {@link UnresolvableArtifactProblem}s if any. */
+public final class ClassPathResult {
+
+  private final ImmutableList<Path> classPath;
+  private final ImmutableListMultimap<Path, DependencyPath> dependencyPaths;
+  private final ImmutableList<UnresolvableArtifactProblem> artifactProblems;
+
+  ClassPathResult(
+      LinkedListMultimap<Path, DependencyPath> dependencyPaths,
+      Iterable<UnresolvableArtifactProblem> artifactProblems) {
+    this.dependencyPaths = ImmutableListMultimap.copyOf(dependencyPaths);
+    this.classPath = ImmutableList.copyOf(dependencyPaths.keySet());
+    this.artifactProblems = ImmutableList.copyOf(artifactProblems);
+  }
+  ;
+
+  /** Returns the list of absolute paths to JAR files of resolved Maven artifacts. */
+  public ImmutableList<Path> getClassPath() {
+    return classPath;
+  }
+
+  /**
+   * Returns an ordered map of absolute paths of JAR files to one or more Maven dependency paths.
+   *
+   * <p>The keys of the returned map represent jar files of {@code artifacts} and their transitive
+   * dependencies. The return value of {@link LinkedListMultimap#keySet()} preserves key iteration
+   * order.
+   *
+   * <p>The values of the returned map for a key (jar file) represent the different Maven dependency
+   * paths from {@code artifacts} to the Maven artifact of the jar file.
+   */
+  public ImmutableListMultimap<Path, DependencyPath> getDependencyPaths() {
+    return dependencyPaths;
+  }
+
+  /** Returns problems encountered while constructing the dependency graph. */
+  ImmutableList<UnresolvableArtifactProblem> getArtifactProblems() {
+    return artifactProblems;
+  }
+}

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathResult.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathResult.java
@@ -21,17 +21,30 @@ import com.google.cloud.tools.opensource.dependencies.UnresolvableArtifactProble
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
 import java.nio.file.Path;
 
 /** Result of class path resolution with {@link UnresolvableArtifactProblem}s if any. */
 public final class ClassPathResult {
 
   private final ImmutableList<Path> classPath;
+
+  /**
+   * An ordered map of absolute paths of JAR files to one or more Maven dependency paths.
+   *
+   * <p>The keys of the returned map represent jar files of {@code artifacts} and their transitive
+   * dependencies. The return value of {@link LinkedListMultimap#keySet()} preserves key iteration
+   * order.
+   *
+   * <p>The values of the returned map for a key (jar file) represent the different Maven dependency
+   * paths from {@code artifacts} to the Maven artifact of the jar file.
+   */
   private final ImmutableListMultimap<Path, DependencyPath> dependencyPaths;
+
   private final ImmutableList<UnresolvableArtifactProblem> artifactProblems;
 
-  ClassPathResult(
-      LinkedListMultimap<Path, DependencyPath> dependencyPaths,
+  public ClassPathResult(
+      Multimap<Path, DependencyPath> dependencyPaths,
       Iterable<UnresolvableArtifactProblem> artifactProblems) {
     this.dependencyPaths = ImmutableListMultimap.copyOf(dependencyPaths);
     this.classPath = ImmutableList.copyOf(dependencyPaths.keySet());
@@ -45,17 +58,11 @@ public final class ClassPathResult {
   }
 
   /**
-   * Returns an ordered map of absolute paths of JAR files to one or more Maven dependency paths.
-   *
-   * <p>The keys of the returned map represent jar files of {@code artifacts} and their transitive
-   * dependencies. The return value of {@link LinkedListMultimap#keySet()} preserves key iteration
-   * order.
-   *
-   * <p>The values of the returned map for a key (jar file) represent the different Maven dependency
-   * paths from {@code artifacts} to the Maven artifact of the jar file.
+   * Returns the dependency path to the JAR file. An empty list if the JAR file is not in the class
+   * path.
    */
-  public ImmutableListMultimap<Path, DependencyPath> getDependencyPaths() {
-    return dependencyPaths;
+  public ImmutableList<DependencyPath> getDependencyPaths(Path jar) {
+    return dependencyPaths.get(jar);
   }
 
   /** Returns problems encountered while constructing the dependency graph. */

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -19,14 +19,12 @@ package com.google.cloud.tools.opensource.classpath;
 import static com.google.cloud.tools.opensource.classpath.ClassDumper.getClassHierarchy;
 
 import com.google.cloud.tools.opensource.dependencies.Bom;
-import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 import java.io.IOException;
@@ -90,10 +88,8 @@ public class LinkageChecker {
     ImmutableList<Artifact> managedDependencies = bom.getManagedDependencies();
 
     ClassPathBuilder classPathBuilder = new ClassPathBuilder();
-    LinkedListMultimap<Path, DependencyPath> jarToDependencyPaths =
-        classPathBuilder.artifactsToDependencyPaths(managedDependencies);
-    // LinkedListMultimap preserves the key order
-    ImmutableList<Path> classpath = ImmutableList.copyOf(jarToDependencyPaths.keySet());
+    ClassPathResult classPathResult = classPathBuilder.resolve(managedDependencies);
+    ImmutableList<Path> classpath = classPathResult.getClassPath();
 
     // When checking a BOM, entry point classes are the ones in the artifacts listed in the BOM
     List<Path> artifactJarsInBom = classpath.subList(0, managedDependencies.size());

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerArguments.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerArguments.java
@@ -200,7 +200,7 @@ final class LinkageCheckerArguments {
 
     if (commandLine.hasOption("b") || commandLine.hasOption("a")) {
       List<Artifact> artifacts = getArtifacts();
-      cachedInputClasspath = classPathBuilder.artifactsToClasspath(artifacts);
+      cachedInputClasspath = classPathBuilder.resolveClassPath(artifacts);
     } else {
       // b, a, or j is specified in OptionGroup
       String[] jarFiles = commandLine.getOptionValues("j");

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerArguments.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerArguments.java
@@ -200,7 +200,7 @@ final class LinkageCheckerArguments {
 
     if (commandLine.hasOption("b") || commandLine.hasOption("a")) {
       List<Artifact> artifacts = getArtifacts();
-      cachedInputClasspath = classPathBuilder.resolveClassPath(artifacts);
+      cachedInputClasspath = classPathBuilder.resolve(artifacts).getClassPath();
     } else {
       // b, a, or j is specified in OptionGroup
       String[] jarFiles = commandLine.getOptionValues("j");

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
+import com.google.cloud.tools.opensource.dependencies.ArtifactProblem;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraphBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -23,6 +24,8 @@ import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimaps;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.commons.cli.ParseException;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
@@ -54,10 +57,15 @@ class LinkageCheckerMain {
     ImmutableList<Artifact> artifacts = linkageCheckerArguments.getArtifacts();
 
     // When JAR files are specified in the argument, artifacts are empty.
-    ImmutableList<Path> inputClassPath =
-        artifacts.isEmpty()
-            ? linkageCheckerArguments.getInputClasspath()
-            : classPathBuilder.artifactsToClasspath(artifacts);
+    ImmutableList<Path> inputClassPath;
+    List<ArtifactProblem> artifactProblems = new ArrayList<>();
+    if (artifacts.isEmpty()) {
+      inputClassPath = linkageCheckerArguments.getInputClasspath();
+    } else {
+      ClassPathResult classPathResult = classPathBuilder.resolve(artifacts);
+      inputClassPath = classPathResult.getClassPath();
+      artifactProblems.addAll(classPathResult.getArtifactProblems());
+    }
 
     ImmutableSet<Path> entryPointJars = linkageCheckerArguments.getEntryPointJars();
     LinkageChecker linkageChecker = LinkageChecker.create(inputClassPath, entryPointJars);
@@ -73,6 +81,12 @@ class LinkageCheckerMain {
     }
 
     System.out.println(SymbolProblem.formatSymbolProblems(symbolProblems));
-  }
 
+    if (!artifactProblems.isEmpty()) {
+      System.out.println("\n");
+      for (ArtifactProblem artifactProblem : artifactProblems) {
+        System.out.println(artifactProblem);
+      }
+    }
+  }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
@@ -84,9 +84,7 @@ class LinkageCheckerMain {
 
     if (!artifactProblems.isEmpty()) {
       System.out.println("\n");
-      for (ArtifactProblem artifactProblem : artifactProblems) {
-        System.out.println(artifactProblem);
-      }
+      System.out.println(ArtifactProblem.formatProblems(artifactProblems));
     }
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
@@ -27,13 +27,8 @@ import org.eclipse.aether.graph.DependencyNode;
 /** Problem in a Maven artifact in a dependency tree. */
 public abstract class ArtifactProblem {
 
-  /** The Maven artifact that has the problem. */
   protected final Artifact artifact;
 
-  /**
-   * The dependency path to the artifact from the root of the dependency tree. An empty list if the
-   * path is unknown.
-   */
   protected final ImmutableList<DependencyNode> dependencyPath;
 
   protected ArtifactProblem(Artifact artifact, List<DependencyNode> dependencyPath) {
@@ -41,7 +36,16 @@ public abstract class ArtifactProblem {
     this.dependencyPath = ImmutableList.copyOf(dependencyPath);
   }
 
+  /**
+   * Returns the dependency path to the artifact from the root of the dependency tree. An empty list
+   * if the path is unknown.
+   */
   protected String getPath() {
     return Joiner.on(" > ").join(dependencyPath);
+  }
+
+  /** Returns the Maven artifact that has the problem. */
+  public Artifact getArtifact() {
+    return artifact;
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphResult.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphResult.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.opensource.dependencies;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
 /** Result of dependency graph building with {@link UnresolvableArtifactProblem}s if any. */
@@ -38,8 +37,7 @@ public final class DependencyGraphResult {
   }
 
   /** Returns problems encountered while constructing the dependency graph. */
-  @VisibleForTesting
-  ImmutableList<UnresolvableArtifactProblem> getArtifactProblems() {
+  public ImmutableList<UnresolvableArtifactProblem> getArtifactProblems() {
     return artifactProblems;
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
+import static com.google.cloud.tools.opensource.classpath.LinkageCheckerTest.resolvePaths;
 import static com.google.cloud.tools.opensource.classpath.TestHelper.absolutePathOfResource;
 import static org.junit.Assert.assertFalse;
 
@@ -37,8 +38,6 @@ import java.util.Set;
 import org.apache.bcel.classfile.ClassParser;
 import org.apache.bcel.classfile.JavaClass;
 import org.eclipse.aether.RepositoryException;
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -197,8 +196,7 @@ public class ClassDumperTest {
   @Test
   public void testMapJarToClasses_classWithDollars()
       throws IOException, RepositoryException {
-    Artifact grpcArtifact = new DefaultArtifact("com.google.code.gson:gson:2.6.2");
-    List<Path> paths = classPathBuilder.artifactsToClasspath(ImmutableList.of(grpcArtifact));
+    List<Path> paths = resolvePaths("com.google.code.gson:gson:2.6.2");
     Path gsonJar = paths.get(0);
 
     ImmutableSetMultimap<Path, String> pathToClasses =
@@ -336,8 +334,7 @@ public class ClassDumperTest {
       throws IOException, RepositoryException {
     // org.graalvm.libgraal.LibGraal class has different implementations between Java 8 and 11 via
     // Multi-release JAR of this artifact.
-    Artifact grpcArtifact = new DefaultArtifact("org.graalvm.compiler:compiler:19.0.0");
-    List<Path> paths = classPathBuilder.artifactsToClasspath(ImmutableList.of(grpcArtifact));
+    List<Path> paths = resolvePaths("org.graalvm.compiler:compiler:19.0.0");
 
     ClassDumper classDumper = ClassDumper.create(paths);
     classDumper.findSymbolReferences();
@@ -352,9 +349,8 @@ public class ClassDumperTest {
   public void testFindSymbolReferences_overLappingClass() throws IOException, RepositoryException {
     // Both artifacts contain com.google.inject.internal.InjectorImpl$BindingsMultimap. The one from
     // sisu-guice should not appear in symbol references because guice supersedes in the class path.
-    Artifact guice = new DefaultArtifact("com.google.inject:guice:3.0");
-    Artifact sisuGuice = new DefaultArtifact("org.sonatype.sisu:sisu-guice:3.2.6");
-    List<Path> paths = classPathBuilder.artifactsToClasspath(ImmutableList.of(guice, sisuGuice));
+    List<Path> paths =
+        resolvePaths("com.google.inject:guice:3.0", "org.sonatype.sisu:sisu-guice:3.2.6");
     Path sisuGuicePath = paths.get(1);
 
     ClassDumper classDumper = ClassDumper.create(paths);
@@ -374,8 +370,7 @@ public class ClassDumperTest {
     // com.amazonaws:amazon-kinesis-client:1.13.0 contains an unexpected lock file
     // /unison/com/e007f77498fd27177e2ea931a06dcf50/unison/tmp/amazonaws/services/kinesis/leases/impl/LeaseTaker.class
     // https://github.com/awslabs/amazon-kinesis-client/issues/654
-    Artifact kinesisClient = new DefaultArtifact("com.amazonaws:amazon-kinesis-client:1.13.0");
-    List<Path> paths = classPathBuilder.artifactsToClasspath(ImmutableList.of(kinesisClient));
+    List<Path> paths = resolvePaths("com.amazonaws:amazon-kinesis-client:1.13.0");
     ClassDumper classDumper = ClassDumper.create(paths);
     Path kinesisJar = paths.get(0);
 
@@ -395,8 +390,7 @@ public class ClassDumperTest {
     // Curator-client has shaded com.google.common.reflect.TypeToken$Bounds but it does not contain
     // the outer class com.google.common.reflect.TypeToken.
     // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1092
-    Artifact curatorClient = new DefaultArtifact("org.apache.curator:curator-client:4.2.0");
-    List<Path> paths = classPathBuilder.artifactsToClasspath(ImmutableList.of(curatorClient));
+    List<Path> paths = resolvePaths("org.apache.curator:curator-client:4.2.0");
 
     Path curatorClientJar = paths.get(0);
     ClassDumper classDumper = ClassDumper.create(ImmutableList.of(curatorClientJar));

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -54,7 +54,8 @@ public class ClassDumperTest {
 
   private static final Correspondence<Symbol, String> SYMBOL_TARGET_CLASS_NAME =
       Correspondence.from(
-          (actual, expected) -> actual.getClassBinaryName().equals(expected), "has class name equal to");
+          (actual, expected) -> actual.getClassBinaryName().equals(expected),
+          "has class name equal to");
 
   private InputStream classFileInputStream;
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -48,6 +48,12 @@ public class ClassPathBuilderTest {
 
   private ClassPathBuilder classPathBuilder = new ClassPathBuilder();
 
+  private ImmutableList<Path> resolveClassPath(String coordinates) throws RepositoryException {
+    Artifact artifact = new DefaultArtifact(coordinates);
+    ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(artifact));
+    return result.getClassPath();
+  }
+
   @Test
   public void testResolve_removingDuplicates() throws RepositoryException {
     Artifact grpcArtifact = new DefaultArtifact("io.grpc:grpc-auth:1.15.1");
@@ -111,8 +117,7 @@ public class ClassPathBuilderTest {
 
   @Test
   public void testresolveClassPath_validCoordinate() throws RepositoryException {
-    Artifact grpcAuth = new DefaultArtifact("io.grpc:grpc-auth:1.15.1");
-    List<Path> paths = classPathBuilder.resolveClassPath(ImmutableList.of(grpcAuth));
+    List<Path> paths = resolveClassPath("io.grpc:grpc-auth:1.15.1");
 
     Truth.assertThat(paths)
         .comparingElementsUsing(PATH_FILE_NAMES)
@@ -129,9 +134,7 @@ public class ClassPathBuilderTest {
 
   @Test
   public void testResolveClassPath_optionalDependency() throws RepositoryException {
-    Artifact bigTable =
-        new DefaultArtifact("com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha");
-    List<Path> paths = classPathBuilder.resolveClassPath(ImmutableList.of(bigTable));
+    List<Path> paths = resolveClassPath("com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha");
     Truth.assertThat(paths).comparingElementsUsing(PATH_FILE_NAMES).contains("log4j-1.2.12.jar");
   }
 
@@ -139,7 +142,7 @@ public class ClassPathBuilderTest {
   public void testResolveClassPath_invalidCoordinate() {
     Artifact nonExistentArtifact = new DefaultArtifact("io.grpc:nosuchartifact:1.2.3");
     try {
-      classPathBuilder.resolveClassPath(ImmutableList.of(nonExistentArtifact));
+      classPathBuilder.resolve(ImmutableList.of(nonExistentArtifact));
       Assert.fail("Invalid Maven coodinate should raise RepositoryException");
     } catch (RepositoryException ex) {
       Truth.assertThat(ex.getMessage())
@@ -148,17 +151,15 @@ public class ClassPathBuilderTest {
   }
 
   @Test
-  public void testResolveClassPath_emptyInput() throws RepositoryException {
-    List<Path> jars = classPathBuilder.resolveClassPath(ImmutableList.of());
+  public void testResolve_emptyInput() throws RepositoryException {
+    List<Path> jars = classPathBuilder.resolve(ImmutableList.of()).getClassPath();
     Truth.assertThat(jars).isEmpty();
   }
 
   @Test
   public void testFindInvalidReferences_selfReferenceFromAbstractClassToInterface()
       throws RepositoryException, IOException {
-    Artifact bigTable =
-        new DefaultArtifact("com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha");
-    List<Path> paths = classPathBuilder.resolveClassPath(ImmutableList.of(bigTable));
+    List<Path> paths = resolveClassPath("com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha");
     Path httpClientJar =
         paths
             .stream()
@@ -196,8 +197,7 @@ public class ClassPathBuilderTest {
 
   @Test
   public void testResolveClasspath_notToGenerateRepositoryException() throws RepositoryException {
-    Artifact guavaGwt = new DefaultArtifact("com.google.guava:guava-gwt:jar:20.0");
-    List<Path> paths = classPathBuilder.resolveClassPath(ImmutableList.of(guavaGwt));
+    List<Path> paths = resolveClassPath("com.google.guava:guava-gwt:jar:20.0");
     Truth.assertThat(paths).isNotEmpty();
   }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblemTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.dependencies;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.junit.Test;
+
+public class ArtifactProblemTest {
+  private Artifact artifactA = new DefaultArtifact("foo:a:1.0.0");
+  private DependencyNode nodeA = new DefaultDependencyNode(new Dependency(artifactA, "compile"));
+  private Artifact artifactB = new DefaultArtifact("foo:b:1.0.0");
+  private DependencyNode nodeB = new DefaultDependencyNode(new Dependency(artifactB, "provided"));
+  private Artifact artifactC = new DefaultArtifact("foo:c:1.0.0");
+  private DependencyNode nodeC = new DefaultDependencyNode(new Dependency(artifactC, "runtime"));
+
+  @Test
+  public void testFormatProblems_2problems() {
+    UnresolvableArtifactProblem problemA_B_C =
+        new UnresolvableArtifactProblem(ImmutableList.of(nodeA, nodeB, nodeC));
+    UnresolvableArtifactProblem problemB_C =
+        new UnresolvableArtifactProblem(ImmutableList.of(nodeA, nodeB, nodeC));
+
+    String actual = ArtifactProblem.formatProblems(ImmutableList.of(problemB_C, problemA_B_C));
+
+    assertEquals(
+        "foo:c:jar:1.0.0 was not resolved. "
+            + "Dependency path: foo:a:jar:1.0.0 (compile) > foo:b:jar:1.0.0 (provided) > "
+            + "foo:c:jar:1.0.0 (runtime) and a problem on the same artifact.\n",
+        actual);
+  }
+
+  @Test
+  public void testFormatProblems_3problems() {
+    UnresolvableArtifactProblem problemA_B_C =
+        new UnresolvableArtifactProblem(ImmutableList.of(nodeA, nodeB, nodeC));
+    UnresolvableArtifactProblem problemB_C =
+        new UnresolvableArtifactProblem(ImmutableList.of(nodeA, nodeB, nodeC));
+    UnresolvableArtifactProblem problemC =
+        new UnresolvableArtifactProblem(ImmutableList.of(nodeA, nodeB, nodeC));
+
+    String actual =
+        ArtifactProblem.formatProblems(ImmutableList.of(problemC, problemB_C, problemA_B_C));
+
+    assertEquals(
+        "foo:c:jar:1.0.0 was not resolved. Dependency path: "
+            + "foo:a:jar:1.0.0 (compile) > foo:b:jar:1.0.0 (provided) > foo:c:jar:1.0.0 (runtime) "
+            + "and 2 problems on the same artifact.\n",
+        actual);
+  }
+
+  @Test
+  public void testFormatProblems_2artifacts() {
+    UnresolvableArtifactProblem problemA = new UnresolvableArtifactProblem(ImmutableList.of(nodeA));
+    UnresolvableArtifactProblem problemB = new UnresolvableArtifactProblem(ImmutableList.of(nodeB));
+
+    String actual = ArtifactProblem.formatProblems(ImmutableList.of(problemA, problemB));
+
+    assertEquals(
+        "foo:a:jar:1.0.0 was not resolved. Dependency path: foo:a:jar:1.0.0 (compile)\n"
+            + "foo:b:jar:1.0.0 was not resolved. Dependency path: foo:b:jar:1.0.0 (provided)\n",
+        actual);
+  }
+}

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -347,7 +347,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
               .map(Dependency::getArtifact)
               .filter(artifact -> !shouldSkipBomMember(artifact))
               .collect(toImmutableList());
-      return classPathBuilder.artifactsToClasspath(artifacts);
+      return classPathBuilder.resolveClassPath(artifacts);
     } catch (RepositoryException ex) {
       throw new EnforcerRuleException("Failed to collect dependency " + ex.getMessage(), ex);
     }

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -347,7 +347,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
               .map(Dependency::getArtifact)
               .filter(artifact -> !shouldSkipBomMember(artifact))
               .collect(toImmutableList());
-      return classPathBuilder.resolveClassPath(artifacts);
+      return classPathBuilder.resolve(artifacts).getClassPath();
     } catch (RepositoryException ex) {
       throw new EnforcerRuleException("Failed to collect dependency " + ex.getMessage(), ex);
     }

--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
@@ -35,7 +35,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.io.MoreFiles;
 import java.io.IOException;
@@ -185,8 +184,7 @@ public class LinkageMonitor {
     Set<SymbolProblem> newProblems = Sets.difference(problemsInSnapshot, problemsInBaseline);
     if (!newProblems.isEmpty()) {
       logger.severe(
-          messageForNewErrors(
-              snapshotSymbolProblems, problemsInBaseline, classPathResult.getDependencyPaths()));
+          messageForNewErrors(snapshotSymbolProblems, problemsInBaseline, classPathResult));
       int errorSize = newProblems.size();
       throw new LinkageMonitorException(
           String.format("Found %d new linkage error%s", errorSize, errorSize > 1 ? "s" : ""));
@@ -208,7 +206,7 @@ public class LinkageMonitor {
   static String messageForNewErrors(
       ImmutableSetMultimap<SymbolProblem, ClassFile> snapshotSymbolProblems,
       Set<SymbolProblem> baselineProblems,
-      Multimap<Path, DependencyPath> jarToDependencyPaths) {
+      ClassPathResult classPathResult) {
     Set<SymbolProblem> newProblems =
         Sets.difference(snapshotSymbolProblems.keySet(), baselineProblems);
     StringBuilder message =
@@ -235,7 +233,7 @@ public class LinkageMonitor {
     message.append("\n");
     for (Path problematicJar : problematicJars.build()) {
       message.append(problematicJar.getFileName() + " is at:\n");
-      for (DependencyPath dependencyPath : jarToDependencyPaths.get(problematicJar)) {
+      for (DependencyPath dependencyPath : classPathResult.getDependencyPaths(problematicJar)) {
         message.append("  " + dependencyPath + "\n");
       }
     }

--- a/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
+++ b/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.cloud.tools.opensource.classpath.ClassFile;
+import com.google.cloud.tools.opensource.classpath.ClassPathResult;
 import com.google.cloud.tools.opensource.classpath.ClassSymbol;
 import com.google.cloud.tools.opensource.classpath.ErrorType;
 import com.google.cloud.tools.opensource.classpath.MethodSymbol;
@@ -130,7 +131,9 @@ public class LinkageMonitorTest {
         LinkageMonitor.messageForNewErrors(
             snapshotProblems,
             baselineProblems,
-            ImmutableListMultimap.of(jarA, dependencyPathToA, jarB, dependencyPathToB));
+            new ClassPathResult(
+                ImmutableListMultimap.of(jarA, dependencyPathToA, jarB, dependencyPathToB),
+                ImmutableList.of()));
     assertEquals(
         "Newly introduced problem:\n"
             + "(b-1.0.0.jar) io.grpc.protobuf.ProtoUtils's method"


### PR DESCRIPTION
Cont. of #1093 

- LinakgeCheckerMain prints artifact problems if any.
  This requires ClassPathBuilder to return both class path as well as artifact problems. This needs a new data type.
- Introducing ClassPathResult to hold the result of class path resolution with problems.
  Because some callers of ClassPathBuilder need the map of JAR Path to DependencyPath (jarToDependencyPath), ClassPathResult holds the information as well.
- Renamed ClassPathBuilder.artifactsToDependencyPaths to "resolve", because the former was not a verb.
- Deleted ClassPathBuilder.artifactsToClassPath because, with the introduction of ClassPathResult, it is just a shortcut to call `classPathResult.getClassPath()`.
- Added ArtifactProblem.formatProblems to remove duplicate problems. Without this de-dup logic, the output would have lots of lines for just one unavailable Maven artifact. Example output: https://gist.github.com/suztomo/f2656887c57ccd736f66f56defd20268
