### PR TITLE
LinkageCheckerMain to report dependency paths

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathResult.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathResult.java
@@ -86,7 +86,7 @@ public final class ClassPathResult {
       if (otherCount == 1) {
         message.append("  and 1 dependency path.\n");
       } else if (otherCount > 1) {
-        message.append("  and other " + otherCount + " dependency paths.\n");
+        message.append("  and " + otherCount + " other dependency paths.\n");
       }
     }
     return message.toString();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathResult.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathResult.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.cloud.tools.opensource.dependencies.UnresolvableArtifactProblem;
 import com.google.common.collect.ImmutableList;
@@ -68,5 +70,25 @@ public final class ClassPathResult {
   /** Returns problems encountered while constructing the dependency graph. */
   ImmutableList<UnresolvableArtifactProblem> getArtifactProblems() {
     return artifactProblems;
+  }
+
+  /** Returns text describing dependency paths to {@code jars} in the dependency tree. */
+  public String formatDependencyPaths(Iterable<Path> jars) {
+    StringBuilder message = new StringBuilder();
+    for (Path jar : jars) {
+      ImmutableList<DependencyPath> dependencyPaths = getDependencyPaths(jar);
+      checkArgument(dependencyPaths.size() >= 1, "%s is not in the class path", jar);
+
+      message.append(jar.getFileName() + " is at:\n");
+
+      int otherCount = dependencyPaths.size() - 1;
+      message.append("  " + dependencyPaths.get(0) + "\n");
+      if (otherCount == 1) {
+        message.append("  and 1 dependency path.\n");
+      } else if (otherCount > 1) {
+        message.append("  and other " + otherCount + " dependency paths.\n");
+      }
+    }
+    return message.toString();
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
@@ -61,8 +61,11 @@ class LinkageCheckerMain {
     List<ArtifactProblem> artifactProblems = new ArrayList<>();
     ClassPathResult classPathResult = null;
     if (artifacts.isEmpty()) {
+      // When JAR files are passed as arguments, classPathResult is null, because there is no need
+      // to resolve Maven dependencies.
       inputClassPath = linkageCheckerArguments.getInputClasspath();
     } else {
+      // When Maven artifacts (or a BOM) are passed as arguments, resolve the dependency tree.
       classPathResult = classPathBuilder.resolve(artifacts);
       inputClassPath = classPathResult.getClassPath();
       artifactProblems.addAll(classPathResult.getArtifactProblems());
@@ -83,18 +86,17 @@ class LinkageCheckerMain {
 
     System.out.println(SymbolProblem.formatSymbolProblems(symbolProblems));
 
-    ImmutableSet.Builder<Path> problematicJars = ImmutableSet.builder();
-    for (SymbolProblem symbolProblem : symbolProblems.keySet()) {
-      ClassFile containingClass = symbolProblem.getContainingClass();
-      if (containingClass != null) {
-        problematicJars.add(containingClass.getJar());
-      }
-      for (ClassFile classFile : symbolProblems.get(symbolProblem)) {
-        problematicJars.add(classFile.getJar());
-      }
-    }
-
     if (classPathResult != null && !symbolProblems.isEmpty()) {
+      ImmutableSet.Builder<Path> problematicJars = ImmutableSet.builder();
+      for (SymbolProblem symbolProblem : symbolProblems.keySet()) {
+        ClassFile containingClass = symbolProblem.getContainingClass();
+        if (containingClass != null) {
+          problematicJars.add(containingClass.getJar());
+        }
+        for (ClassFile classFile : symbolProblems.get(symbolProblem)) {
+          problematicJars.add(classFile.getJar());
+        }
+      }
       System.out.println(classPathResult.formatDependencyPaths(problematicJars.build()));
     }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathResultTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathResultTest.java
@@ -107,7 +107,7 @@ public class ClassPathResultTest {
     String actual = classPathResult.formatDependencyPaths(ImmutableList.of(jarA));
 
     assertEquals(
-        "a.jar is at:\n" + "  com.google:a:1 (compile)\n" + "  and other 2 dependency paths.\n",
+        "a.jar is at:\n" + "  com.google:a:1 (compile)\n" + "  and 2 other dependency paths.\n",
         actual);
   }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathResultTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathResultTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.classpath;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import com.google.cloud.tools.opensource.dependencies.DependencyPath;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableSet;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ClassPathResultTest {
+  private Artifact artifactA = new DefaultArtifact("com.google:a:1");
+  private Artifact artifactB = new DefaultArtifact("com.google:b:1");
+  private DependencyPath dependencyPath_A = new DependencyPath();
+  private DependencyPath dependencyPath_B = new DependencyPath();
+  private DependencyPath dependencyPath_B_A = new DependencyPath();
+  private DependencyPath dependencyPath_A_B_A = new DependencyPath();
+  private Path jarA = Paths.get("a.jar");
+  private Path jarB = Paths.get("b.jar");
+
+  @Before
+  public void setup() {
+    dependencyPath_A.add(artifactA, "compile", false);
+
+    dependencyPath_B.add(artifactB, "compile", false);
+
+    dependencyPath_B_A.add(artifactB, "compile", false);
+    dependencyPath_B_A.add(artifactA, "compile", false);
+
+    dependencyPath_A_B_A.add(artifactA, "compile", false);
+    dependencyPath_A_B_A.add(artifactB, "compile", false);
+    dependencyPath_A_B_A.add(artifactA, "compile", false);
+  }
+
+  @Test
+  public void testFormatDependencyPaths_onePath() {
+    ImmutableListMultimap<Path, DependencyPath> tree =
+        ImmutableListMultimap.of(jarA, dependencyPath_A, jarB, dependencyPath_B);
+
+    ClassPathResult classPathResult = new ClassPathResult(tree, ImmutableSet.of());
+
+    String actual = classPathResult.formatDependencyPaths(ImmutableList.of(jarA));
+
+    assertEquals("a.jar is at:\n" + "  com.google:a:1 (compile)\n", actual);
+  }
+
+  @Test
+  public void testFormatDependencyPaths_path_A_B() {
+    ImmutableListMultimap<Path, DependencyPath> tree =
+        ImmutableListMultimap.of(jarA, dependencyPath_A, jarB, dependencyPath_B);
+
+    ClassPathResult classPathResult = new ClassPathResult(tree, ImmutableSet.of());
+
+    String actual = classPathResult.formatDependencyPaths(ImmutableList.of(jarA, jarB));
+
+    assertEquals(
+        "a.jar is at:\n"
+            + "  com.google:a:1 (compile)\n"
+            + "b.jar is at:\n"
+            + "  com.google:b:1 (compile)\n",
+        actual);
+  }
+
+  @Test
+  public void testFormatDependencyPaths_twoPathsForA() {
+    ImmutableListMultimap<Path, DependencyPath> tree =
+        ImmutableListMultimap.of(jarA, dependencyPath_A, jarA, dependencyPath_B_A);
+
+    ClassPathResult classPathResult = new ClassPathResult(tree, ImmutableSet.of());
+
+    String actual = classPathResult.formatDependencyPaths(ImmutableList.of(jarA));
+
+    assertEquals(
+        "a.jar is at:\n" + "  com.google:a:1 (compile)\n" + "  and 1 dependency path.\n", actual);
+  }
+
+  @Test
+  public void testFormatDependencyPaths_threePathsForA() {
+    ImmutableListMultimap<Path, DependencyPath> tree =
+        ImmutableListMultimap.of(
+            jarA, dependencyPath_A, jarA, dependencyPath_B_A, jarA, dependencyPath_A_B_A);
+
+    ClassPathResult classPathResult = new ClassPathResult(tree, ImmutableSet.of());
+
+    String actual = classPathResult.formatDependencyPaths(ImmutableList.of(jarA));
+
+    assertEquals(
+        "a.jar is at:\n" + "  com.google:a:1 (compile)\n" + "  and other 2 dependency paths.\n",
+        actual);
+  }
+
+  @Test
+  public void testFormatDependencyPaths_irrelevantJar() {
+    ImmutableListMultimap<Path, DependencyPath> tree =
+        ImmutableListMultimap.of(jarA, dependencyPath_A);
+
+    ClassPathResult classPathResult = new ClassPathResult(tree, ImmutableSet.of());
+
+    try {
+      classPathResult.formatDependencyPaths(ImmutableList.of(jarB));
+      fail("The irrelevant JAR file should be invalidated.");
+    } catch (IllegalArgumentException ex) {
+      // pass
+      assertEquals("b.jar is not in the class path", ex.getMessage());
+    }
+  }
+}

--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
@@ -26,7 +26,6 @@ import com.google.cloud.tools.opensource.classpath.LinkageChecker;
 import com.google.cloud.tools.opensource.classpath.SymbolProblem;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.Bom;
-import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.cloud.tools.opensource.dependencies.MavenRepositoryException;
 import com.google.cloud.tools.opensource.dependencies.RepositoryUtility;
 import com.google.common.annotations.VisibleForTesting;
@@ -231,12 +230,7 @@ public class LinkageMonitor {
     }
 
     message.append("\n");
-    for (Path problematicJar : problematicJars.build()) {
-      message.append(problematicJar.getFileName() + " is at:\n");
-      for (DependencyPath dependencyPath : classPathResult.getDependencyPaths(problematicJar)) {
-        message.append("  " + dependencyPath + "\n");
-      }
-    }
+    message.append(classPathResult.formatDependencyPaths(problematicJars.build()));
 
     return message.toString();
   }


### PR DESCRIPTION
Applying #981 (and #983) for LinkageCheckerMain, which I use for Apache Beam.

Example output:
```
beam-sdks-java-core-2.20.0-SNAPSHOT.jar is at:
  org.apache.beam:beam-sdks-java-io-hadoop-format:2.20.0-SNAPSHOT (compile) / org.apache.beam:beam-sdks-java-core:2.20.0-SNAPSHOT (compile)
  and 1 dependency path.
beam-vendor-bytebuddy-1_9_3-0.1.jar is at:
  org.apache.beam:beam-sdks-java-io-hadoop-format:2.20.0-SNAPSHOT (compile) / org.apache.beam:beam-sdks-java-core:2.20.0-SNAPSHOT (compile) / org.apache.beam:beam-vendor-bytebuddy-1_9_3:0.1 (compile)
  and 1 dependency path.
jackson-xc-1.8.3.jar is at:
  org.apache.beam:beam-sdks-java-io-hadoop-format:2.20.0-SNAPSHOT (compile) / org.apache.hadoop:hadoop-common:2.8.5 (provided) / com.sun.jersey:jersey-json:1.9 (compile) / org.codehaus.jackson:jackson-xc:1.8.3 (compile)
  and 125 other dependency paths.
jackson-mapper-asl-1.9.13.jar is at:
  org.apache.beam:beam-sdks-java-io-hadoop-format:2.20.0-SNAPSHOT (compile) / org.apache.hadoop:hadoop-common:2.8.5 (provided) / org.codehaus.jackson:jackson-mapper-asl:1.9.13 (compile)
  and 177 other dependency paths.
weld-osgi-bundle-1.1.0.Final.jar is at:
  org.apache.beam:beam-sdks-java-io-hadoop-format:2.20.0-SNAPSHOT (compile) / org.apache.hadoop:hadoop-common:2.8.5 (provided) / com.sun.jersey:jersey-server:1.9 (compile) / org.jboss.weld:weld-osgi-bundle:1.1.0.Final (provided)
  and 151 other dependency paths.
guava-11.0.2.jar is at:
  org.apache.beam:beam-sdks-java-io-hadoop-format:2.20.0-SNAPSHOT (compile) / org.apache.hadoop:hadoop-common:2.8.5 (provided) / com.google.guava:guava:11.0.2 (compile)
  and 194 other dependency paths.
apacheds-kerberos-codec-2.0.0-M15.jar is at:
  org.apache.beam:beam-sdks-java-io-hadoop-format:2.20.0-SNAPSHOT (compile) / org.apache.hadoop:hadoop-common:2.8.5 (provided) / org.apache.hadoop:hadoop-auth:2.8.5 (compile) / org.apache.directory.server:apacheds-kerberos-codec:2.0.0-M15 (compile)
  and 100 other dependency paths.

```
