### PR TITLE
Fixed the relativize order

### DIFF
--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
@@ -120,12 +120,9 @@ public class LinkageMonitor {
         continue;
       }
 
-      if (path.isAbsolute()) {
-        // relative path from project directory
-        path = projectDirectory.relativize(path);
-      }
       // This path element check should not depend on directory name outside the project
-      ImmutableSet<Path> elements = ImmutableSet.copyOf(path);
+      Path relativePath = path.isAbsolute() ? projectDirectory.relativize(path) : path;
+      ImmutableSet<Path> elements = ImmutableSet.copyOf(relativePath);
       if (elements.contains(Paths.get("build")) || elements.contains(Paths.get("target"))) {
         // Exclude Gradle's build directory and Maven's target directory, which would contain irrelevant pom.xml such as
         // gax/build/tmp/expandedArchives/(... omit ...)/META-INF/maven/org.jacoco/org.jacoco.agent/pom.xml

--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
@@ -121,9 +121,8 @@ public class LinkageMonitor {
       }
 
       if (path.isAbsolute()) {
-        // As of Guava 28, MoreFiles.fileTraverser returns relative paths. Just in case it changes the behavior,
-        // converting absolute paths to relative paths.
-        path = path.relativize(Paths.get(".").toAbsolutePath());
+        // relative path from project directory
+        path = projectDirectory.relativize(path);
       }
       // This path element check should not depend on directory name outside the project
       ImmutableSet<Path> elements = ImmutableSet.copyOf(path);

--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
@@ -30,7 +30,6 @@ import com.google.cloud.tools.opensource.dependencies.MavenRepositoryException;
 import com.google.cloud.tools.opensource.dependencies.RepositoryUtility;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
-import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;

--- a/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
+++ b/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
@@ -235,10 +235,22 @@ public class LinkageMonitorTest {
 
   @Test
   public void testFindLocalArtifacts() {
-    // Current working directory of linkage-monitor should have one linkage monitor artifact
     ImmutableMap<String, String> localArtifacts =
         LinkageMonitor.findLocalArtifacts(
             system, session, Paths.get("src/test/resources/testproject"));
+
+    // This should not include project under "build" directory
+    Truth.assertThat(localArtifacts).hasSize(2);
+    Truth.assertThat(localArtifacts).containsKey("com.google.cloud.tools:test-project");
+    Truth.assertThat(localArtifacts).containsKey("com.google.cloud.tools:test-subproject");
+  }
+
+  @Test
+  public void testFindLocalArtifacts_absolutePath() {
+    Path absolutePath = Paths.get("src/test/resources/testproject").toAbsolutePath();
+    ImmutableMap<String, String> localArtifacts =
+            LinkageMonitor.findLocalArtifacts(
+                    system, session, absolutePath);
 
     Truth.assertThat(localArtifacts).hasSize(2);
     Truth.assertThat(localArtifacts).containsKey("com.google.cloud.tools:test-project");

--- a/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
+++ b/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
@@ -247,13 +247,16 @@ public class LinkageMonitorTest {
 
   @Test
   public void testFindLocalArtifacts_absolutePath() {
-    Path absolutePath = Paths.get("src/test/resources/testproject").toAbsolutePath();
-    ImmutableMap<String, String> localArtifacts =
+    Path relativePath = Paths.get("src/test/resources/testproject");
+    Path absolutePath = relativePath.toAbsolutePath();
+    ImmutableMap<String, String> localArtifactsFromAbsolutePath =
             LinkageMonitor.findLocalArtifacts(
                     system, session, absolutePath);
 
-    Truth.assertThat(localArtifacts).hasSize(2);
-    Truth.assertThat(localArtifacts).containsKey("com.google.cloud.tools:test-project");
-    Truth.assertThat(localArtifacts).containsKey("com.google.cloud.tools:test-subproject");
+    ImmutableMap<String, String> localArtifactsFromRelativePath =
+            LinkageMonitor.findLocalArtifacts(
+                    system, session, relativePath);
+
+    assertEquals(localArtifactsFromRelativePath, localArtifactsFromAbsolutePath);
   }
 }

--- a/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
+++ b/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
@@ -250,13 +250,14 @@ public class LinkageMonitorTest {
     Path relativePath = Paths.get("src/test/resources/testproject");
     Path absolutePath = relativePath.toAbsolutePath();
     ImmutableMap<String, String> localArtifactsFromAbsolutePath =
-            LinkageMonitor.findLocalArtifacts(
-                    system, session, absolutePath);
+        LinkageMonitor.findLocalArtifacts(system, session, absolutePath);
 
     ImmutableMap<String, String> localArtifactsFromRelativePath =
-            LinkageMonitor.findLocalArtifacts(
-                    system, session, relativePath);
+        LinkageMonitor.findLocalArtifacts(system, session, relativePath);
 
-    assertEquals(localArtifactsFromRelativePath, localArtifactsFromAbsolutePath);
+    assertEquals(
+        "findLocalArtifacts should behave the same for relative and absolute paths",
+        localArtifactsFromRelativePath,
+        localArtifactsFromAbsolutePath);
   }
 }


### PR DESCRIPTION
Fixing the previous commit on `relativize` and added tst.

My assumption on `MoreFiles.fileTraverser` always returning relative paths, was wrong. `MoreFiles.fileTraverser` returns absolute paths when it takes an absolute path. And my use of relativize was incorrect.