### PR TITLE
DependencyTreeFormatter to respect scopes and optional flags

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
@@ -64,7 +64,7 @@ public final class DependencyPath {
   }
 
   /**
-   * Returns the dependency path of the parent node of the leaf. Empty dependency node if the leaf
+   * Returns the dependency path of the parent node of the leaf. Empty dependency path if the leaf
    * does not have a parent or {@link #path} is empty.
    */
   DependencyPath getParentPath() {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
@@ -63,6 +63,18 @@ public final class DependencyPath {
     return path.get(i).getArtifact();
   }
 
+  /**
+   * Returns the dependency path of the parent node of the leaf. Empty dependency node if the leaf
+   * does not have a parent or {@link #path} is empty.
+   */
+  DependencyPath getParentPath() {
+    DependencyPath parent = new DependencyPath();
+    for (int i = 0; i < path.size() - 1; i++) {
+      parent.add(path.get(i));
+    }
+    return parent;
+  }
+
   @Override
   public String toString() {
     List<String> formatted =

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatter.java
@@ -21,8 +21,6 @@ import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import java.util.Collection;
 import java.util.List;
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.graph.Dependency;
 
 /** Formats Maven artifact dependency tree. */
 public class DependencyTreeFormatter {
@@ -76,13 +74,8 @@ public class DependencyTreeFormatter {
     // LinkedListMultimap preserves insertion order for values
     ListMultimap<DependencyPath, DependencyPath> tree = LinkedListMultimap.create();
     for (DependencyPath dependencyPath : dependencyPaths) {
-      List<Artifact> artifactPath = dependencyPath.getArtifacts();
-      List<Artifact> parentArtifactPath = artifactPath.subList(0, artifactPath.size() - 1);
-      DependencyPath parentDependencyPath = new DependencyPath();
-      parentArtifactPath.forEach(
-          parentArtifactPathNode ->
-              parentDependencyPath.add(new Dependency(parentArtifactPathNode, "compile", false)));
       // Relying on DependencyPath's equality
+      DependencyPath parentDependencyPath = dependencyPath.getParentPath();
       tree.put(parentDependencyPath, dependencyPath);
     }
     return tree;

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyPathTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyPathTest.java
@@ -46,7 +46,42 @@ public class DependencyPathTest {
     Assert.assertEquals(foo, path.get(0));
     Assert.assertEquals(bar, path.get(1));
   }
-  
+
+  @Test
+  public void testGetParentPath() {
+    DependencyPath path = new DependencyPath();
+    path.add(new Dependency(foo, "compile", false));
+    path.add(new Dependency(bar, "provided"));
+    path.add(new Dependency(foo, "compile"));
+
+    DependencyPath parent = path.getParentPath();
+
+    DependencyPath expected = new DependencyPath();
+    expected.add(new Dependency(foo, "compile", false));
+    expected.add(new Dependency(bar, "provided"));
+
+    Assert.assertEquals(expected, parent);
+  }
+
+  @Test
+  public void testGetParentPath_empty() {
+    DependencyPath path = new DependencyPath();
+
+    DependencyPath parent = path.getParentPath();
+
+    Assert.assertEquals(new DependencyPath(), parent);
+  }
+
+  @Test
+  public void testGetParentPath_oneElement() {
+    DependencyPath path = new DependencyPath();
+    path.add(new Dependency(foo, "compile", false));
+
+    DependencyPath parent = path.getParentPath();
+
+    Assert.assertEquals(new DependencyPath(), parent);
+  }
+
   @Test
   public void testToString() {
     DependencyPath path = new DependencyPath();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatterTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyTreeFormatterTest.java
@@ -73,4 +73,24 @@ public class DependencyTreeFormatterTest {
         "The dependency should be output as tree with indentation",
         expectedTreeOutput, actualTreeOutput);
   }
+
+  @Test
+  public void testDependencyTree_scopeAndOptionalFlag() {
+    List<DependencyPath> dependencyPathList = new ArrayList<>();
+
+    DependencyPath path1 = new DependencyPath();
+    path1.add(new Dependency(new DefaultArtifact("io.grpc:grpc-auth:jar:1.15.0"), "compile", true));
+    dependencyPathList.add(path1);
+
+    DependencyPath path2 = new DependencyPath();
+    path2.add(new Dependency(new DefaultArtifact("io.grpc:grpc-auth:jar:1.15.0"), "compile", true));
+    path2.add(
+        new Dependency(new DefaultArtifact("io.grpc:grpc-core:jar:1.15.0"), "provided", false));
+    dependencyPathList.add(path2);
+
+    String actualTreeOutput = DependencyTreeFormatter.formatDependencyPaths(dependencyPathList);
+    String expectedTreeOutput =
+        "  io.grpc:grpc-auth:jar:1.15.0\n" + "    io.grpc:grpc-core:jar:1.15.0\n";
+    Assert.assertEquals(expectedTreeOutput, actualTreeOutput);
+  }
 }


### PR DESCRIPTION
Revise of https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/1229 .

DependencyTreeFormatter was assuming every dependency has "compile" scope and optional false:

```
      parentArtifactPath.forEach(
          parentArtifactPathNode ->
              parentDependencyPath.add(new Dependency(parentArtifactPathNode, "compile", false)));
```

https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/1237/files#diff-e825ccadbd98c809005839481296b814L84

This caused incorrect tree output when a dependency is not compile scope or optional=true.