### PR TITLE
remove deprecated class

### DIFF
--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/VersionSubstitutingModelResolver.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/VersionSubstitutingModelResolver.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.maven.model.building.ModelSource;
+import org.apache.maven.model.building.ModelSource2;
 import org.apache.maven.model.resolution.ModelResolver;
 import org.apache.maven.model.resolution.UnresolvableModelException;
 import org.apache.maven.project.ProjectModelResolver;
@@ -68,16 +68,16 @@ class VersionSubstitutingModelResolver extends ProjectModelResolver {
   }
 
   /**
-   * Returns model source for {@code groupId:artifactId:version}. The version is substituted if
-   * {@link #versionSubstitution} contains the versionless coordinates ({@code groupId:artifactId})
-   * in its keys.
+   * Returns a file model source for {@code groupId:artifactId:version}.
+   * The version is substituted if {@link #versionSubstitution} contains the
+   * versionless coordinates ({@code groupId:artifactId}) in its keys.
    */
   @Override
-  public ModelSource resolveModel(String groupId, String artifactId, String version)
+  public ModelSource2 resolveModel(String groupId, String artifactId, String version)
       throws UnresolvableModelException {
     String versionlessCoordinates = groupId + ":" + artifactId;
     String versionToResolve = versionSubstitution.getOrDefault(versionlessCoordinates, version);
-    return super.resolveModel(groupId, artifactId, versionToResolve);
+    return (ModelSource2) super.resolveModel(groupId, artifactId, versionToResolve);
   }
 
   @Override

--- a/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/VersionSubstitutingModelResolverTest.java
+++ b/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/VersionSubstitutingModelResolverTest.java
@@ -31,7 +31,6 @@ import org.apache.maven.model.building.DefaultModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuildingException;
 import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuildingResult;
-import org.apache.maven.model.building.ModelSource;
 import org.apache.maven.model.resolution.ModelResolver;
 import org.apache.maven.model.resolution.UnresolvableModelException;
 import org.eclipse.aether.RepositorySystem;
@@ -120,7 +119,7 @@ public class VersionSubstitutingModelResolverTest {
     Truth.assertThat(copiedResolver).isInstanceOf(VersionSubstitutingModelResolver.class);
 
     // request for guava:20.0 is replaced with 25.1-jre
-    ModelSource guavaModelSource = copiedResolver.resolveModel("com.google.guava", "guava", "20.0");
-    Truth.assertThat(guavaModelSource.getLocation()).contains("guava-25.1-jre.pom");
+    Truth.assertThat(copiedResolver.resolveModel(
+        "com.google.guava", "guava", "20.0").getLocation()).contains("guava-25.1-jre.pom");
   }
 }


### PR DESCRIPTION
@suztomo " This interface does not support loading of parent POM(s) from the same backing store, integrators are strongly encouraged to implement {@link ModelSource2} instead of implementing this interface directly." and in fact the superclass here does that.
