### PR TITLE
DependencyGraphBuilder refactoring

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
@@ -67,7 +67,7 @@ public final class ClassPathBuilder {
     }
     // dependencyGraph holds multiple versions for one artifact key (groupId:artifactId)
     DependencyGraphResult result =
-        dependencyGraphBuilder.getStaticLinkageCheckDependencyGraph(artifacts);
+        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(artifacts);
     List<DependencyPath> dependencyPaths = result.getDependencyGraph().list();
 
     // To remove duplicates on (groupId:artifactId) for dependency mediation

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -195,7 +195,7 @@ public final class DependencyGraphBuilder {
    * @param artifacts Maven artifacts to retrieve their dependencies
    * @return dependency graph representing the tree of Maven artifacts
    */
-  public DependencyGraphResult getStaticLinkageCheckDependencyGraph(List<Artifact> artifacts) {
+  public DependencyGraphResult buildLinkageCheckDependencyGraph(List<Artifact> artifacts) {
     ImmutableList<DependencyNode> dependencyNodes =
         artifacts.stream().map(DefaultDependencyNode::new).collect(toImmutableList());
     return buildDependencyGraph(

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -33,7 +33,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Stack;
-import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -131,17 +130,6 @@ public final class DependencyGraphBuilder {
     this.repositories = repositoryListBuilder.build();
   }
 
-  private DependencyNode resolveCompileTimeDependencies(DependencyNode root)
-      throws DependencyResolutionException {
-    return resolveCompileTimeDependencies(root, false);
-  }
-
-  private DependencyNode resolveCompileTimeDependencies(
-      DependencyNode root, boolean includeProvidedScope) throws DependencyResolutionException {
-    return resolveCompileTimeDependencies(
-        ImmutableList.of(root), includeProvidedScope);
-  }
-
   private DependencyNode resolveCompileTimeDependencies(
       List<DependencyNode> dependencyNodes, boolean includeProvidedScope)
       throws DependencyResolutionException {
@@ -198,18 +186,6 @@ public final class DependencyGraphBuilder {
     }
 
     return node;
-  }
-
-  /** Returns the non-transitive compile time dependencies of a dependency. */
-  List<DependencyNode> getDirectDependencies(Dependency dependency) throws RepositoryException {
-
-    List<DependencyNode> result = new ArrayList<>();
-
-    DependencyNode node = resolveCompileTimeDependencies(new DefaultDependencyNode(dependency));
-    for (DependencyNode child : node.getChildren()) {
-      result.add(child);
-    }
-    return result;
   }
 
   /**
@@ -314,10 +290,6 @@ public final class DependencyGraphBuilder {
     }
   }
 
-  private DependencyGraphResult levelOrder(DependencyNode node) {
-    return levelOrder(node, GraphTraversalOption.NONE);
-  }
-
   private enum GraphTraversalOption {
     NONE,
     FULL_DEPENDENCY,
@@ -383,7 +355,9 @@ public final class DependencyGraphBuilder {
           try {
             boolean includeProvidedScope =
                 graphTraversalOption == GraphTraversalOption.FULL_DEPENDENCY_WITH_PROVIDED;
-            dependencyNode = resolveCompileTimeDependencies(dependencyNode, includeProvidedScope);
+            dependencyNode =
+                resolveCompileTimeDependencies(
+                    ImmutableList.of(dependencyNode), includeProvidedScope);
           } catch (DependencyResolutionException resolutionException) {
             // A dependency may be unavailable. For example, com.google.guava:guava-gwt:jar:20.0
             // has a transitive dependency to org.eclipse.jdt.core.compiler:ecj:jar:4.4RC4 (not

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DirectReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DirectReport.java
@@ -16,12 +16,10 @@
 
 package com.google.cloud.tools.opensource.dependencies;
 
-import java.util.List;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.Dependency;
-import org.eclipse.aether.graph.DependencyNode;
 
 class DirectReport {
 
@@ -44,11 +42,14 @@ class DirectReport {
     
     Artifact input = new DefaultArtifact(args[0]);
     DependencyGraphBuilder dependencyGraphBuilder = new DependencyGraphBuilder();
-    List<DependencyNode> dependencies = dependencyGraphBuilder.getDirectDependencies(
-        new Dependency(input, ""));
+    DependencyGraphResult dependencyGraphResult =
+        dependencyGraphBuilder.buildGraph(new Dependency(input, ""));
 
-    for (DependencyNode node : dependencies) {
-      Artifact artifact = node.getArtifact();
+    for (DependencyPath dependencyPath : dependencyGraphResult.getDependencyGraph().list()) {
+      if (dependencyPath.size() != 2) {
+        continue;
+      }
+      Artifact artifact = dependencyPath.getLeaf();
       System.out.println("  <dependency>");
       System.out.println("    <groupId>" + artifact.getGroupId() + "</groupId>");
       System.out.println("    <artifactId>" + artifact.getArtifactId() + "</artifactId>");

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -90,23 +90,23 @@ public class DependencyGraphBuilderTest {
   }
 
   @Test
-  public void testGetDirectDependencies_nonExistentZipDependency() throws RepositoryException {
+  public void testBuildLinkageCheckDependencyGraph_nonExistentZipDependency() throws RepositoryException {
     // This artifact depends on log4j-api-java9 (type:zip), which does not exist in Maven central.
     DefaultArtifact log4j2 = new DefaultArtifact("org.apache.logging.log4j:log4j-api:2.11.1");
 
     // This should not raise DependencyResolutionException
     DependencyGraph completeDependencies =
         dependencyGraphBuilder
-            .getStaticLinkageCheckDependencyGraph(ImmutableList.of(log4j2))
+            .buildLinkageCheckDependencyGraph(ImmutableList.of(log4j2))
             .getDependencyGraph();
     Truth.assertThat(completeDependencies.list()).isNotEmpty();
   }
 
   @Test
-  public void testGetStaticLinkageCheckDependencyGraph_multipleArtifacts() {
+  public void testBuildLinkageCheckDependencyGraph_multipleArtifacts() {
     DependencyGraph graph =
         dependencyGraphBuilder
-            .getStaticLinkageCheckDependencyGraph(Arrays.asList(datastore, guava))
+            .buildLinkageCheckDependencyGraph(Arrays.asList(datastore, guava))
             .getDependencyGraph();
 
     List<DependencyPath> list = graph.list();
@@ -136,14 +136,14 @@ public class DependencyGraphBuilderTest {
   }
 
   @Test
-  public void testSetDetectedOsSystemProperties_grpcProtobufExclusion() throws RepositoryException {
+  public void testBuildLinkageCheckDependencyGraph_grpcProtobufExclusion() throws RepositoryException {
     // Grpc-protobuf depends on grpc-protobuf-lite with protobuf-lite exclusion.
     // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1056
     Artifact grpcProtobuf = new DefaultArtifact("io.grpc:grpc-protobuf:1.25.0");
 
     DependencyGraph dependencyGraph =
         dependencyGraphBuilder
-            .getStaticLinkageCheckDependencyGraph(ImmutableList.of(grpcProtobuf))
+            .buildLinkageCheckDependencyGraph(ImmutableList.of(grpcProtobuf))
             .getDependencyGraph();
 
     Correspondence<DependencyPath, String> pathToArtifactKey =
@@ -156,7 +156,7 @@ public class DependencyGraphBuilderTest {
   }
 
   @Test
-  public void testGetDirectDependencies_respectExclusions() throws RepositoryException {
+  public void testBuildLinkageCheckDependencyGraph_respectExclusions() throws RepositoryException {
     // hibernate-core declares jboss-jacc-api_JDK4 dependency excluding jboss-servlet-api_3.0.
     // jboss-jacc-api_JDK4 depends on jboss-servlet-api_3.0:1.0-SNAPSHOT, which is unavailable.
     // DependencyGraphBuilder should respect the exclusion and should not try to download
@@ -164,7 +164,7 @@ public class DependencyGraphBuilderTest {
     Artifact hibernateCore = new DefaultArtifact("org.hibernate:hibernate-core:jar:3.5.1-Final");
 
     DependencyGraphResult result =
-        dependencyGraphBuilder.getStaticLinkageCheckDependencyGraph(
+        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(
             ImmutableList.of(hibernateCore));
 
     ImmutableList<UnresolvableArtifactProblem> problems = result.getArtifactProblems();
@@ -174,13 +174,13 @@ public class DependencyGraphBuilderTest {
   }
 
   @Test
-  public void testGetStaticLinkageCheckDependencyGraph_artifactProblems() {
+  public void testBuildLinkageCheckDependencyGraph_artifactProblems() {
     // In the full dependency tree of hibernate-core, xerces-impl:2.6.2 and xml-apis:2.6.2 are not
     // available in Maven Central.
     Artifact hibernateCore = new DefaultArtifact("org.hibernate:hibernate-core:jar:3.5.1-Final");
 
     DependencyGraphResult result =
-        dependencyGraphBuilder.getStaticLinkageCheckDependencyGraph(
+        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(
             ImmutableList.of(hibernateCore));
 
     ImmutableList<UnresolvableArtifactProblem> artifactProblems = result.getArtifactProblems();
@@ -234,7 +234,7 @@ public class DependencyGraphBuilderTest {
   public void testBuildLinkageCheckDependencyGraph_catchRootException() throws RepositoryException {
     // This should not throw exception
     DependencyGraphResult result =
-        dependencyGraphBuilder.getStaticLinkageCheckDependencyGraph(
+        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(
             ImmutableList.of(new DefaultArtifact("ant:ant:jar:1.6.2")));
 
     ImmutableList<UnresolvableArtifactProblem> problems = result.getArtifactProblems();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNotNull;
 import com.google.common.collect.ImmutableList;
 import com.google.common.truth.Correspondence;
 import com.google.common.truth.Truth;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -30,7 +29,6 @@ import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.Dependency;
-import org.eclipse.aether.graph.DependencyNode;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -92,18 +90,6 @@ public class DependencyGraphBuilderTest {
   }
 
   @Test
-  public void testGetDirectDependencies() throws RepositoryException {
-    List<DependencyNode> nodes =
-        dependencyGraphBuilder.getDirectDependencies(new Dependency(guava, ""));
-    List<String> coordinates = new ArrayList<>();
-    for (DependencyNode node : nodes) {
-      coordinates.add(node.getArtifact().toString());
-    }
-
-    Truth.assertThat(coordinates).contains("com.google.code.findbugs:jsr305:jar:3.0.2");
-  }
-
-  @Test
   public void testGetDirectDependencies_nonExistentZipDependency() throws RepositoryException {
     // This artifact depends on log4j-api-java9 (type:zip), which does not exist in Maven central.
     DefaultArtifact log4j2 = new DefaultArtifact("org.apache.logging.log4j:log4j-api:2.11.1");
@@ -138,13 +124,15 @@ public class DependencyGraphBuilderTest {
   }
 
   @Test
-  public void testSetDetectedOsSystemProperties_netty4Dependency() throws RepositoryException {
+  public void testSetDetectedOsSystemProperties_netty4Dependency() {
     Artifact nettyArtifact = new DefaultArtifact("io.netty:netty-all:4.1.31.Final");
 
     // Without system properties "os.detected.arch" and "os.detected.name", this would fail.
-    List<DependencyNode> nodes = dependencyGraphBuilder.getDirectDependencies(
-        new Dependency(nettyArtifact, ""));
-    Truth.assertThat(nodes).isNotEmpty();
+    DependencyGraphResult dependencyGraphResult =
+        dependencyGraphBuilder.buildGraph(new Dependency(nettyArtifact, ""));
+
+    Truth.assertThat(dependencyGraphResult.getArtifactProblems()).isEmpty();
+    Truth.assertThat(dependencyGraphResult.getDependencyGraph().list()).isNotEmpty();
   }
 
   @Test


### PR DESCRIPTION
Followup of https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/1210#discussion_r378497821.

- Removed overloaded `resolveCompileTimeDependencies`, which was used only once.
- Removed `getDirectDependencies` which can be replaced via `buildGraph` 
- Renamed getStaticLinkageCheckDependencyGraph to buildLinkageCheckDependencyGraph