### PR TITLE
DependencyGraphBuilder.buildLinkageCheckDependencyGraph to catch DependencyResolutionException

### DIFF
--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -169,8 +169,7 @@ public class DashboardMain {
 
   @VisibleForTesting
   static Path generate(Path bomFile)
-      throws IOException, TemplateException, RepositoryException, URISyntaxException,
-      MavenRepositoryException {
+      throws IOException, TemplateException, URISyntaxException, MavenRepositoryException {
     checkArgument(Files.isRegularFile(bomFile), "The input BOM %s is not a regular file", bomFile);
     checkArgument(Files.isReadable(bomFile), "The input BOM %s is not readable", bomFile);
     Path output = generate(RepositoryUtility.readBom(bomFile));
@@ -178,8 +177,7 @@ public class DashboardMain {
     return output;
   }
 
-  private static Path generate(Bom bom)
-      throws IOException, TemplateException, RepositoryException, URISyntaxException {
+  private static Path generate(Bom bom) throws IOException, TemplateException, URISyntaxException {
 
     ImmutableList<Artifact> managedDependencies = bom.getManagedDependencies();
 

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -339,23 +339,18 @@ public class DashboardMain {
     List<DependencyGraph> globalDependencies = new ArrayList<>();
 
     for (Artifact artifact : artifacts) {
-      try {
-        DependencyGraphResult completeDependencyResult =
-            dependencyGraphBuilder.buildCompleteGraph(new Dependency(artifact, "compile"));
-        DependencyGraph completeDependencies = completeDependencyResult.getDependencyGraph();
-        globalDependencies.add(completeDependencies);
+      DependencyGraphResult completeDependencyResult =
+          dependencyGraphBuilder.buildCompleteGraph(new Dependency(artifact, "compile"));
+      DependencyGraph completeDependencies = completeDependencyResult.getDependencyGraph();
+      globalDependencies.add(completeDependencies);
 
-        // picks versions according to Maven rules
-        DependencyGraphResult transitiveDependencyResult =
-            dependencyGraphBuilder.buildGraph(new Dependency(artifact, "compile"));
-        DependencyGraph transitiveDependencies = transitiveDependencyResult.getDependencyGraph();
+      // picks versions according to Maven rules
+      DependencyGraphResult transitiveDependencyResult =
+          dependencyGraphBuilder.buildGraph(new Dependency(artifact, "compile"));
+      DependencyGraph transitiveDependencies = transitiveDependencyResult.getDependencyGraph();
 
-        ArtifactInfo info = new ArtifactInfo(completeDependencies, transitiveDependencies);
-        infoMap.put(artifact, info);
-      } catch (RepositoryException ex) {
-        ArtifactInfo info = new ArtifactInfo(ex);
-        infoMap.put(artifact, info);
-      }
+      ArtifactInfo info = new ArtifactInfo(completeDependencies, transitiveDependencies);
+      infoMap.put(artifact, info);
     }
 
     ArtifactCache cache = new ArtifactCache();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
@@ -27,7 +27,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 
 /**
@@ -59,9 +58,8 @@ public final class ClassPathBuilder {
    * closest' strategy follows Maven's dependency mediation.
    *
    * @param artifacts Maven artifacts to check. They are treated as the root of the dependency tree.
-   * @throws RepositoryException when there is a problem retrieving jar files
    */
-  public ClassPathResult resolve(List<Artifact> artifacts) throws RepositoryException {
+  public ClassPathResult resolve(List<Artifact> artifacts) {
 
     LinkedListMultimap<Path, DependencyPath> multimap = LinkedListMultimap.create();
     if (artifacts.isEmpty()) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
@@ -23,6 +23,8 @@ import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Maps;
+
+import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -76,7 +78,12 @@ public final class ClassPathBuilder {
 
     for (DependencyPath dependencyPath : dependencyPaths) {
       Artifact artifact = dependencyPath.getLeaf();
-      Path jarAbsolutePath = artifact.getFile().toPath().toAbsolutePath();
+      File file = artifact.getFile();
+      if (file == null) {
+        // When artifact was not downloaded, it's recorded in result.getArtifactProblems().
+        continue;
+      }
+      Path jarAbsolutePath = file.toPath().toAbsolutePath();
       if (!jarAbsolutePath.toString().endsWith(".jar")) {
         continue;
       }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
@@ -68,7 +68,7 @@ public final class ClassPathBuilder {
     }
     // dependencyGraph holds multiple versions for one artifact key (groupId:artifactId)
     DependencyGraphResult result =
-        dependencyGraphBuilder.getStaticLinkageCheckDependencyGraph(artifacts);
+        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(artifacts);
     List<DependencyPath> dependencyPaths = result.getDependencyGraph().list();
 
     // To remove duplicates on (groupId:artifactId) for dependency mediation

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
@@ -67,7 +67,7 @@ public final class ClassPathBuilder {
     }
     // dependencyGraph holds multiple versions for one artifact key (groupId:artifactId)
     DependencyGraphResult result =
-        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(artifacts);
+        dependencyGraphBuilder.getStaticLinkageCheckDependencyGraph(artifacts);
     List<DependencyPath> dependencyPaths = result.getDependencyGraph().list();
 
     // To remove duplicates on (groupId:artifactId) for dependency mediation

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
@@ -23,7 +23,6 @@ import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Maps;
-
 import java.io.File;
 import java.nio.file.Path;
 import java.util.List;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathResult.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathResult.java
@@ -67,7 +67,7 @@ public final class ClassPathResult {
   }
 
   /** Returns problems encountered while constructing the dependency graph. */
-  ImmutableList<UnresolvableArtifactProblem> getArtifactProblems() {
+  public ImmutableList<UnresolvableArtifactProblem> getArtifactProblems() {
     return artifactProblems;
   }
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -42,7 +42,6 @@ import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.FieldOrMethod;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
-import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 
 /** A tool to find linkage errors in a class path. */
@@ -83,7 +82,7 @@ public class LinkageChecker {
     return new LinkageChecker(dumper, jars, symbolReferenceMaps, classReferenceGraph);
   }
 
-  public static LinkageChecker create(Bom bom) throws RepositoryException, IOException {
+  public static LinkageChecker create(Bom bom) throws IOException {
     // duplicate code from DashboardMain follows. We need to refactor to extract this.
     ImmutableList<Artifact> managedDependencies = bom.getManagedDependencies();
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerArguments.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerArguments.java
@@ -205,8 +205,8 @@ final class LinkageCheckerArguments {
       ClassPathResult result = classPathBuilder.resolve(artifacts);
       ImmutableList<UnresolvableArtifactProblem> artifactProblems = result.getArtifactProblems();
       if (!artifactProblems.isEmpty()) {
-        throw new RepositoryException("Unresolved artifacts: " + Joiner.on(",").join(
-            artifactProblems));
+        throw new RepositoryException(
+            "Unresolved artifacts: " + Joiner.on(",").join(artifactProblems));
       }
       cachedInputClasspath = result.getClassPath();
     } else {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerArguments.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerArguments.java
@@ -20,6 +20,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.cloud.tools.opensource.dependencies.RepositoryUtility;
+import com.google.cloud.tools.opensource.dependencies.UnresolvableArtifactProblem;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.nio.file.Path;
@@ -200,7 +202,13 @@ final class LinkageCheckerArguments {
 
     if (commandLine.hasOption("b") || commandLine.hasOption("a")) {
       List<Artifact> artifacts = getArtifacts();
-      cachedInputClasspath = classPathBuilder.resolve(artifacts).getClassPath();
+      ClassPathResult result = classPathBuilder.resolve(artifacts);
+      ImmutableList<UnresolvableArtifactProblem> artifactProblems = result.getArtifactProblems();
+      if (!artifactProblems.isEmpty()) {
+        throw new RepositoryException("Unresolved artifacts: " + Joiner.on(",").join(
+            artifactProblems));
+      }
+      cachedInputClasspath = result.getClassPath();
     } else {
       // b, a, or j is specified in OptionGroup
       String[] jarFiles = commandLine.getOptionValues("j");

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerArguments.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerArguments.java
@@ -206,7 +206,7 @@ final class LinkageCheckerArguments {
       ImmutableList<UnresolvableArtifactProblem> artifactProblems = result.getArtifactProblems();
       if (!artifactProblems.isEmpty()) {
         throw new RepositoryException(
-            "Unresolved artifacts: " + Joiner.on(",").join(artifactProblems));
+            "Unresolved artifacts: " + Joiner.on(", ").join(artifactProblems));
       }
       cachedInputClasspath = result.getClassPath();
     } else {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
@@ -84,8 +84,13 @@ public abstract class ArtifactProblem {
 
   @Override
   public boolean equals(Object other) {
-    if (this == other) return true;
-    if (other == null || getClass() != other.getClass()) return false;
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+
     ArtifactProblem otherProblem = (ArtifactProblem) other;
     return Objects.equals(artifact, otherProblem.artifact)
         && sameDependencyPath(dependencyPath, otherProblem.dependencyPath);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
@@ -93,11 +93,11 @@ public abstract class ArtifactProblem {
 
     ArtifactProblem otherProblem = (ArtifactProblem) other;
     return Objects.equals(artifact, otherProblem.artifact)
-        && sameDependencyPath(dependencyPath, otherProblem.dependencyPath);
+        && equalsOnDependencies(dependencyPath, otherProblem.dependencyPath);
   }
 
-  private static boolean sameDependencyPath(
-      ImmutableList<DependencyNode> listA, ImmutableList<DependencyNode> listB) {
+  private static boolean equalsOnDependencies(
+      List<DependencyNode> listA, List<DependencyNode> listB) {
     int size = listA.size();
     if (listB.size() != size) {
       return false;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -237,7 +237,7 @@ public final class DependencyGraphBuilder {
     // root node
     DependencyNode node =
         resolveDependencyGraph(ImmutableList.of(new DefaultDependencyNode(dependency)), false);
-    return levelOrder(node);
+    return levelOrder(node, GraphTraversalOption.NONE);
   }
 
   private static final class LevelOrderQueueItem {
@@ -248,10 +248,6 @@ public final class DependencyGraphBuilder {
       this.dependencyNode = dependencyNode;
       this.parentNodes = parentNodes;
     }
-  }
-
-  private DependencyGraphResult levelOrder(DependencyNode node) {
-    return levelOrder(node, GraphTraversalOption.NONE);
   }
 
   private enum GraphTraversalOption {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -208,7 +208,6 @@ public final class DependencyGraphBuilder {
    *
    * @param artifacts Maven artifacts to retrieve their dependencies
    * @return dependency graph representing the tree of Maven artifacts
-   * @throws RepositoryException when there is a problem resolving or collecting dependencies
    */
   public DependencyGraphResult buildLinkageCheckDependencyGraph(List<Artifact> artifacts) {
     ImmutableList<DependencyNode> dependencyNodes =

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -191,7 +191,8 @@ public final class DependencyGraphBuilder {
 
     List<DependencyNode> result = new ArrayList<>();
 
-    DependencyNode node = resolveDependencyGraph(ImmutableList.of(new DefaultDependencyNode(dependency)), false);
+    DependencyNode node =
+        resolveDependencyGraph(ImmutableList.of(new DefaultDependencyNode(dependency)), false);
     for (DependencyNode child : node.getChildren()) {
       result.add(child);
     }
@@ -234,7 +235,8 @@ public final class DependencyGraphBuilder {
   public DependencyGraphResult buildGraph(Dependency dependency)
       throws RepositoryException {
     // root node
-    DependencyNode node = resolveDependencyGraph(ImmutableList.of(new DefaultDependencyNode(dependency)), false);
+    DependencyNode node =
+        resolveDependencyGraph(ImmutableList.of(new DefaultDependencyNode(dependency)), false);
     return levelOrder(node);
   }
 
@@ -317,7 +319,8 @@ public final class DependencyGraphBuilder {
           try {
             boolean includeProvidedScope =
                 graphTraversalOption == GraphTraversalOption.FULL_DEPENDENCY_WITH_PROVIDED;
-            dependencyNode = resolveDependencyGraph(ImmutableList.of(dependencyNode), includeProvidedScope);
+            dependencyNode =
+                resolveDependencyGraph(ImmutableList.of(dependencyNode), includeProvidedScope);
           } catch (DependencyResolutionException resolutionException) {
             // A dependency may be unavailable. For example, com.google.guava:guava-gwt:jar:20.0
             // has a transitive dependency to org.eclipse.jdt.core.compiler:ecj:jar:4.4RC4 (not

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -242,14 +242,15 @@ public final class DependencyGraphBuilder {
         traversalOption == GraphTraversalOption.FULL_DEPENDENCY_WITH_PROVIDED;
     DependencyNode node;
     ImmutableSet.Builder<UnresolvableArtifactProblem> artifactProblems = ImmutableSet.builder();
+
     try {
       node = resolveDependencyGraph(dependencyNodes, includeProvidedScope);
     } catch (DependencyResolutionException ex) {
       DependencyResult result = ex.getResult();
       node = result.getRoot();
       for (ArtifactResult artifactResult : result.getArtifactResults()) {
-        List<Exception> exceptions = artifactResult.getExceptions();
-        if (exceptions.isEmpty()) {
+        Artifact resolvedArtifact = artifactResult.getArtifact();
+        if (resolvedArtifact != null) {
           continue;
         }
         Artifact requestedArtifact = artifactResult.getRequest().getArtifact();
@@ -258,7 +259,9 @@ public final class DependencyGraphBuilder {
     }
 
     DependencyGraphResult result = levelOrder(node, traversalOption);
+    // Duplicate problems found in resolveDependencyGraph and levelOrder are removed by ImmutableSet
     artifactProblems.addAll(result.getArtifactProblems());
+
     return new DependencyGraphResult(result.getDependencyGraph(), artifactProblems.build());
   }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ClassPathBuilderTest {
@@ -131,15 +130,15 @@ public class ClassPathBuilderTest {
   }
 
   @Test
-  public void testResolveClassPath_invalidCoordinate() {
+  public void testResolveClassPath_invalidCoordinate() throws RepositoryException {
     Artifact nonExistentArtifact = new DefaultArtifact("io.grpc:nosuchartifact:1.2.3");
-    try {
-      classPathBuilder.resolve(ImmutableList.of(nonExistentArtifact));
-      Assert.fail("Invalid Maven coodinate should raise RepositoryException");
-    } catch (RepositoryException ex) {
-      Truth.assertThat(ex.getMessage())
-          .contains("Could not find artifact io.grpc:nosuchartifact:jar:1.2.3");
-    }
+    ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(nonExistentArtifact));
+    ImmutableList<UnresolvableArtifactProblem> artifactProblems = result.getArtifactProblems();
+    Truth.assertThat(artifactProblems).hasSize(1);
+    assertEquals(
+        "io.grpc:nosuchartifact:jar:1.2.3 was not resolved. Dependency path:"
+            + " io.grpc:nosuchartifact:jar:1.2.3 (compile)",
+        artifactProblems.get(0).toString());
   }
 
   @Test

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -43,14 +43,14 @@ public class ClassPathBuilderTest {
 
   private ClassPathBuilder classPathBuilder = new ClassPathBuilder();
 
-  private ImmutableList<Path> resolveClassPath(String coordinates) throws RepositoryException {
+  private ImmutableList<Path> resolveClassPath(String coordinates) {
     Artifact artifact = new DefaultArtifact(coordinates);
     ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(artifact));
     return result.getClassPath();
   }
 
   @Test
-  public void testResolve_removingDuplicates() throws RepositoryException {
+  public void testResolve_removingDuplicates() {
     Artifact grpcArtifact = new DefaultArtifact("io.grpc:grpc-auth:1.15.1");
     ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(grpcArtifact));
 
@@ -69,11 +69,9 @@ public class ClassPathBuilderTest {
         .isGreaterThan(1);
   }
 
-  /**
-   * Test that BOM members come before the transitive dependencies.
-   */
+  /** Test that BOM members come before the transitive dependencies. */
   @Test
-  public void testBomToPaths_firstElementsAreBomMembers() throws RepositoryException {    
+  public void testBomToPaths_firstElementsAreBomMembers() throws RepositoryException {
     List<Artifact> managedDependencies = 
         RepositoryUtility.readBom("com.google.cloud:google-cloud-bom:0.81.0-alpha")
         .getManagedDependencies();
@@ -90,7 +88,7 @@ public class ClassPathBuilderTest {
   }
 
   @Test
-  public void testResolve() throws RepositoryException {
+  public void testResolve() {
 
     Artifact grpcAuth = new DefaultArtifact("io.grpc:grpc-auth:1.15.1");
 
@@ -107,7 +105,7 @@ public class ClassPathBuilderTest {
   }
 
   @Test
-  public void testresolveClassPath_validCoordinate() throws RepositoryException {
+  public void testresolveClassPath_validCoordinate() {
     List<Path> paths = resolveClassPath("io.grpc:grpc-auth:1.15.1");
 
     Truth.assertThat(paths)
@@ -124,13 +122,13 @@ public class ClassPathBuilderTest {
   }
 
   @Test
-  public void testResolveClassPath_optionalDependency() throws RepositoryException {
+  public void testResolveClassPath_optionalDependency() {
     List<Path> paths = resolveClassPath("com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha");
     Truth.assertThat(paths).comparingElementsUsing(PATH_FILE_NAMES).contains("log4j-1.2.12.jar");
   }
 
   @Test
-  public void testResolveClassPath_invalidCoordinate() throws RepositoryException {
+  public void testResolveClassPath_invalidCoordinate() {
     Artifact nonExistentArtifact = new DefaultArtifact("io.grpc:nosuchartifact:1.2.3");
     ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(nonExistentArtifact));
     ImmutableList<UnresolvableArtifactProblem> artifactProblems = result.getArtifactProblems();
@@ -142,14 +140,14 @@ public class ClassPathBuilderTest {
   }
 
   @Test
-  public void testResolve_emptyInput() throws RepositoryException {
+  public void testResolve_emptyInput() {
     List<Path> jars = classPathBuilder.resolve(ImmutableList.of()).getClassPath();
     Truth.assertThat(jars).isEmpty();
   }
 
   @Test
   public void testFindInvalidReferences_selfReferenceFromAbstractClassToInterface()
-      throws RepositoryException, IOException {
+      throws IOException {
     List<Path> paths = resolveClassPath("com.google.cloud:google-cloud-bigtable:jar:0.66.0-alpha");
     Path httpClientJar =
         paths
@@ -187,13 +185,13 @@ public class ClassPathBuilderTest {
   }
 
   @Test
-  public void testResolveClasspath_notToGenerateRepositoryException() throws RepositoryException {
+  public void testResolveClasspath_notToGenerateRepositoryException() {
     List<Path> paths = resolveClassPath("com.google.guava:guava-gwt:jar:20.0");
     Truth.assertThat(paths).isNotEmpty();
   }
 
   @Test
-  public void testResolve_artifactProblems() throws RepositoryException {
+  public void testResolve_artifactProblems() {
     // In the full dependency tree of hibernate-core, xerces-impl:2.6.2 and xml-apis:2.6.2 are not
     // available in Maven Central.
     Artifact hibernateCore = new DefaultArtifact("org.hibernate:hibernate-core:jar:3.5.1-Final");

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -75,7 +75,8 @@ public class LinkageCheckerTest {
   private ImmutableList<Path> resolveTransitiveDependencyPaths(String coordinates)
       throws RepositoryException {
     DependencyGraph dependencies =
-        dependencyGraphBuilder.buildGraph(new Dependency(new DefaultArtifact(coordinates), "compile"))
+        dependencyGraphBuilder
+            .buildGraph(new Dependency(new DefaultArtifact(coordinates), "compile"))
             .getDependencyGraph();
     ImmutableList<Path> jars =
         dependencies.list().stream()
@@ -681,8 +682,7 @@ public class LinkageCheckerTest {
           "Because the unavailable dependency is not optional, it should throw an exception");
     } catch (RepositoryException ex) {
       Truth.assertThat(ex.getMessage())
-          .startsWith(
-              "Unresolved artifacts: org.eclipse.jdt.core.compiler:ecj:jar:4.4RC4");
+          .startsWith("Unresolved artifacts: org.eclipse.jdt.core.compiler:ecj:jar:4.4RC4");
     }
   }
 
@@ -792,10 +792,15 @@ public class LinkageCheckerTest {
     // org.slf4j.MDC catches NoSuchMethodError to detect the availability of
     // implementation for logging backend. The tool should not show errors for such classes.
     DependencyGraph slf4jGraph =
-        dependencyGraphBuilder.buildGraph(new Dependency(new DefaultArtifact("org.slf4j:slf4j-api:1.7.26"), "compile"))
+        dependencyGraphBuilder
+            .buildGraph(
+                new Dependency(new DefaultArtifact("org.slf4j:slf4j-api:1.7.26"), "compile"))
             .getDependencyGraph();
     DependencyGraph logbackGraph =
-        dependencyGraphBuilder.buildGraph(new Dependency(new DefaultArtifact("ch.qos.logback:logback-classic:1.2.3"), "compile"))
+        dependencyGraphBuilder
+            .buildGraph(
+                new Dependency(
+                    new DefaultArtifact("ch.qos.logback:logback-classic:1.2.3"), "compile"))
             .getDependencyGraph();
 
     Path slf4jJar = slf4jGraph.list().get(0).getLeaf().getFile().toPath();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -64,7 +64,7 @@ public class LinkageCheckerTest {
   private Path firestorePath;
 
   /** Returns JAR files resolved for the full dependency tree of {@code coordinates}. */
-  static ImmutableList<Path> resolvePaths(String... coordinates) throws RepositoryException {
+  static ImmutableList<Path> resolvePaths(String... coordinates) {
     ImmutableList<Artifact> artifacts =
         Arrays.stream(coordinates).map(DefaultArtifact::new).collect(toImmutableList());
     ClassPathResult result = (new ClassPathBuilder()).resolve(artifacts);
@@ -72,8 +72,7 @@ public class LinkageCheckerTest {
   }
 
   /** Returns JAR files resolved for the transitive dependencies of {@code coordinates}. */
-  private ImmutableList<Path> resolveTransitiveDependencyPaths(String coordinates)
-      throws RepositoryException {
+  private ImmutableList<Path> resolveTransitiveDependencyPaths(String coordinates) {
     DependencyGraph dependencies =
         dependencyGraphBuilder
             .buildGraph(new Dependency(new DefaultArtifact(coordinates), "compile"))
@@ -755,8 +754,7 @@ public class LinkageCheckerTest {
   }
 
   @Test
-  public void testFindSymbolProblems_catchesNoClassDefFoundError()
-      throws RepositoryException, IOException {
+  public void testFindSymbolProblems_catchesNoClassDefFoundError() throws IOException {
     // SLF4J classes catch NoClassDefFoundError to detect the availability of logger backends
     // the tool should not show errors for such classes.
     List<Path> paths = resolvePaths("org.slf4j:slf4j-api:jar:1.7.21");
@@ -770,7 +768,7 @@ public class LinkageCheckerTest {
   }
 
   @Test
-  public void testFindSymbolProblems_catchesLinkageError() throws RepositoryException, IOException {
+  public void testFindSymbolProblems_catchesLinkageError() throws IOException {
     // org.eclipse.sisu.inject.Implementations catches LinkageError to detect the availability of
     // implementation for dependency injection. The tool should not show errors for such classes.
     List<Path> paths = resolvePaths("org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3");
@@ -787,8 +785,7 @@ public class LinkageCheckerTest {
   }
 
   @Test
-  public void testFindSymbolProblems_catchesNoSuchMethodError()
-      throws RepositoryException, IOException {
+  public void testFindSymbolProblems_catchesNoSuchMethodError() throws IOException {
     // org.slf4j.MDC catches NoSuchMethodError to detect the availability of
     // implementation for logging backend. The tool should not show errors for such classes.
     DependencyGraph slf4jGraph =
@@ -844,8 +841,7 @@ public class LinkageCheckerTest {
   }
 
   @Test
-  public void testFindSymbolProblems_shouldNotFailOnDuplicateClass()
-      throws RepositoryException, IOException {
+  public void testFindSymbolProblems_shouldNotFailOnDuplicateClass() throws IOException {
     // There was an issue (#495) where com.google.api.client.http.apache.ApacheHttpRequest is in
     // both google-http-client-1.19.0.jar and google-http-client-apache-2.0.0.jar.
     // LinkageChecker.findLinkageErrors was not handling the case properly.
@@ -862,10 +858,8 @@ public class LinkageCheckerTest {
     assertNotNull(symbolProblems);
   }
 
-
   @Test
-  public void testFindSymbolProblems_shouldNotDetectWhitelistedClass()
-      throws RepositoryException, IOException {
+  public void testFindSymbolProblems_shouldNotDetectWhitelistedClass() throws IOException {
     // Reactor-core's Traces is known to catch Throwable to detect availability of Java 9+ classes.
     // Linkage Checker does not need to report it.
     // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/816
@@ -880,8 +874,7 @@ public class LinkageCheckerTest {
   }
 
   @Test
-  public void testFindSymbolProblems_shouldDetectMissingParentClass()
-      throws RepositoryException, IOException {
+  public void testFindSymbolProblems_shouldDetectMissingParentClass() throws IOException {
     // There was a false positive of missing class problem of
     // com.oracle.graal.pointsto.meta.AnalysisType (in com.oracle.substratevm:svm:19.0.0). The class
     // was in the class path but its parent class was missing.
@@ -912,8 +905,7 @@ public class LinkageCheckerTest {
   }
 
   @Test
-  public void testFindSymbolProblems_shouldSuppressJvmCIPackage()
-      throws RepositoryException, IOException {
+  public void testFindSymbolProblems_shouldSuppressJvmCIPackage() throws IOException {
     // There was a false positive of missing class problem of
     // com.oracle.graal.pointsto.meta.AnalysisType (in com.oracle.substratevm:svm:19.0.0). The class
     // was in the class path but its parent class was missing.
@@ -931,7 +923,7 @@ public class LinkageCheckerTest {
 
   @Test
   public void testFindSymbolProblems_shouldSuppressMockitoMockMethodDispatcher()
-      throws RepositoryException, IOException {
+      throws IOException {
     // Mockito's MockMethodDispatcher class file has ".raw" extension so that the class is only
     // loaded by Mockito's special class loader.
     // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/407
@@ -992,8 +984,7 @@ public class LinkageCheckerTest {
   }
 
   @Test
-  public void testFindSymbolProblems_defaultInterfaceMethods()
-      throws IOException, RepositoryException {
+  public void testFindSymbolProblems_defaultInterfaceMethods() throws IOException {
     ImmutableList<Path> jars = resolvePaths("com.oracle.substratevm:svm:19.2.0.1");
 
     LinkageChecker linkageChecker = LinkageChecker.create(jars, jars);
@@ -1011,8 +1002,7 @@ public class LinkageCheckerTest {
   }
 
   @Test
-  public void testFindSymbolProblems_unimplementedAbstractMethod()
-      throws RepositoryException, IOException {
+  public void testFindSymbolProblems_unimplementedAbstractMethod() throws IOException {
     // Non-abstract NioEventLoopGroup class extends MultithreadEventLoopGroup.
     // Abstract MultithreadEventLoopGroup class extends MultithreadEventExecutorGroup
     // Abstract MultithreadEventExecutorGroup class has abstract newChild method.
@@ -1045,8 +1035,7 @@ public class LinkageCheckerTest {
   }
 
   @Test
-  public void testFindSymbolProblems_nativeMethodsOnAbstractClass()
-      throws IOException, RepositoryException {
+  public void testFindSymbolProblems_nativeMethodsOnAbstractClass() throws IOException {
     ImmutableList<Path> jars = resolvePaths("com.oracle.substratevm:svm:19.2.0.1");
 
     LinkageChecker linkageChecker = LinkageChecker.create(jars, jars);

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -682,8 +682,7 @@ public class LinkageCheckerTest {
     } catch (RepositoryException ex) {
       Truth.assertThat(ex.getMessage())
           .startsWith(
-              "Could not find artifact org.eclipse.jdt.core.compiler:ecj:jar:4.4RC4 in "
-                  + " (https://repo1.maven.org/maven2/)");
+              "Unresolved artifacts: org.eclipse.jdt.core.compiler:ecj:jar:4.4RC4");
     }
   }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblemTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.opensource.dependencies;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.DefaultDependencyNode;
@@ -80,5 +81,22 @@ public class ArtifactProblemTest {
         "foo:a:jar:1.0.0 was not resolved. Dependency path: foo:a:jar:1.0.0 (compile)\n"
             + "foo:b:jar:1.0.0 was not resolved. Dependency path: foo:b:jar:1.0.0 (provided)\n",
         actual);
+  }
+
+  @Test
+  public void testEquality() {
+    UnresolvableArtifactProblem problemA = new UnresolvableArtifactProblem(ImmutableList.of(nodeA));
+
+    Artifact artifactACopy = new DefaultArtifact("foo:a:1.0.0");
+    DependencyNode nodeACopy = new DefaultDependencyNode(new Dependency(artifactACopy, "compile"));
+    UnresolvableArtifactProblem problemACopy =
+        new UnresolvableArtifactProblem(ImmutableList.of(nodeACopy));
+
+    UnresolvableArtifactProblem problemB = new UnresolvableArtifactProblem(ImmutableList.of(nodeB));
+
+    new EqualsTester()
+        .addEqualityGroup(problemA, problemACopy)
+        .addEqualityGroup(problemB)
+        .testEquals();
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblemTest.java
@@ -92,11 +92,17 @@ public class ArtifactProblemTest {
     UnresolvableArtifactProblem problemACopy =
         new UnresolvableArtifactProblem(ImmutableList.of(nodeACopy));
 
+    DependencyNode nodeAWithProvidedScope =
+        new DefaultDependencyNode(new Dependency(artifactACopy, "provided"));
+    UnresolvableArtifactProblem problemAWithProvidedScope =
+        new UnresolvableArtifactProblem(ImmutableList.of(nodeAWithProvidedScope));
+
     UnresolvableArtifactProblem problemB = new UnresolvableArtifactProblem(ImmutableList.of(nodeB));
 
     new EqualsTester()
         .addEqualityGroup(problemA, problemACopy)
         .addEqualityGroup(problemB)
+        .addEqualityGroup(problemAWithProvidedScope)
         .testEquals();
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -248,8 +248,25 @@ public class DependencyGraphBuilderTest {
             ImmutableList.of(new DefaultArtifact("ant:ant:jar:1.6.2")));
 
     ImmutableList<UnresolvableArtifactProblem> problems = result.getArtifactProblems();
+
     Truth.assertThat(problems)
         .comparingElementsUsing(problemOnArtifact)
         .containsAtLeast("xerces:xerces-impl:2.6.2", "xml-apis:xml-apis:2.6.2");
+
+    Truth.assertThat(problems).hasSize(4);
+    Truth.assertThat(problems)
+        .comparingElementsUsing(
+            Correspondence.transforming(UnresolvableArtifactProblem::toString, "has description"))
+        .containsExactly(
+            "xerces:xerces-impl:jar:2.6.2 was not resolved. Dependency path: ant:ant:jar:1.6.2"
+                + " (compile) > xerces:xerces-impl:jar:2.6.2 (compile?)",
+            "xml-apis:xml-apis:jar:2.6.2 was not resolved. Dependency path: ant:ant:jar:1.6.2"
+                + " (compile) > xml-apis:xml-apis:jar:2.6.2 (compile?)",
+            "xerces:xerces-impl:jar:2.6.2 was not resolved. Dependency path: ant:ant:jar:1.6.2"
+                + " (compile) > xerces:xerces-impl:jar:2.6.2 (compile?) >"
+                + " xerces:xerces-impl:jar:2.6.2 (compile?)",
+            "xml-apis:xml-apis:jar:2.6.2 was not resolved. Dependency path: ant:ant:jar:1.6.2"
+                + " (compile) > xml-apis:xml-apis:jar:2.6.2 (compile?) >"
+                + " xml-apis:xml-apis:jar:2.6.2 (compile?)");
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -247,6 +247,7 @@ public class DependencyGraphBuilderTest {
     DependencyGraphResult result =
         dependencyGraphBuilder.buildLinkageCheckDependencyGraph(
             ImmutableList.of(new DefaultArtifact("ant:ant:jar:1.6.2")));
+
     ImmutableList<UnresolvableArtifactProblem> problems = result.getArtifactProblems();
     Truth.assertThat(problems)
         .comparingElementsUsing(

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -253,7 +253,7 @@ public class DependencyGraphBuilderTest {
         .comparingElementsUsing(problemOnArtifact)
         .containsAtLeast("xerces:xerces-impl:2.6.2", "xml-apis:xml-apis:2.6.2");
 
-    Truth.assertThat(problems).hasSize(4);
+    Truth.assertThat(problems).hasSize(2);
     Truth.assertThat(problems)
         .comparingElementsUsing(
             Correspondence.transforming(UnresolvableArtifactProblem::toString, "has description"))
@@ -261,12 +261,6 @@ public class DependencyGraphBuilderTest {
             "xerces:xerces-impl:jar:2.6.2 was not resolved. Dependency path: ant:ant:jar:1.6.2"
                 + " (compile) > xerces:xerces-impl:jar:2.6.2 (compile?)",
             "xml-apis:xml-apis:jar:2.6.2 was not resolved. Dependency path: ant:ant:jar:1.6.2"
-                + " (compile) > xml-apis:xml-apis:jar:2.6.2 (compile?)",
-            "xerces:xerces-impl:jar:2.6.2 was not resolved. Dependency path: ant:ant:jar:1.6.2"
-                + " (compile) > xerces:xerces-impl:jar:2.6.2 (compile?) >"
-                + " xerces:xerces-impl:jar:2.6.2 (compile?)",
-            "xml-apis:xml-apis:jar:2.6.2 was not resolved. Dependency path: ant:ant:jar:1.6.2"
-                + " (compile) > xml-apis:xml-apis:jar:2.6.2 (compile?) >"
-                + " xml-apis:xml-apis:jar:2.6.2 (compile?)");
+                + " (compile) > xml-apis:xml-apis:jar:2.6.2 (compile?)");
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -111,16 +111,16 @@ public class DependencyGraphBuilderTest {
     // This should not raise DependencyResolutionException
     DependencyGraph completeDependencies =
         dependencyGraphBuilder
-            .buildLinkageCheckDependencyGraph(ImmutableList.of(log4j2))
+            .getStaticLinkageCheckDependencyGraph(ImmutableList.of(log4j2))
             .getDependencyGraph();
     Truth.assertThat(completeDependencies.list()).isNotEmpty();
   }
 
   @Test
-  public void testBuildLinkageCheckDependencyGraph_multipleArtifacts() throws RepositoryException {
+  public void testGetStaticLinkageCheckDependencyGraph_multipleArtifacts() {
     DependencyGraph graph =
         dependencyGraphBuilder
-            .buildLinkageCheckDependencyGraph(Arrays.asList(datastore, guava))
+            .getStaticLinkageCheckDependencyGraph(Arrays.asList(datastore, guava))
             .getDependencyGraph();
 
     List<DependencyPath> list = graph.list();
@@ -155,7 +155,7 @@ public class DependencyGraphBuilderTest {
 
     DependencyGraph dependencyGraph =
         dependencyGraphBuilder
-            .buildLinkageCheckDependencyGraph(ImmutableList.of(grpcProtobuf))
+            .getStaticLinkageCheckDependencyGraph(ImmutableList.of(grpcProtobuf))
             .getDependencyGraph();
 
     Correspondence<DependencyPath, String> pathToArtifactKey =
@@ -176,7 +176,8 @@ public class DependencyGraphBuilderTest {
     Artifact hibernateCore = new DefaultArtifact("org.hibernate:hibernate-core:jar:3.5.1-Final");
 
     DependencyGraphResult result =
-        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(ImmutableList.of(hibernateCore));
+        dependencyGraphBuilder.getStaticLinkageCheckDependencyGraph(
+            ImmutableList.of(hibernateCore));
 
     ImmutableList<UnresolvableArtifactProblem> problems = result.getArtifactProblems();
     for (UnresolvableArtifactProblem problem : problems) {
@@ -185,13 +186,14 @@ public class DependencyGraphBuilderTest {
   }
 
   @Test
-  public void testBuildLinkageCheckDependencyGraph_artifactProblems() throws RepositoryException {
+  public void testGetStaticLinkageCheckDependencyGraph_artifactProblems() {
     // In the full dependency tree of hibernate-core, xerces-impl:2.6.2 and xml-apis:2.6.2 are not
     // available in Maven Central.
     Artifact hibernateCore = new DefaultArtifact("org.hibernate:hibernate-core:jar:3.5.1-Final");
 
     DependencyGraphResult result =
-        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(ImmutableList.of(hibernateCore));
+        dependencyGraphBuilder.getStaticLinkageCheckDependencyGraph(
+            ImmutableList.of(hibernateCore));
 
     ImmutableList<UnresolvableArtifactProblem> artifactProblems = result.getArtifactProblems();
 
@@ -244,7 +246,7 @@ public class DependencyGraphBuilderTest {
   public void testBuildLinkageCheckDependencyGraph_catchRootException() throws RepositoryException {
     // This should not throw exception
     DependencyGraphResult result =
-        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(
+        dependencyGraphBuilder.getStaticLinkageCheckDependencyGraph(
             ImmutableList.of(new DefaultArtifact("ant:ant:jar:1.6.2")));
 
     ImmutableList<UnresolvableArtifactProblem> problems = result.getArtifactProblems();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -108,17 +108,17 @@ public class DependencyGraphBuilderTest {
     // This should not raise DependencyResolutionException
     DependencyGraph completeDependencies =
         dependencyGraphBuilder
-            .getStaticLinkageCheckDependencyGraph(ImmutableList.of(log4j2))
+            .buildLinkageCheckDependencyGraph(ImmutableList.of(log4j2))
             .getDependencyGraph();
     Truth.assertThat(completeDependencies.list()).isNotEmpty();
   }
 
   @Test
-  public void testGetStaticLinkageCheckDependencyGraph_multipleArtifacts()
+  public void testBuildLinkageCheckDependencyGraph_multipleArtifacts()
       throws RepositoryException {
     DependencyGraph graph =
         dependencyGraphBuilder
-            .getStaticLinkageCheckDependencyGraph(Arrays.asList(datastore, guava))
+            .buildLinkageCheckDependencyGraph(Arrays.asList(datastore, guava))
             .getDependencyGraph();
 
     List<DependencyPath> list = graph.list();
@@ -153,7 +153,7 @@ public class DependencyGraphBuilderTest {
 
     DependencyGraph dependencyGraph =
         dependencyGraphBuilder
-            .getStaticLinkageCheckDependencyGraph(ImmutableList.of(grpcProtobuf))
+            .buildLinkageCheckDependencyGraph(ImmutableList.of(grpcProtobuf))
             .getDependencyGraph();
 
     Correspondence<DependencyPath, String> pathToArtifactKey =
@@ -174,7 +174,7 @@ public class DependencyGraphBuilderTest {
     Artifact hibernateCore = new DefaultArtifact("org.hibernate:hibernate-core:jar:3.5.1-Final");
 
     DependencyGraphResult result =
-        dependencyGraphBuilder.getStaticLinkageCheckDependencyGraph(
+        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(
             ImmutableList.of(hibernateCore));
 
     ImmutableList<UnresolvableArtifactProblem> problems = result.getArtifactProblems();
@@ -184,14 +184,14 @@ public class DependencyGraphBuilderTest {
   }
 
   @Test
-  public void testGetStaticLinkageCheckDependencyGraph_artifactProblems()
+  public void testBuildLinkageCheckDependencyGraph_artifactProblems()
       throws RepositoryException {
     // In the full dependency tree of hibernate-core, xerces-impl:2.6.2 and xml-apis:2.6.2 are not
     // available in Maven Central.
     Artifact hibernateCore = new DefaultArtifact("org.hibernate:hibernate-core:jar:3.5.1-Final");
 
     DependencyGraphResult result =
-        dependencyGraphBuilder.getStaticLinkageCheckDependencyGraph(
+        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(
             ImmutableList.of(hibernateCore));
 
     ImmutableList<UnresolvableArtifactProblem> artifactProblems = result.getArtifactProblems();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -114,8 +114,7 @@ public class DependencyGraphBuilderTest {
   }
 
   @Test
-  public void testBuildLinkageCheckDependencyGraph_multipleArtifacts()
-      throws RepositoryException {
+  public void testBuildLinkageCheckDependencyGraph_multipleArtifacts() throws RepositoryException {
     DependencyGraph graph =
         dependencyGraphBuilder
             .buildLinkageCheckDependencyGraph(Arrays.asList(datastore, guava))
@@ -174,8 +173,7 @@ public class DependencyGraphBuilderTest {
     Artifact hibernateCore = new DefaultArtifact("org.hibernate:hibernate-core:jar:3.5.1-Final");
 
     DependencyGraphResult result =
-        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(
-            ImmutableList.of(hibernateCore));
+        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(ImmutableList.of(hibernateCore));
 
     ImmutableList<UnresolvableArtifactProblem> problems = result.getArtifactProblems();
     for (UnresolvableArtifactProblem problem : problems) {
@@ -184,15 +182,13 @@ public class DependencyGraphBuilderTest {
   }
 
   @Test
-  public void testBuildLinkageCheckDependencyGraph_artifactProblems()
-      throws RepositoryException {
+  public void testBuildLinkageCheckDependencyGraph_artifactProblems() throws RepositoryException {
     // In the full dependency tree of hibernate-core, xerces-impl:2.6.2 and xml-apis:2.6.2 are not
     // available in Maven Central.
     Artifact hibernateCore = new DefaultArtifact("org.hibernate:hibernate-core:jar:3.5.1-Final");
 
     DependencyGraphResult result =
-        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(
-            ImmutableList.of(hibernateCore));
+        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(ImmutableList.of(hibernateCore));
 
     ImmutableList<UnresolvableArtifactProblem> artifactProblems = result.getArtifactProblems();
 
@@ -243,5 +239,21 @@ public class DependencyGraphBuilderTest {
               "Could not find artifact com.google.guava:guava:jar:28.2-jre in "
                   + " (https://dl.google.com/dl/android/maven2)");
     }
+  }
+
+  @Test
+  public void testBuildLinkageCheckDependencyGraph_catchRootException() throws RepositoryException {
+    // This should not throw exception
+    DependencyGraphResult result =
+        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(
+            ImmutableList.of(new DefaultArtifact("ant:ant:jar:1.6.2")));
+    ImmutableList<UnresolvableArtifactProblem> problems = result.getArtifactProblems();
+    Truth.assertThat(problems)
+        .comparingElementsUsing(
+            Correspondence.transforming(
+                (UnresolvableArtifactProblem problem) ->
+                    Artifacts.toCoordinates(problem.getArtifact()),
+                "has artifact"))
+        .containsAtLeast("xerces:xerces-impl:2.6.2", "xml-apis:xml-apis:2.6.2");
   }
 }

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -26,16 +26,13 @@ import com.google.cloud.tools.opensource.classpath.ClassReferenceGraph;
 import com.google.cloud.tools.opensource.classpath.LinkageChecker;
 import com.google.cloud.tools.opensource.classpath.SymbolProblem;
 import com.google.cloud.tools.opensource.dependencies.ArtifactProblem;
-import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraphBuilder;
 import com.google.cloud.tools.opensource.dependencies.FilteringZipDependencySelector;
 import com.google.cloud.tools.opensource.dependencies.NonTestDependencySelector;
-import com.google.cloud.tools.opensource.dependencies.UnresolvableArtifactProblem;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Iterables;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -67,12 +64,10 @@ import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.ArtifactTypeRegistry;
 import org.eclipse.aether.graph.Dependency;
-import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.transfer.ArtifactTransferException;
 import org.eclipse.aether.util.graph.selector.AndDependencySelector;
 import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
-import org.eclipse.aether.util.graph.visitor.PathRecordingDependencyVisitor;
 
 /** Linkage Checker Maven Enforcer Rule. */
 public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
@@ -294,16 +289,8 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
       if (cause instanceof ArtifactTransferException) {
         ArtifactTransferException artifactException = (ArtifactTransferException) cause;
         Artifact artifact = artifactException.getArtifact();
-        List<DependencyNode> firstArtifactPath =
-            Iterables.getFirst(findArtifactPaths(dependencyGraph, artifact), ImmutableList.of());
-        if (firstArtifactPath.isEmpty()) {
-          // On certain conditions, Maven throws ArtifactDescriptorException even when the
-          // (transformed) dependency graph does not contain the problematic artifact any more.
-          // https://issues.apache.org/jira/browse/MNG-6732
-          artifactProblems.add(new UnresolvableArtifactProblem(artifact));
-        } else {
-          artifactProblems.add(new UnresolvableArtifactProblem(firstArtifactPath));
-        }
+        artifactProblems.add(
+            DependencyGraphBuilder.createUnresolvableArtifactProblem(dependencyGraph, artifact));
         break;
       }
     }
@@ -351,15 +338,5 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
     } catch (RepositoryException ex) {
       throw new EnforcerRuleException("Failed to collect dependency " + ex.getMessage(), ex);
     }
-  }
-
-  private static ImmutableList<List<DependencyNode>> findArtifactPaths(
-      DependencyNode root, Artifact artifact) {
-    String coordinates = Artifacts.toCoordinates(artifact);
-    DependencyFilter filter =
-        (node, parents) -> Artifacts.toCoordinates(node.getArtifact()).equals(coordinates);
-    PathRecordingDependencyVisitor visitor = new PathRecordingDependencyVisitor(filter);
-    root.accept(visitor);
-    return ImmutableList.copyOf(visitor.getPaths());
   }
 }


### PR DESCRIPTION
Fixes #1209 .

Motivation of this change is [testBuildLinkageCheckDependencyGraph_catchRootException](https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/1210/files#r378501664), where DependencyGraphBuilder throws an exception for unresolved dependencies of "ant:1.6.2", rather than returning UnresolvedArtifactProblems.


