### PR TITLE
Fixing the argument order in CycleBreakingGraphTrasnformer.removeChildFromParent

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/CycleBreakerGraphTransformer.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/CycleBreakerGraphTransformer.java
@@ -48,7 +48,7 @@ final class CycleBreakerGraphTransformer implements DependencyGraphTransformer {
 
     if (ancestors.contains(artifact)) { // Set (rather than List) gives O(1) lookup here
       // parent is not null when ancestors is not empty
-      removeChildFromParent(parent, node);
+      removeChildFromParent(node, parent);
       return;
     }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -203,4 +203,18 @@ public class ClassPathBuilderTest {
     assertEquals("xerces:xerces-impl:jar:2.6.2", artifactProblems.get(0).getArtifact().toString());
     assertEquals("xml-apis:xml-apis:jar:2.6.2", artifactProblems.get(1).getArtifact().toString());
   }
+
+  @Test
+  public void testResolve_shouldNotRaiseStackOverflowErrorOnJUnit() {
+    // There was StackOverflowError beam-sdks-java-extensions-sql-zetasql:jar:2.19.0, which was
+    // caused by a cycle of the following artifacts:
+    // junit:junit:jar:4.10 (compile?)
+    //   org.hamcrest:hamcrest-core:jar:1.1 (compile)
+    //     jmock:jmock:jar:1.1.0 (provided)
+    //       junit:junit:jar:3.8.1 (compile)
+    //         org.hamcrest:hamcrest-core:jar:1.1 (compile)
+    Artifact beamZetaSqlExtensions = new DefaultArtifact("junit:junit:jar:4.10");
+    // This should not throw StackOverflowError
+    ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(beamZetaSqlExtensions));
+  }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.opensource.classpath;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import com.google.cloud.tools.opensource.dependencies.RepositoryUtility;
 import com.google.cloud.tools.opensource.dependencies.UnresolvableArtifactProblem;
@@ -214,7 +215,9 @@ public class ClassPathBuilderTest {
     //       junit:junit:jar:3.8.1 (compile)
     //         org.hamcrest:hamcrest-core:jar:1.1 (compile)
     Artifact beamZetaSqlExtensions = new DefaultArtifact("junit:junit:jar:4.10");
+
     // This should not throw StackOverflowError
     ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(beamZetaSqlExtensions));
+    assertNotNull(result);
   }
 }


### PR DESCRIPTION
I forgot to change the argument order when I applied the previous code review for CycleBreakingGraphTransformer.