### PR TITLE
Merging FULL_DEPENDENCY and FULL_DEPENDENCY_WITH_PROVIDED into FULL

### DIFF
--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -79,6 +79,7 @@ import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
 
 public class DashboardMain {
 
@@ -343,7 +344,7 @@ public class DashboardMain {
 
       // picks versions according to Maven rules
       DependencyGraphResult transitiveDependencyResult =
-          dependencyGraphBuilder.buildMavenDependencyGraph(artifact);
+          dependencyGraphBuilder.buildMavenDependencyGraph(new Dependency(artifact, "compile"));
       DependencyGraph transitiveDependencies = transitiveDependencyResult.getDependencyGraph();
 
       ArtifactInfo info = new ArtifactInfo(completeDependencies, transitiveDependencies);

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -79,7 +79,6 @@ import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.graph.Dependency;
 
 public class DashboardMain {
 
@@ -344,7 +343,7 @@ public class DashboardMain {
 
       // picks versions according to Maven rules
       DependencyGraphResult transitiveDependencyResult =
-          dependencyGraphBuilder.buildMavenDependencyGraph(new Dependency(artifact, "compile"));
+          dependencyGraphBuilder.buildMavenDependencyGraph(artifact);
       DependencyGraph transitiveDependencies = transitiveDependencyResult.getDependencyGraph();
 
       ArtifactInfo info = new ArtifactInfo(completeDependencies, transitiveDependencies);

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -338,13 +338,13 @@ public class DashboardMain {
 
     for (Artifact artifact : artifacts) {
       DependencyGraphResult completeDependencyResult =
-          dependencyGraphBuilder.buildCompleteGraph(new Dependency(artifact, "compile"));
+          dependencyGraphBuilder.buildFullDependencyGraph(ImmutableList.of(artifact));
       DependencyGraph completeDependencies = completeDependencyResult.getDependencyGraph();
       globalDependencies.add(completeDependencies);
 
       // picks versions according to Maven rules
       DependencyGraphResult transitiveDependencyResult =
-          dependencyGraphBuilder.buildGraph(new Dependency(artifact, "compile"));
+          dependencyGraphBuilder.buildMavenDependencyGraph(new Dependency(artifact, "compile"));
       DependencyGraph transitiveDependencies = transitiveDependencyResult.getDependencyGraph();
 
       ArtifactInfo info = new ArtifactInfo(completeDependencies, transitiveDependencies);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilder.java
@@ -66,8 +66,7 @@ public final class ClassPathBuilder {
       return new ClassPathResult(multimap, ImmutableList.of());
     }
     // dependencyGraph holds multiple versions for one artifact key (groupId:artifactId)
-    DependencyGraphResult result =
-        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(artifacts);
+    DependencyGraphResult result = dependencyGraphBuilder.buildFullDependencyGraph(artifacts);
     List<DependencyPath> dependencyPaths = result.getDependencyGraph().list();
 
     // To remove duplicates on (groupId:artifactId) for dependency mediation

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
@@ -118,7 +118,10 @@ public abstract class ArtifactProblem {
   @Override
   public int hashCode() {
     ImmutableList<Dependency> dependencyList =
-        dependencyPath.stream().map(DependencyNode::getDependency).collect(toImmutableList());
+        dependencyPath.stream()
+            .map(DependencyNode::getDependency)
+            .filter(Objects::nonNull)
+            .collect(toImmutableList());
     return Objects.hash(artifact, dependencyList);
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/ArtifactProblem.java
@@ -120,7 +120,7 @@ public abstract class ArtifactProblem {
     ImmutableList<Dependency> dependencyList =
         dependencyPath.stream()
             .map(DependencyNode::getDependency)
-            .filter(Objects::nonNull)
+            .filter(Objects::nonNull) // root may not have a dependency
             .collect(toImmutableList());
     return Objects.hash(artifact, dependencyList);
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -66,8 +66,8 @@ import org.eclipse.aether.util.graph.visitor.PathRecordingDependencyVisitor;
  *   <li>It does not contain transitive optional dependencies.
  * </ul>
  *
- * <p>{@link #buildFullDependencyGraph(List)} builds a full dependency graph. This dependency graph
- * has the following attributes:
+ * <p>{@link #buildFullDependencyGraph(List)} builds a full dependency graph. This graph has the
+ * following attributes:
  *
  * <ul>
  *   <li>The same artifact, which have the same group:artifact:version, appears in different nodes

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -49,8 +49,33 @@ import org.eclipse.aether.resolution.DependencyResult;
 import org.eclipse.aether.util.graph.visitor.PathRecordingDependencyVisitor;
 
 /**
- * Based on the <a href="https://maven.apache.org/resolver/index.html">Apache Maven Artifact
- * Resolver</a> (formerly known as Eclipse Aether).
+ * This class builds dependency graphs for Maven artifacts. The nodes in the graph are Maven
+ * artifacts and its edges are dependencies from an artifact to another.
+ *
+ * <p>{@link #buildMavenDependencyGraph(Dependency)} builds a normal Maven dependency graph. This
+ * graph has the following attributes:
+ *
+ * <ul>
+ *   <li>It contains at most one node for the same groupId and artifactId. (<a
+ *       href="https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Transitive_Dependencies">dependency
+ *       mediation</a>)
+ *   <li>The scope of a dependency affects the scope of its children's dependencies as per <a
+ *       href="https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope">Maven:
+ *       Dependency Scope</a>
+ *   <li>It does not contain transitive provided-scope dependencies.
+ *   <li>It does not contain transitive optional dependencies.
+ * </ul>
+ *
+ * <p>{@link #buildFullDependencyGraph(List)} builds a full dependency graph. This dependency graph
+ * has the following attributes:
+ *
+ * <ul>
+ *   <li>The same artifact, which have the same group:artifact:version, appears in different nodes
+ *       in the graph.
+ *   <li>The scope of a dependency does not affect the scope of its children's dependencies.
+ *   <li>It contains transitive provided-scope dependencies.
+ *   <li>It contains transitive optional dependencies.
+ * </ul>
  */
 public final class DependencyGraphBuilder {
 
@@ -277,21 +302,7 @@ public final class DependencyGraphBuilder {
   }
 
   private enum GraphTraversalOption {
-    /**
-     * Normal Maven dependency graph. This dependency graph has the following attributes:
-     *
-     * <ul>
-     *   <li>It contains at most one node for the same groupId and artifactId. (dependency
-     *       mediation)
-     *   <li>The scope of a dependency affects the scope of its children's dependencies.
-     *   <li>It does not contain transitive provided-scope dependencies.
-     *   <li>It does not contain transitive optional dependencies.
-     * </ul>
-     *
-     * @see <a
-     *     href="https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html"
-     *     >Maven: Introduction to the Dependency Mechanism</a>
-     */
+    /** Normal Maven dependency graph */
     MAVEN,
 
     /**

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -147,14 +147,12 @@ public final class DependencyGraphBuilder {
     ImmutableList<Dependency> dependencyList = dependenciesBuilder.build();
 
     // The cache key includes exclusion elements of Maven artifacts
-    Map<Dependency, DependencyNode> cache = fullDependencies ? cacheForFullDependency : null;
     // cacheKey is null when there's no need to use cache. Cache is only needed for a single
     // artifact's dependency resolution. A call with multiple dependencyNodes will not come again
     // in our usage.
-    Dependency cacheKey =
-        (cache != null && dependencyList.size() == 1) ? dependencyList.get(0) : null;
-    if (cacheKey != null && cache.containsKey(cacheKey)) {
-      return cache.get(cacheKey);
+    Dependency cacheKey = dependencyList.size() == 1 ? dependencyList.get(0) : null;
+    if (cacheKey != null && cacheForFullDependency.containsKey(cacheKey)) {
+      return cacheForFullDependency.get(cacheKey);
     }
 
     RepositorySystemSession session =
@@ -181,7 +179,7 @@ public final class DependencyGraphBuilder {
     DependencyNode node = dependencyResult.getRoot();
 
     if (cacheKey != null) {
-      cache.put(cacheKey, node);
+      cacheForFullDependency.put(cacheKey, node);
     }
 
     return node;
@@ -285,8 +283,8 @@ public final class DependencyGraphBuilder {
      *
      * <ul>
      *   <li>It contains at most one node for the same groupId and artifactId.
-     *   <li>It does not contain transitive provided-scope dependencies
-     *   <li>It does not contain transitive optional dependencies
+     *   <li>It does not contain transitive provided-scope dependencies.
+     *   <li>It does not contain transitive optional dependencies.
      * </ul>
      */
     NONE,
@@ -296,8 +294,8 @@ public final class DependencyGraphBuilder {
      *
      * <ul>
      *   <li>It may contain different dependency nodes for the same groupId and artifactId.
-     *   <li>It may contain transitive provided-scope dependencies
-     *   <li>It may contain transitive optional dependencies
+     *   <li>It may contain transitive provided-scope dependencies.
+     *   <li>It may contain transitive optional dependencies.
      * </ul>
      */
     FULL_DEPENDENCY;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -305,17 +305,7 @@ public final class DependencyGraphBuilder {
     /** Normal Maven dependency graph */
     MAVEN,
 
-    /**
-     * The full dependency graph. This dependency graph has the following attributes:
-     *
-     * <ul>
-     *   <li>The same artifact, which have the same group:artifact:version, appears in different
-     *       nodes in the graph.
-     *   <li>The scope of a dependency does not affect the scope of its children's dependencies.
-     *   <li>It contains transitive provided-scope dependencies.
-     *   <li>It contains transitive optional dependencies.
-     * </ul>
-     */
+    /** The full dependency graph */
     FULL;
   }
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -52,7 +52,7 @@ import org.eclipse.aether.util.graph.visitor.PathRecordingDependencyVisitor;
  * This class builds dependency graphs for Maven artifacts. The nodes in the graph are Maven
  * artifacts and its edges are dependencies from an artifact to another.
  *
- * <p>{@link #buildMavenDependencyGraph(Dependency)} builds a normal Maven dependency graph. This
+ * <p>{@link #buildMavenDependencyGraph(Artifact)} builds a normal Maven dependency graph. This
  * graph has the following attributes:
  *
  * <ul>
@@ -228,9 +228,10 @@ public final class DependencyGraphBuilder {
    * conflicting versions. That is, this resolves conflicting versions by picking the first version
    * seen. This is how Maven normally operates.
    */
-  public DependencyGraphResult buildMavenDependencyGraph(Dependency dependency) {
+  public DependencyGraphResult buildMavenDependencyGraph(Artifact artifact) {
+    Dependency rootDependency = new Dependency(artifact, "compile");
     return buildDependencyGraph(
-        ImmutableList.of(new DefaultDependencyNode(dependency)), GraphTraversalOption.MAVEN);
+        ImmutableList.of(new DefaultDependencyNode(rootDependency)), GraphTraversalOption.MAVEN);
   }
 
   private DependencyGraphResult buildDependencyGraph(

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -49,14 +49,13 @@ import org.eclipse.aether.resolution.DependencyResult;
 import org.eclipse.aether.util.graph.visitor.PathRecordingDependencyVisitor;
 
 /**
- * This class builds dependency graphs for Maven artifacts. The nodes in the graph are Maven
- * artifacts and its edges are dependencies from an artifact to another.
+ * This class builds dependency graphs for Maven artifacts.
  *
- * <p>{@link #buildMavenDependencyGraph(Artifact)} builds a normal Maven dependency graph. This
- * graph has the following attributes:
+ * <p>A Maven dependency graph is the tree you see in {@code mvn dependency:tree} output. This graph
+ * has the following attributes:
  *
  * <ul>
- *   <li>It contains at most one node for the same groupId and artifactId. (<a
+ *   <li>It contains at most one node for the same group ID and artifact ID. (<a
  *       href="https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Transitive_Dependencies">dependency
  *       mediation</a>)
  *   <li>The scope of a dependency affects the scope of its children's dependencies as per <a
@@ -66,15 +65,15 @@ import org.eclipse.aether.util.graph.visitor.PathRecordingDependencyVisitor;
  *   <li>It does not contain transitive optional dependencies.
  * </ul>
  *
- * <p>{@link #buildFullDependencyGraph(List)} builds a full dependency graph. This graph has the
- * following attributes:
+ * <p>A full dependency graph is a dependency tree where each node's dependencies are fully resolved
+ * recursively. This graph has the following attributes:
  *
  * <ul>
- *   <li>The same artifact, which have the same group:artifact:version, appears in different nodes
- *       in the graph.
+ *   <li>The same artifact, which has the same group:artifact:version, appears in different nodes in
+ *       the graph.
  *   <li>The scope of a dependency does not affect the scope of its children's dependencies.
- *   <li>It contains transitive provided-scope dependencies.
- *   <li>It contains transitive optional dependencies.
+ *   <li>Provided-scope and optional dependencies are not treated differently than any other
+ *       dependency.
  * </ul>
  */
 public final class DependencyGraphBuilder {
@@ -228,10 +227,9 @@ public final class DependencyGraphBuilder {
    * conflicting versions. That is, this resolves conflicting versions by picking the first version
    * seen. This is how Maven normally operates.
    */
-  public DependencyGraphResult buildMavenDependencyGraph(Artifact artifact) {
-    Dependency rootDependency = new Dependency(artifact, "compile");
+  public DependencyGraphResult buildMavenDependencyGraph(Dependency dependency) {
     return buildDependencyGraph(
-        ImmutableList.of(new DefaultDependencyNode(rootDependency)), GraphTraversalOption.MAVEN);
+        ImmutableList.of(new DefaultDependencyNode(dependency)), GraphTraversalOption.MAVEN);
   }
 
   private DependencyGraphResult buildDependencyGraph(

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyLister.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyLister.java
@@ -16,10 +16,10 @@
 
 package com.google.cloud.tools.opensource.dependencies;
 
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.graph.Dependency;
 
 class DependencyLister {
 
@@ -36,7 +36,9 @@ class DependencyLister {
 
       DependencyGraphBuilder dependencyGraphBuilder = new DependencyGraphBuilder();
       DependencyGraph graph =
-          dependencyGraphBuilder.buildCompleteGraph(new Dependency(artifact, "compile")).getDependencyGraph();
+          dependencyGraphBuilder
+              .buildFullDependencyGraph(ImmutableList.of(artifact))
+              .getDependencyGraph();
 
       List<DependencyPath> paths = graph.list();
       for (DependencyPath path : paths) { 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
@@ -30,8 +30,7 @@ public class DependencyTreeFormatter {
    * Formats dependencies as a tree in a similar way to {@code mvn dependency:tree}.
    *
    * @param dependencyPaths dependency paths from @{@link
-   *     DependencyGraphBuilder#buildFullDependencyGraph(List)} (Dependency)}. Each element must
-   *     have its parent in the list, except the ones at the root.
+   *     DependencyGraphBuilder#buildFullDependencyGraph(List)} (Dependency)}.
    */
   static String formatDependencyPaths(List<DependencyPath> dependencyPaths) {
     StringBuilder stringBuilder = new StringBuilder();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
@@ -30,8 +30,8 @@ public class DependencyTreeFormatter {
    * Formats dependencies as a tree in a similar way to {@code mvn dependency:tree}.
    *
    * @param dependencyPaths dependency paths from @{@link
-   *     DependencyGraphBuilder#buildCompleteGraph(Dependency)}. Each element must have its
-   *     parent in the list, except the ones at the root.
+   *     DependencyGraphBuilder#buildFullDependencyGraph(List)} (Dependency)}. Each element must
+   *     have its parent in the list, except the ones at the root.
    */
   static String formatDependencyPaths(List<DependencyPath> dependencyPaths) {
     StringBuilder stringBuilder = new StringBuilder();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreePrinter.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreePrinter.java
@@ -18,9 +18,9 @@ package com.google.cloud.tools.opensource.dependencies;
 
 import static com.google.cloud.tools.opensource.dependencies.DependencyTreeFormatter.formatDependencyPaths;
 
+import com.google.common.collect.ImmutableList;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.graph.Dependency;
 
 /** Prints the dependency tree of Maven artifacts. */
 class DependencyTreePrinter {
@@ -43,7 +43,9 @@ class DependencyTreePrinter {
     DefaultArtifact rootArtifact = new DefaultArtifact(coordinates);
     DependencyGraphBuilder dependencyGraphBuilder = new DependencyGraphBuilder();
     DependencyGraph dependencyGraph =
-        dependencyGraphBuilder.buildCompleteGraph(new Dependency(rootArtifact, "compile")).getDependencyGraph();
+        dependencyGraphBuilder
+            .buildFullDependencyGraph(ImmutableList.of(rootArtifact))
+            .getDependencyGraph();
     System.out.println("Dependencies for " + coordinates);
     System.out.println(formatDependencyPaths(dependencyGraph.list()));
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DirectReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DirectReport.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.opensource.dependencies;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.graph.Dependency;
 
 class DirectReport {
 
@@ -43,7 +42,7 @@ class DirectReport {
     Artifact input = new DefaultArtifact(args[0]);
     DependencyGraphBuilder dependencyGraphBuilder = new DependencyGraphBuilder();
     DependencyGraphResult dependencyGraphResult =
-        dependencyGraphBuilder.buildMavenDependencyGraph(new Dependency(input, ""));
+        dependencyGraphBuilder.buildMavenDependencyGraph(input);
 
     for (DependencyPath dependencyPath : dependencyGraphResult.getDependencyGraph().list()) {
       if (dependencyPath.size() != 2) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DirectReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DirectReport.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.opensource.dependencies;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
 
 class DirectReport {
 
@@ -42,7 +43,7 @@ class DirectReport {
     Artifact input = new DefaultArtifact(args[0]);
     DependencyGraphBuilder dependencyGraphBuilder = new DependencyGraphBuilder();
     DependencyGraphResult dependencyGraphResult =
-        dependencyGraphBuilder.buildMavenDependencyGraph(input);
+        dependencyGraphBuilder.buildMavenDependencyGraph(new Dependency(input, ""));
 
     for (DependencyPath dependencyPath : dependencyGraphResult.getDependencyGraph().list()) {
       if (dependencyPath.size() != 2) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DirectReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DirectReport.java
@@ -43,7 +43,7 @@ class DirectReport {
     Artifact input = new DefaultArtifact(args[0]);
     DependencyGraphBuilder dependencyGraphBuilder = new DependencyGraphBuilder();
     DependencyGraphResult dependencyGraphResult =
-        dependencyGraphBuilder.buildGraph(new Dependency(input, ""));
+        dependencyGraphBuilder.buildMavenDependencyGraph(new Dependency(input, ""));
 
     for (DependencyPath dependencyPath : dependencyGraphResult.getDependencyGraph().list()) {
       if (dependencyPath.size() != 2) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -129,9 +129,9 @@ public final class RepositoryUtility {
   /**
    * Opens a new Maven repository session in the same way as {@link
    * RepositoryUtility#newSession(RepositorySystem)}, with its dependency selector to include
-   * dependencies with 'provided' scope.
+   * dependencies with 'provided' scope and optional dependencies.
    */
-  static RepositorySystemSession newSessionWithProvidedScope(RepositorySystem system) {
+  static RepositorySystemSession newSessionForFullDependency(RepositorySystem system) {
     DefaultRepositorySystemSession session = createDefaultRepositorySystemSession(system);
 
     // This combination of DependencySelector comes from the default specified in

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/UpdateReport.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/UpdateReport.java
@@ -16,10 +16,10 @@
 
 package com.google.cloud.tools.opensource.dependencies;
 
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.graph.Dependency;
 
 class UpdateReport {
 
@@ -43,7 +43,9 @@ class UpdateReport {
 
       DependencyGraphBuilder dependencyGraphBuilder = new DependencyGraphBuilder();
       DependencyGraph graph =
-          dependencyGraphBuilder.buildCompleteGraph(new Dependency(artifact, "compile")).getDependencyGraph();
+          dependencyGraphBuilder
+              .buildFullDependencyGraph(ImmutableList.of(artifact))
+              .getDependencyGraph();
       List<Update> updates = graph.findUpdates();
       
       if (updates.isEmpty()) {

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -46,7 +46,6 @@ import org.apache.commons.cli.ParseException;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.graph.Dependency;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -75,7 +74,7 @@ public class LinkageCheckerTest {
   private ImmutableList<Path> resolveTransitiveDependencyPaths(String coordinates) {
     DependencyGraph dependencies =
         dependencyGraphBuilder
-            .buildMavenDependencyGraph(new Dependency(new DefaultArtifact(coordinates), "compile"))
+            .buildMavenDependencyGraph(new DefaultArtifact(coordinates))
             .getDependencyGraph();
     ImmutableList<Path> jars =
         dependencies.list().stream()
@@ -790,14 +789,11 @@ public class LinkageCheckerTest {
     // implementation for logging backend. The tool should not show errors for such classes.
     DependencyGraph slf4jGraph =
         dependencyGraphBuilder
-            .buildMavenDependencyGraph(
-                new Dependency(new DefaultArtifact("org.slf4j:slf4j-api:1.7.26"), "compile"))
+            .buildMavenDependencyGraph(new DefaultArtifact("org.slf4j:slf4j-api:1.7.26"))
             .getDependencyGraph();
     DependencyGraph logbackGraph =
         dependencyGraphBuilder
-            .buildMavenDependencyGraph(
-                new Dependency(
-                    new DefaultArtifact("ch.qos.logback:logback-classic:1.2.3"), "compile"))
+            .buildMavenDependencyGraph(new DefaultArtifact("ch.qos.logback:logback-classic:1.2.3"))
             .getDependencyGraph();
 
     Path slf4jJar = slf4jGraph.list().get(0).getLeaf().getFile().toPath();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -46,6 +46,7 @@ import org.apache.commons.cli.ParseException;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -74,7 +75,7 @@ public class LinkageCheckerTest {
   private ImmutableList<Path> resolveTransitiveDependencyPaths(String coordinates) {
     DependencyGraph dependencies =
         dependencyGraphBuilder
-            .buildMavenDependencyGraph(new DefaultArtifact(coordinates))
+            .buildMavenDependencyGraph(new Dependency(new DefaultArtifact(coordinates), "compile"))
             .getDependencyGraph();
     ImmutableList<Path> jars =
         dependencies.list().stream()
@@ -789,11 +790,14 @@ public class LinkageCheckerTest {
     // implementation for logging backend. The tool should not show errors for such classes.
     DependencyGraph slf4jGraph =
         dependencyGraphBuilder
-            .buildMavenDependencyGraph(new DefaultArtifact("org.slf4j:slf4j-api:1.7.26"))
+            .buildMavenDependencyGraph(
+                new Dependency(new DefaultArtifact("org.slf4j:slf4j-api:1.7.26"), "compile"))
             .getDependencyGraph();
     DependencyGraph logbackGraph =
         dependencyGraphBuilder
-            .buildMavenDependencyGraph(new DefaultArtifact("ch.qos.logback:logback-classic:1.2.3"))
+            .buildMavenDependencyGraph(
+                new Dependency(
+                    new DefaultArtifact("ch.qos.logback:logback-classic:1.2.3"), "compile"))
             .getDependencyGraph();
 
     Path slf4jJar = slf4jGraph.list().get(0).getLeaf().getFile().toPath();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -75,7 +75,7 @@ public class LinkageCheckerTest {
   private ImmutableList<Path> resolveTransitiveDependencyPaths(String coordinates) {
     DependencyGraph dependencies =
         dependencyGraphBuilder
-            .buildGraph(new Dependency(new DefaultArtifact(coordinates), "compile"))
+            .buildMavenDependencyGraph(new Dependency(new DefaultArtifact(coordinates), "compile"))
             .getDependencyGraph();
     ImmutableList<Path> jars =
         dependencies.list().stream()
@@ -790,12 +790,12 @@ public class LinkageCheckerTest {
     // implementation for logging backend. The tool should not show errors for such classes.
     DependencyGraph slf4jGraph =
         dependencyGraphBuilder
-            .buildGraph(
+            .buildMavenDependencyGraph(
                 new Dependency(new DefaultArtifact("org.slf4j:slf4j-api:1.7.26"), "compile"))
             .getDependencyGraph();
     DependencyGraph logbackGraph =
         dependencyGraphBuilder
-            .buildGraph(
+            .buildMavenDependencyGraph(
                 new Dependency(
                     new DefaultArtifact("ch.qos.logback:logback-classic:1.2.3"), "compile"))
             .getDependencyGraph();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -50,7 +50,7 @@ public class DependencyGraphBuilderTest {
   public void testGetTransitiveDependencies() throws RepositoryException {
     DependencyGraph graph =
         dependencyGraphBuilder
-            .buildGraph(new Dependency(datastore, "compile"))
+            .buildMavenDependencyGraph(new Dependency(datastore, "compile"))
             .getDependencyGraph();
     List<DependencyPath> list = graph.list();
 
@@ -65,7 +65,7 @@ public class DependencyGraphBuilderTest {
   public void testGetCompleteDependencies() throws RepositoryException {
     DependencyGraph graph =
         dependencyGraphBuilder
-            .buildCompleteGraph(new Dependency(datastore, "compile"))
+            .buildFullDependencyGraph(ImmutableList.of(datastore))
             .getDependencyGraph();
     List<DependencyPath> paths = graph.list();
     Assert.assertTrue(paths.size() > 10);
@@ -97,7 +97,7 @@ public class DependencyGraphBuilderTest {
     // This should not raise DependencyResolutionException
     DependencyGraph completeDependencies =
         dependencyGraphBuilder
-            .buildLinkageCheckDependencyGraph(ImmutableList.of(log4j2))
+            .buildFullDependencyGraph(ImmutableList.of(log4j2))
             .getDependencyGraph();
     Truth.assertThat(completeDependencies.list()).isNotEmpty();
   }
@@ -106,7 +106,7 @@ public class DependencyGraphBuilderTest {
   public void testBuildLinkageCheckDependencyGraph_multipleArtifacts() {
     DependencyGraph graph =
         dependencyGraphBuilder
-            .buildLinkageCheckDependencyGraph(Arrays.asList(datastore, guava))
+            .buildFullDependencyGraph(Arrays.asList(datastore, guava))
             .getDependencyGraph();
 
     List<DependencyPath> list = graph.list();
@@ -129,7 +129,7 @@ public class DependencyGraphBuilderTest {
 
     // Without system properties "os.detected.arch" and "os.detected.name", this would fail.
     DependencyGraphResult dependencyGraphResult =
-        dependencyGraphBuilder.buildGraph(new Dependency(nettyArtifact, ""));
+        dependencyGraphBuilder.buildMavenDependencyGraph(new Dependency(nettyArtifact, ""));
 
     Truth.assertThat(dependencyGraphResult.getArtifactProblems()).isEmpty();
     Truth.assertThat(dependencyGraphResult.getDependencyGraph().list()).isNotEmpty();
@@ -143,7 +143,7 @@ public class DependencyGraphBuilderTest {
 
     DependencyGraph dependencyGraph =
         dependencyGraphBuilder
-            .buildLinkageCheckDependencyGraph(ImmutableList.of(grpcProtobuf))
+            .buildFullDependencyGraph(ImmutableList.of(grpcProtobuf))
             .getDependencyGraph();
 
     Correspondence<DependencyPath, String> pathToArtifactKey =
@@ -164,8 +164,7 @@ public class DependencyGraphBuilderTest {
     Artifact hibernateCore = new DefaultArtifact("org.hibernate:hibernate-core:jar:3.5.1-Final");
 
     DependencyGraphResult result =
-        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(
-            ImmutableList.of(hibernateCore));
+        dependencyGraphBuilder.buildFullDependencyGraph(ImmutableList.of(hibernateCore));
 
     ImmutableList<UnresolvableArtifactProblem> problems = result.getArtifactProblems();
     for (UnresolvableArtifactProblem problem : problems) {
@@ -180,8 +179,7 @@ public class DependencyGraphBuilderTest {
     Artifact hibernateCore = new DefaultArtifact("org.hibernate:hibernate-core:jar:3.5.1-Final");
 
     DependencyGraphResult result =
-        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(
-            ImmutableList.of(hibernateCore));
+        dependencyGraphBuilder.buildFullDependencyGraph(ImmutableList.of(hibernateCore));
 
     ImmutableList<UnresolvableArtifactProblem> artifactProblems = result.getArtifactProblems();
 
@@ -209,8 +207,7 @@ public class DependencyGraphBuilderTest {
     Artifact artifact = new DefaultArtifact("androidx.lifecycle:lifecycle-common-java8:2.0.0");
 
     // This should not raise an exception
-    DependencyGraphResult graph =
-        graphBuilder.buildCompleteGraph(new Dependency(artifact, "compile"));
+    DependencyGraphResult graph = graphBuilder.buildFullDependencyGraph(ImmutableList.of(artifact));
     assertNotNull(graph.getDependencyGraph());
   }
 
@@ -224,7 +221,7 @@ public class DependencyGraphBuilderTest {
     Artifact artifact = new DefaultArtifact("com.google.guava:guava:28.2-jre");
 
     DependencyGraphResult result =
-        graphBuilder.buildCompleteGraph(new Dependency(artifact, "compile"));
+        graphBuilder.buildFullDependencyGraph(ImmutableList.of(artifact));
     Truth.assertThat(result.getArtifactProblems())
         .comparingElementsUsing(problemOnArtifact)
         .contains("com.google.guava:guava:28.2-jre");
@@ -234,7 +231,7 @@ public class DependencyGraphBuilderTest {
   public void testBuildLinkageCheckDependencyGraph_catchRootException() throws RepositoryException {
     // This should not throw exception
     DependencyGraphResult result =
-        dependencyGraphBuilder.buildLinkageCheckDependencyGraph(
+        dependencyGraphBuilder.buildFullDependencyGraph(
             ImmutableList.of(new DefaultArtifact("ant:ant:jar:1.6.2")));
 
     ImmutableList<UnresolvableArtifactProblem> problems = result.getArtifactProblems();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -48,7 +49,9 @@ public class DependencyGraphBuilderTest {
   @Test
   public void testGetTransitiveDependencies() throws RepositoryException {
     DependencyGraph graph =
-        dependencyGraphBuilder.buildMavenDependencyGraph(datastore).getDependencyGraph();
+        dependencyGraphBuilder
+            .buildMavenDependencyGraph(new Dependency(datastore, "compile"))
+            .getDependencyGraph();
     List<DependencyPath> list = graph.list();
 
     Assert.assertTrue(list.size() > 10);
@@ -126,7 +129,7 @@ public class DependencyGraphBuilderTest {
 
     // Without system properties "os.detected.arch" and "os.detected.name", this would fail.
     DependencyGraphResult dependencyGraphResult =
-        dependencyGraphBuilder.buildMavenDependencyGraph(nettyArtifact);
+        dependencyGraphBuilder.buildMavenDependencyGraph(new Dependency(nettyArtifact, ""));
 
     Truth.assertThat(dependencyGraphResult.getArtifactProblems()).isEmpty();
     Truth.assertThat(dependencyGraphResult.getDependencyGraph().list()).isNotEmpty();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.graph.Dependency;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -49,9 +48,7 @@ public class DependencyGraphBuilderTest {
   @Test
   public void testGetTransitiveDependencies() throws RepositoryException {
     DependencyGraph graph =
-        dependencyGraphBuilder
-            .buildMavenDependencyGraph(new Dependency(datastore, "compile"))
-            .getDependencyGraph();
+        dependencyGraphBuilder.buildMavenDependencyGraph(datastore).getDependencyGraph();
     List<DependencyPath> list = graph.list();
 
     Assert.assertTrue(list.size() > 10);
@@ -129,7 +126,7 @@ public class DependencyGraphBuilderTest {
 
     // Without system properties "os.detected.arch" and "os.detected.name", this would fail.
     DependencyGraphResult dependencyGraphResult =
-        dependencyGraphBuilder.buildMavenDependencyGraph(new Dependency(nettyArtifact, ""));
+        dependencyGraphBuilder.buildMavenDependencyGraph(nettyArtifact);
 
     Truth.assertThat(dependencyGraphResult.getArtifactProblems()).isEmpty();
     Truth.assertThat(dependencyGraphResult.getDependencyGraph().list()).isNotEmpty();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -128,7 +129,9 @@ public class DependencyGraphIntegrationTest {
             .buildFullDependencyGraph(ImmutableList.of(grpc))
             .getDependencyGraph();
     DependencyGraph transitiveDependencies =
-        dependencyGraphBuilder.buildMavenDependencyGraph(grpc).getDependencyGraph();
+        dependencyGraphBuilder
+            .buildMavenDependencyGraph(new Dependency(grpc, "compile"))
+            .getDependencyGraph();
 
     Map<String, String> complete = completeDependencies.getHighestVersionMap();
     Map<String, String> transitive =

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphIntegrationTest.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Set;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.graph.Dependency;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -129,9 +128,7 @@ public class DependencyGraphIntegrationTest {
             .buildFullDependencyGraph(ImmutableList.of(grpc))
             .getDependencyGraph();
     DependencyGraph transitiveDependencies =
-        dependencyGraphBuilder
-            .buildMavenDependencyGraph(new Dependency(grpc, "compile"))
-            .getDependencyGraph();
+        dependencyGraphBuilder.buildMavenDependencyGraph(grpc).getDependencyGraph();
 
     Map<String, String> complete = completeDependencies.getHighestVersionMap();
     Map<String, String> transitive =


### PR DESCRIPTION
Towards https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1188.

This PR merges FULL_DEPENDENCY and FULL_DEPENDENCY_WITH_PROVIDED flags into one FULL, deleting "_with_provided" the flag.

# Background

- FULL_DEPENDENCY was for our Dashboard's dependency convergence check. It (somehow) did not include provided dependencies.
- FULL_DEPENDENCY_WITH_PROVIDED was introduced for Linkage Checker. At that time, I had to distinguish the flag with WITH_PROVIDED.

Now, because FULL_DEPENDENCY is used only the dashboard's dependency convergence columns (which we don't use much) and we're fine including provided dependency there, this PR makes the dashboard and Linkage Checker to use the same graph generation logic which includes provided-scope dependencies, deleting FULL_DEPENDENCY option.

After FULL_DEPENDENCY is deleted, the "_WITH_PROVIDED" in FULL_DEPENDENCY_WITH_PROVIDED does not make sense. Therefore, renaming FULL_DEPENDENCY_WITH_PROVIDED to FULL_DEPENDENCY.

# 2 Graph Types

DependencyGraphBuilder now has 2 graph generation functions:
- buildFullDependencyGraph
- buildMavenDependencyGraph

See [GraphTraversalOption's Javadoc]( https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/1218/files#diff-659d7bf4148f942fcc1eb60a50a2ee80R279) and [go/jdd-tree-comparison](http://go/jdd-tree-comparison) for comparison. This PR handles the red rectangles below:

![image](https://user-images.githubusercontent.com/28604/74496639-51fa0200-4ea9-11ea-8b6c-1f77f15eb4c9.png)
