### PR TITLE
Replace Stack with ArrayDeque

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -267,9 +267,9 @@ public final class DependencyGraphBuilder {
 
   private static final class LevelOrderQueueItem {
     final DependencyNode dependencyNode;
-    final Stack<DependencyNode> parentNodes;
+    final ArrayDeque<DependencyNode> parentNodes;
 
-    LevelOrderQueueItem(DependencyNode dependencyNode, Stack<DependencyNode> parentNodes) {
+    LevelOrderQueueItem(DependencyNode dependencyNode, ArrayDeque<DependencyNode> parentNodes) {
       this.dependencyNode = dependencyNode;
       this.parentNodes = parentNodes;
     }
@@ -297,13 +297,13 @@ public final class DependencyGraphBuilder {
     DependencyGraph graph = new DependencyGraph();
 
     Queue<LevelOrderQueueItem> queue = new ArrayDeque<>();
-    queue.add(new LevelOrderQueueItem(firstNode, new Stack<>()));
+    queue.add(new LevelOrderQueueItem(firstNode, new ArrayDeque<>()));
 
     while (!queue.isEmpty()) {
       LevelOrderQueueItem item = queue.poll();
       DependencyNode dependencyNode = item.dependencyNode;
       DependencyPath path = new DependencyPath();
-      Stack<DependencyNode> parentNodes = item.parentNodes;
+      ArrayDeque<DependencyNode> parentNodes = item.parentNodes;
       parentNodes.forEach(
           parentNode -> path.add(parentNode.getDependency()));
       Artifact artifact = dependencyNode.getArtifact();
@@ -330,8 +330,7 @@ public final class DependencyGraphBuilder {
       }
       
       for (DependencyNode child : dependencyNode.getChildren()) {
-        @SuppressWarnings("unchecked")
-        Stack<DependencyNode> clone = (Stack<DependencyNode>) parentNodes.clone();
+        ArrayDeque<DependencyNode> clone = parentNodes.clone();
         queue.add(new LevelOrderQueueItem(child, clone));
       }
     }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -28,7 +28,6 @@ import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Locale;
 import java.util.Queue;
-import java.util.Stack;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -297,7 +296,7 @@ public final class DependencyGraphBuilder {
     DependencyGraph graph = new DependencyGraph();
 
     Queue<LevelOrderQueueItem> queue = new ArrayDeque<>();
-      queue.add(new LevelOrderQueueItem(firstNode, new ArrayDeque<>()));
+    queue.add(new LevelOrderQueueItem(firstNode, new ArrayDeque<>()));
 
     while (!queue.isEmpty()) {
       LevelOrderQueueItem item = queue.poll();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -297,7 +297,7 @@ public final class DependencyGraphBuilder {
     DependencyGraph graph = new DependencyGraph();
 
     Queue<LevelOrderQueueItem> queue = new ArrayDeque<>();
-    queue.add(new LevelOrderQueueItem(firstNode, new ArrayDeque<>()));
+      queue.add(new LevelOrderQueueItem(firstNode, new ArrayDeque<>()));
 
     while (!queue.isEmpty()) {
       LevelOrderQueueItem item = queue.poll();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -325,7 +325,7 @@ public final class DependencyGraphBuilder {
         }
 
         path.add(dependencyNode.getDependency());
-        parentNodes.push(dependencyNode);
+        parentNodes.add(dependencyNode);
         graph.addPath(path);
       }
       

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -223,7 +223,8 @@ public class ClassPathBuilderTest {
 
   @Test
   public void testBeamHCatalogOutOfMemoryError() {
-    Artifact hibernateCore = new DefaultArtifact("org.apache.beam:beam-sdks-java-io-hcatalog:2.19.0");
+    Artifact hibernateCore =
+        new DefaultArtifact("org.apache.beam:beam-sdks-java-io-hcatalog:2.19.0");
     ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(hibernateCore));
     assertNotNull(result);
   }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -220,12 +220,4 @@ public class ClassPathBuilderTest {
     ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(beamZetaSqlExtensions));
     assertNotNull(result);
   }
-
-  @Test
-  public void testBeamHCatalogOutOfMemoryError() {
-    Artifact hibernateCore =
-        new DefaultArtifact("org.apache.beam:beam-sdks-java-io-hcatalog:2.19.0");
-    ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(hibernateCore));
-    assertNotNull(result);
-  }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -220,4 +220,11 @@ public class ClassPathBuilderTest {
     ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(beamZetaSqlExtensions));
     assertNotNull(result);
   }
+
+  @Test
+  public void testBeamHCatalogOutOfMemoryError() {
+    Artifact hibernateCore = new DefaultArtifact("org.apache.beam:beam-sdks-java-io-hcatalog:2.19.0");
+    ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(hibernateCore));
+    assertNotNull(result);
+  }
 }


### PR DESCRIPTION
As per go/java-practices/choosing-collections

> Stack
>   Nonstandard class that predates the Java Collections Framework; use ArrayDeque
