### PR TITLE
Linkage Monitor to work with repositories that hosts other BOMs than google-cloud-bom

### DIFF
--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
@@ -288,14 +288,13 @@ public class LinkageMonitor {
     modelRequest.setTwoPhaseBuilding(true); // This forces the builder stop after phase 1
     modelRequest.setPomFile(bomResult.getArtifact().getFile());
     modelRequest.setModelResolver(
-        new ProjectModelResolver(
+        new VersionSubstitutingModelResolver(
             session,
             null,
             repositorySystem,
             new DefaultRemoteRepositoryManager(),
             ImmutableList.of(CENTRAL), // Needed when parent pom is not locally available
-            null,
-            null));
+            localArtifacts));
     // Profile activation needs JDK version through system properties
     // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/923
     modelRequest.setSystemProperties(System.getProperties());

--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/VersionSubstitutingModelResolver.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/VersionSubstitutingModelResolver.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.dependencies.linkagemonitor;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.maven.model.building.ModelSource;
+import org.apache.maven.model.resolution.ModelResolver;
+import org.apache.maven.model.resolution.UnresolvableModelException;
+import org.apache.maven.project.ProjectModelResolver;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.RequestTrace;
+import org.eclipse.aether.impl.RemoteRepositoryManager;
+import org.eclipse.aether.repository.RemoteRepository;
+
+import java.util.List;
+
+/**
+ * POM Resolver that substitutes the version of a POM specified in {@code versionSubstitution} map.
+ * {@code VersionSubstitution}'s keys are versionless coordinates ({@code groupId:artifactId}) and
+ * the values are the version to use when resolving the corresponding artifacts.
+ */
+class VersionSubstitutingModelResolver extends ProjectModelResolver {
+
+  private final ImmutableMap<String, String> versionSubstitution;
+
+  // Following fields are for newCopy method.
+  private final RepositorySystemSession session;
+  private final RequestTrace trace;
+  private final RepositorySystem resolver;
+  private final RemoteRepositoryManager remoteRepositoryManager;
+  private final ImmutableList<RemoteRepository> repositories;
+
+  VersionSubstitutingModelResolver(
+      RepositorySystemSession session,
+      RequestTrace trace,
+      RepositorySystem resolver,
+      RemoteRepositoryManager remoteRepositoryManager,
+      List<RemoteRepository> repositories,
+      Map<String, String> versionSubstitution) {
+    super(session, trace, resolver, remoteRepositoryManager, repositories, null, null);
+    this.session = session;
+    this.trace = trace;
+    this.resolver = resolver;
+    this.remoteRepositoryManager = remoteRepositoryManager;
+    this.repositories = ImmutableList.copyOf(repositories);
+    this.versionSubstitution = ImmutableMap.copyOf(versionSubstitution);
+  }
+
+  /**
+   * Returns model source for {@code groupId:artifactId:version}. The version is substituted if
+   * {@link #versionSubstitution} contains the versionless coordinates ({@code groupId:artifactId})
+   * in its keys.
+   */
+  @Override
+  public ModelSource resolveModel(String groupId, String artifactId, String version)
+      throws UnresolvableModelException {
+    String versionlessCoordinates = groupId + ":" + artifactId;
+    String versionToResolve = versionSubstitution.getOrDefault(versionlessCoordinates, version);
+    return super.resolveModel(groupId, artifactId, versionToResolve);
+  }
+
+  @Override
+  public ModelResolver newCopy() {
+    return new VersionSubstitutingModelResolver(
+        session, trace, resolver, remoteRepositoryManager, repositories, versionSubstitution);
+  }
+}

--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/VersionSubstitutingModelResolver.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/VersionSubstitutingModelResolver.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.dependencies.linkagemonitor;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.maven.model.building.ModelSource;
 import org.apache.maven.model.resolution.ModelResolver;
@@ -29,12 +30,15 @@ import org.eclipse.aether.RequestTrace;
 import org.eclipse.aether.impl.RemoteRepositoryManager;
 import org.eclipse.aether.repository.RemoteRepository;
 
-import java.util.List;
-
 /**
- * POM Resolver that substitutes the version of a POM specified in {@code versionSubstitution} map.
- * {@code VersionSubstitution}'s keys are versionless coordinates ({@code groupId:artifactId}) and
- * the values are the version to use when resolving the corresponding artifacts.
+ * Model resolver that substitutes the version of a POM specified in {@code versionSubstitution}
+ * map. {@code VersionSubstitution}'s keys are versionless coordinates ({@code groupId:artifactId})
+ * and the values are the version to use when resolving the corresponding artifacts.
+ *
+ * <p>For example, when {@code versionSubstitution} contains a key-value pair of {@code
+ * "com.google.guava:guava-bom" → "25.1-android"}, {@link VersionSubstitutingModelResolver}
+ * substitutes the version of model building requests that has {@code groupId:com.google.guava} and
+ * {@code artifactId:guava-bom} with {@code 25.1-android}.
  */
 class VersionSubstitutingModelResolver extends ProjectModelResolver {
 

--- a/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/VersionSubstitutingModelResolverTest.java
+++ b/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/VersionSubstitutingModelResolverTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.dependencies.linkagemonitor;
+
+import static com.google.cloud.tools.opensource.dependencies.RepositoryUtility.CENTRAL;
+
+import com.google.cloud.tools.opensource.dependencies.RepositoryUtility;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.truth.Correspondence;
+import com.google.common.truth.Truth;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.building.DefaultModelBuilder;
+import org.apache.maven.model.building.DefaultModelBuilderFactory;
+import org.apache.maven.model.building.DefaultModelBuildingRequest;
+import org.apache.maven.model.building.ModelBuildingException;
+import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.model.building.ModelBuildingResult;
+import org.apache.maven.model.building.ModelSource;
+import org.apache.maven.model.resolution.ModelResolver;
+import org.apache.maven.model.resolution.UnresolvableModelException;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.internal.impl.DefaultRemoteRepositoryManager;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.junit.Test;
+
+public class VersionSubstitutingModelResolverTest {
+  private static final DefaultModelBuilder modelBuilder =
+      new DefaultModelBuilderFactory().newInstance();
+
+  private final RepositorySystem repositorySystem = RepositoryUtility.newRepositorySystem();
+  private final RepositorySystemSession session = RepositoryUtility.newSession(repositorySystem);
+  private final DefaultRemoteRepositoryManager remoteRepositoryManager =
+      new DefaultRemoteRepositoryManager();;
+
+  private final Correspondence<Dependency, String> dependencyToCoordinates =
+      Correspondence.transforming(
+          (Dependency dependency) ->
+              dependency.getGroupId()
+                  + ":"
+                  + dependency.getArtifactId()
+                  + ":"
+                  + dependency.getVersion(),
+          "has dependency of coordinates");
+
+  @Test
+  public void testSubstitution() throws ArtifactResolutionException, ModelBuildingException {
+
+    // Google-cloud-bom 0.121.0-alpha imports google-auth-library-bom 0.19.0.
+    DefaultArtifact googleCloudBom =
+        new DefaultArtifact("com.google.cloud:google-cloud-bom:pom:0.121.0-alpha");
+    ArtifactResult bomResult =
+        repositorySystem.resolveArtifact(
+            session, new ArtifactRequest(googleCloudBom, ImmutableList.of(CENTRAL), null));
+
+    ImmutableMap<String, String> substitution =
+        ImmutableMap.of(
+            "com.google.auth:google-auth-library-bom",
+            "0.18.0" // This is intentionally different from 0.19.0
+            );
+    VersionSubstitutingModelResolver resolver =
+        new VersionSubstitutingModelResolver(
+            session,
+            null,
+            repositorySystem,
+            remoteRepositoryManager,
+            ImmutableList.of(CENTRAL), // Needed when parent pom is not locally available
+            substitution);
+
+    ModelBuildingRequest modelRequest = new DefaultModelBuildingRequest();
+    modelRequest.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
+    modelRequest.setPomFile(bomResult.getArtifact().getFile());
+    modelRequest.setModelResolver(resolver);
+    modelRequest.setSystemProperties(System.getProperties()); // for Java version property
+
+    ModelBuildingResult result = modelBuilder.build(modelRequest);
+    DependencyManagement dependencyManagement =
+        result.getEffectiveModel().getDependencyManagement();
+
+    Truth.assertWithMessage(
+            "Google-cloud-bom's google-auth-library part should be substituted for a different version.")
+        .that(dependencyManagement.getDependencies())
+        .comparingElementsUsing(dependencyToCoordinates)
+        .contains("com.google.auth:google-auth-library-credentials:0.18.0");
+  }
+
+  @Test
+  public void testNewCopy() throws UnresolvableModelException {
+    ImmutableMap<String, String> substitution =
+        ImmutableMap.of("com.google.guava:guava", "25.1-jre");
+    VersionSubstitutingModelResolver resolver =
+        new VersionSubstitutingModelResolver(
+            session,
+            null,
+            repositorySystem,
+            remoteRepositoryManager,
+            ImmutableList.of(CENTRAL), // Needed when parent pom is not locally available
+            substitution);
+
+    ModelResolver copiedResolver = resolver.newCopy();
+    Truth.assertThat(copiedResolver).isInstanceOf(VersionSubstitutingModelResolver.class);
+
+    // request for guava:20.0 is replaced with 25.1-jre
+    ModelSource guavaModelSource = copiedResolver.resolveModel("com.google.guava", "guava", "20.0");
+    Truth.assertThat(guavaModelSource.getLocation()).contains("guava-25.1-jre.pom");
+  }
+}


### PR DESCRIPTION
Fixes #1154 .

# Problem to solve

Before this PR, Linkage Monitor does not check the updated BOM in a repository. Suppose Linkage Monitor is setup for https://github.com/googleapis/google-auth-library-java. It ignores any new change in the google-auth-library-bom.

# How to solve

Maven's model builder provides API `modelRequest.setModelResolver(ModelResolver modelResolver)`, where we can intercept model resolution. This PR leverages the API by introducing `VersionSubstitutingModelResolver` which substitutes the versions of specified Maven coordinates.



