### PR TITLE
DependencyPath.formatDependency takes care of null optional value

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
@@ -70,11 +70,10 @@ public final class DependencyPath {
     return Joiner.on(" / ").join(formatted);
   }
 
-  private static String optionalFlag(Boolean optionalFlag) {
+  private static String formatOptionalFlag(Boolean optionalFlag) {
     if (optionalFlag == null) {
       return "null";
-    }
-    if (optionalFlag) {
+    } else if (optionalFlag) {
       return "optional";
     } else {
       return "";
@@ -82,9 +81,9 @@ public final class DependencyPath {
   }
   
   private static String formatDependency(Dependency dependency) {
-    String optionalPart = optionalFlag(dependency.getOptional());
+    String optionalPart = formatOptionalFlag(dependency.getOptional());
     String scopeAndOptional =
-        dependency.getScope() + (optionalPart.equals("") ? "" : ", " + optionalPart);
+        dependency.getScope() + (optionalPart.isEmpty() ? "" : ", " + optionalPart);
     String coordinates = Artifacts.toCoordinates(dependency.getArtifact());
     return String.format("%s (%s)", coordinates, scopeAndOptional);
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
@@ -69,10 +69,22 @@ public final class DependencyPath {
         path.stream().map(DependencyPath::formatDependency).collect(Collectors.toList());
     return Joiner.on(" / ").join(formatted);
   }
+
+  private static String optionalFlag(Boolean optionalFlag) {
+    if (optionalFlag == null) {
+      return "null";
+    }
+    if (optionalFlag) {
+      return "optional";
+    } else {
+      return "";
+    }
+  }
   
   private static String formatDependency(Dependency dependency) {
+    String optionalPart = optionalFlag(dependency.getOptional());
     String scopeAndOptional =
-        dependency.getScope() + (dependency.getOptional() ? ", optional" : "");
+        dependency.getScope() + (optionalPart.equals("") ? "" : ", " + optionalPart);
     String coordinates = Artifacts.toCoordinates(dependency.getArtifact());
     return String.format("%s (%s)", coordinates, scopeAndOptional);
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
@@ -70,20 +70,8 @@ public final class DependencyPath {
     return Joiner.on(" / ").join(formatted);
   }
 
-  private static String formatOptionalFlag(Boolean optionalFlag) {
-    if (optionalFlag == null) {
-      return "null";
-    } else if (optionalFlag) {
-      return "optional";
-    } else {
-      return "";
-    }
-  }
-  
   private static String formatDependency(Dependency dependency) {
-    String optionalPart = formatOptionalFlag(dependency.getOptional());
-    String scopeAndOptional =
-        dependency.getScope() + (optionalPart.isEmpty() ? "" : ", " + optionalPart);
+    String scopeAndOptional = dependency.getScope() + (dependency.isOptional() ? ", optional" : "");
     String coordinates = Artifacts.toCoordinates(dependency.getArtifact());
     return String.format("%s (%s)", coordinates, scopeAndOptional);
   }
@@ -140,7 +128,7 @@ public final class DependencyPath {
                   artifact.getArtifactId(),
                   artifact.getVersion(),
                   node.getScope(),
-                  node.getOptional());
+                  node.isOptional());
     }
     return hashCode;
   }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyPathTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyPathTest.java
@@ -16,12 +16,12 @@
 
 package com.google.cloud.tools.opensource.dependencies;
 
+import com.google.common.testing.EqualsTester;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.Dependency;
 import org.junit.Assert;
 import org.junit.Test;
-import com.google.common.testing.EqualsTester;
 
 public class DependencyPathTest {
 
@@ -61,8 +61,7 @@ public class DependencyPathTest {
     DependencyPath path = new DependencyPath();
     path.add(new Dependency(foo, "test", false));
     path.add(new Dependency(bar, "compile", null));
-    Assert.assertEquals(
-            "com.google:foo:1 (test) / com.google:bar:1 (compile, null)", path.toString());
+    Assert.assertEquals("com.google:foo:1 (test) / com.google:bar:1 (compile)", path.toString());
   }
 
   @Test
@@ -87,4 +86,17 @@ public class DependencyPathTest {
         .testEquals();
   }
 
+  @Test
+  public void testEquals_nullOptional() {
+    DependencyPath path1 = new DependencyPath();
+    DependencyPath path2 = new DependencyPath();
+
+    path1.add(new Dependency(foo, "compile"));
+    path1.add(new Dependency(bar, "compile"));
+
+    path2.add(new Dependency(foo, "compile"));
+    path2.add(new Dependency(bar, "compile", null));
+
+    new EqualsTester().addEqualityGroup(path1, path2).testEquals();
+  }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyPathTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyPathTest.java
@@ -55,7 +55,16 @@ public class DependencyPathTest {
     Assert.assertEquals(
         "com.google:foo:1 (test) / com.google:bar:1 (compile, optional)", path.toString());
   }
-  
+
+  @Test
+  public void testToString_nullOptionalFlag() {
+    DependencyPath path = new DependencyPath();
+    path.add(new Dependency(foo, "test", false));
+    path.add(new Dependency(bar, "compile", null));
+    Assert.assertEquals(
+            "com.google:foo:1 (test) / com.google:bar:1 (compile, null)", path.toString());
+  }
+
   @Test
   public void testEquals() {
     DependencyPath path1 = new DependencyPath();


### PR DESCRIPTION
It turned out that `isOptional()` returns 'boolean' while `getOptional()` may return null. Using isOptional() resolves the issue. 