### PR TITLE
DependencyPath and DependencyTreeFormatter to handle null optional flag.

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
@@ -66,8 +66,8 @@ public final class DependencyPath {
   }
 
   /**
-   * Returns dependency path of the parent node of the leaf. Empty dependency node if the leaf does
-   * not have parent or {@link #path} is empty.
+   * Returns the dependency path of the parent node of the leaf. Empty dependency node if the leaf
+   * does not have a parent or {@link #path} is empty.
    */
   DependencyPath getParentPath() {
     DependencyPath parent = new DependencyPath();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
@@ -69,7 +69,7 @@ public final class DependencyPath {
    * Returns dependency path of the parent node of the leaf. Empty dependency node if the leaf does
    * not have parent or {@link #path} is empty.
    */
-  DependencyPath getParent() {
+  DependencyPath getParentPath() {
     DependencyPath parent = new DependencyPath();
     for (int i = 0; i < path.size() - 1; i++) {
       parent.add(path.get(i));

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
@@ -37,7 +37,9 @@ public final class DependencyPath {
 
   @VisibleForTesting
   public void add(Dependency dependency) {
-    path.add(dependency);
+    // null optional is translated to false
+    boolean isOptional = dependency.getOptional() != null && dependency.getOptional();
+    path.add(dependency.setOptional(isOptional));
   }
 
   /** Returns the length of the path. */
@@ -61,6 +63,18 @@ public final class DependencyPath {
    */
   public Artifact get(int i) {
     return path.get(i).getArtifact();
+  }
+
+  /**
+   * Returns dependency path of the parent node of the leaf. Empty dependency node if the leaf does
+   * not have parent or {@link #path} is empty.
+   */
+  DependencyPath getParent() {
+    DependencyPath parent = new DependencyPath();
+    for (int i = 0; i < path.size() - 1; ++i) {
+      parent.add(path.get(i));
+    }
+    return parent;
   }
 
   @Override

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
@@ -71,7 +71,7 @@ public final class DependencyPath {
    */
   DependencyPath getParent() {
     DependencyPath parent = new DependencyPath();
-    for (int i = 0; i < path.size() - 1; ++i) {
+    for (int i = 0; i < path.size() - 1; i++) {
       parent.add(path.get(i));
     }
     return parent;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
@@ -74,7 +74,7 @@ public class DependencyTreeFormatter {
     // LinkedListMultimap preserves insertion order for values
     ListMultimap<DependencyPath, DependencyPath> tree = LinkedListMultimap.create();
     for (DependencyPath dependencyPath : dependencyPaths) {
-      DependencyPath parentDependencyPath = dependencyPath.getParent();
+      DependencyPath parentDependencyPath = dependencyPath.getParentPath();
       // Relying on DependencyPath's equality
       tree.put(parentDependencyPath, dependencyPath);
     }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
@@ -21,8 +21,6 @@ import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import java.util.Collection;
 import java.util.List;
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.graph.Dependency;
 
 /** Formats Maven artifact dependency tree. */
 public class DependencyTreeFormatter {
@@ -76,12 +74,7 @@ public class DependencyTreeFormatter {
     // LinkedListMultimap preserves insertion order for values
     ListMultimap<DependencyPath, DependencyPath> tree = LinkedListMultimap.create();
     for (DependencyPath dependencyPath : dependencyPaths) {
-      List<Artifact> artifactPath = dependencyPath.getArtifacts();
-      List<Artifact> parentArtifactPath = artifactPath.subList(0, artifactPath.size() - 1);
-      DependencyPath parentDependencyPath = new DependencyPath();
-      parentArtifactPath.forEach(
-          parentArtifactPathNode ->
-              parentDependencyPath.add(new Dependency(parentArtifactPathNode, "compile", false)));
+      DependencyPath parentDependencyPath = dependencyPath.getParent();
       // Relying on DependencyPath's equality
       tree.put(parentDependencyPath, dependencyPath);
     }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyPathTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyPathTest.java
@@ -16,12 +16,12 @@
 
 package com.google.cloud.tools.opensource.dependencies;
 
+import com.google.common.testing.EqualsTester;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.Dependency;
 import org.junit.Assert;
 import org.junit.Test;
-import com.google.common.testing.EqualsTester;
 
 public class DependencyPathTest {
 
@@ -46,7 +46,42 @@ public class DependencyPathTest {
     Assert.assertEquals(foo, path.get(0));
     Assert.assertEquals(bar, path.get(1));
   }
-  
+
+  @Test
+  public void testGetParent() {
+    DependencyPath path = new DependencyPath();
+    path.add(new Dependency(foo, "compile", false));
+    path.add(new Dependency(bar, "provided"));
+    path.add(new Dependency(foo, "compile"));
+
+    DependencyPath parent = path.getParent();
+
+    DependencyPath expected = new DependencyPath();
+    expected.add(new Dependency(foo, "compile", false));
+    expected.add(new Dependency(bar, "provided"));
+
+    Assert.assertEquals(expected, parent);
+  }
+
+  @Test
+  public void testGetParent_empty() {
+    DependencyPath path = new DependencyPath();
+
+    DependencyPath parent = path.getParent();
+
+    Assert.assertEquals(new DependencyPath(), parent);
+  }
+
+  @Test
+  public void testGetParent_oneElement() {
+    DependencyPath path = new DependencyPath();
+    path.add(new Dependency(foo, "compile", false));
+
+    DependencyPath parent = path.getParent();
+
+    Assert.assertEquals(new DependencyPath(), parent);
+  }
+
   @Test
   public void testToString() {
     DependencyPath path = new DependencyPath();
@@ -78,4 +113,19 @@ public class DependencyPathTest {
         .testEquals();
   }
 
+  @Test
+  public void testEquals_optionalFlags() {
+    DependencyPath pathOptional = new DependencyPath();
+    DependencyPath pathFalseOptional = new DependencyPath();
+    DependencyPath pathNullOptional = new DependencyPath();
+
+    pathOptional.add(new Dependency(foo, "compile", true));
+    pathFalseOptional.add(new Dependency(foo, "compile", false));
+    pathNullOptional.add(new Dependency(foo, "compile", null));
+
+    new EqualsTester()
+        .addEqualityGroup(pathOptional)
+        .addEqualityGroup(pathFalseOptional, pathNullOptional)
+        .testEquals();
+  }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyPathTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyPathTest.java
@@ -48,7 +48,7 @@ public class DependencyPathTest {
   }
 
   @Test
-  public void testGetParent() {
+  public void testGetParentPath() {
     DependencyPath path = new DependencyPath();
     path.add(new Dependency(foo, "compile", false));
     path.add(new Dependency(bar, "provided"));
@@ -64,7 +64,7 @@ public class DependencyPathTest {
   }
 
   @Test
-  public void testGetParent_empty() {
+  public void testGetParentPath_empty() {
     DependencyPath path = new DependencyPath();
 
     DependencyPath parent = path.getParentPath();
@@ -73,7 +73,7 @@ public class DependencyPathTest {
   }
 
   @Test
-  public void testGetParent_oneElement() {
+  public void testGetParentPath_oneElement() {
     DependencyPath path = new DependencyPath();
     path.add(new Dependency(foo, "compile", false));
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyPathTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyPathTest.java
@@ -54,7 +54,7 @@ public class DependencyPathTest {
     path.add(new Dependency(bar, "provided"));
     path.add(new Dependency(foo, "compile"));
 
-    DependencyPath parent = path.getParent();
+    DependencyPath parent = path.getParentPath();
 
     DependencyPath expected = new DependencyPath();
     expected.add(new Dependency(foo, "compile", false));
@@ -67,7 +67,7 @@ public class DependencyPathTest {
   public void testGetParent_empty() {
     DependencyPath path = new DependencyPath();
 
-    DependencyPath parent = path.getParent();
+    DependencyPath parent = path.getParentPath();
 
     Assert.assertEquals(new DependencyPath(), parent);
   }
@@ -77,7 +77,7 @@ public class DependencyPathTest {
     DependencyPath path = new DependencyPath();
     path.add(new Dependency(foo, "compile", false));
 
-    DependencyPath parent = path.getParent();
+    DependencyPath parent = path.getParentPath();
 
     Assert.assertEquals(new DependencyPath(), parent);
   }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatterTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatterTest.java
@@ -73,4 +73,24 @@ public class DependencyTreeFormatterTest {
         "The dependency should be output as tree with indentation",
         expectedTreeOutput, actualTreeOutput);
   }
+
+  @Test
+  public void testDependencyTree_scopeAndOptionalFlag() {
+    List<DependencyPath> dependencyPathList = new ArrayList<>();
+
+    DependencyPath path1 = new DependencyPath();
+    path1.add(new Dependency(new DefaultArtifact("io.grpc:grpc-auth:jar:1.15.0"), "compile", true));
+    dependencyPathList.add(path1);
+
+    DependencyPath path2 = new DependencyPath();
+    path2.add(new Dependency(new DefaultArtifact("io.grpc:grpc-auth:jar:1.15.0"), "compile", true));
+    path2.add(
+        new Dependency(new DefaultArtifact("io.grpc:grpc-core:jar:1.15.0"), "provided", false));
+    dependencyPathList.add(path2);
+
+    String actualTreeOutput = DependencyTreeFormatter.formatDependencyPaths(dependencyPathList);
+    String expectedTreeOutput =
+        "  io.grpc:grpc-auth:jar:1.15.0\n" + "    io.grpc:grpc-core:jar:1.15.0\n";
+    Assert.assertEquals(expectedTreeOutput, actualTreeOutput);
+  }
 }


### PR DESCRIPTION

- DependencyPath was not handling null optional flag.
- DependencyTreeFormatter was ignoring scopes and optional flags.

