### PR TITLE
Extract OsProperties class

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>4.1.2-SNAPSHOT</version>
+  <version>4.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>4.1.2-SNAPSHOT</version>
+        <version>4.2.1-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -20,13 +20,10 @@ import static com.google.cloud.tools.opensource.dependencies.RepositoryUtility.C
 import static com.google.cloud.tools.opensource.dependencies.RepositoryUtility.mavenRepositoryFromUrl;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
-import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.ArrayDeque;
 import java.util.List;
-import java.util.Locale;
 import java.util.Queue;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -75,57 +72,11 @@ public final class DependencyGraphBuilder {
 
   private static final RepositorySystem system = RepositoryUtility.newRepositorySystem();
 
-  private static final CharMatcher LOWER_ALPHA_NUMERIC =
-      CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('0', '9'));
-
   /** Maven Repositories to use when resolving dependencies. */
   private final ImmutableList<RemoteRepository> repositories;
 
   static {
-    detectOsProperties().forEach(System::setProperty);
-  }
-
-  public static ImmutableMap<String, String> detectOsProperties() {
-    // System properties to select Netty dependencies through os-maven-plugin
-    // Definition of the properties: https://github.com/trustin/os-maven-plugin
-    String osDetectedName = osDetectedName();
-    String osDetectedArch = osDetectedArch();
-    return ImmutableMap.of(
-        "os.detected.name",
-        osDetectedName,
-        "os.detected.arch",
-        osDetectedArch,
-        "os.detected.classifier",
-        osDetectedName + "-" + osDetectedArch);
-  }
-
-  private static String osDetectedName() {
-    String osNameNormalized =
-        LOWER_ALPHA_NUMERIC.retainFrom(System.getProperty("os.name").toLowerCase(Locale.ENGLISH));
-
-    if (osNameNormalized.startsWith("macosx") || osNameNormalized.startsWith("osx")) {
-      return "osx";
-    } else if (osNameNormalized.startsWith("windows")) {
-      return "windows";
-    }
-    // Since we only load the dependency graph, not actually use the
-    // dependency, it doesn't matter a great deal which one we pick.
-    return "linux";
-  }
-
-  private static String osDetectedArch() {
-    String osArchNormalized =
-        LOWER_ALPHA_NUMERIC.retainFrom(System.getProperty("os.arch").toLowerCase(Locale.ENGLISH));
-    switch (osArchNormalized) {
-      case "x8664":
-      case "amd64":
-      case "ia32e":
-      case "em64t":
-      case "x64":
-        return "x86_64";
-      default:
-        return "x86_32";
-    }
+    OsProperties.detectOsProperties().forEach(System::setProperty);
   }
 
   public DependencyGraphBuilder() {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -224,7 +224,7 @@ public final class RepositoryUtility {
       // Profile activation needs properties such as JDK version
       Properties properties = new Properties(); // allowing duplicate entries
       properties.putAll(projectBuildingRequest.getSystemProperties());
-      properties.putAll(DependencyGraphBuilder.detectOsProperties());
+      properties.putAll(OsProperties.detectOsProperties());
       properties.putAll(System.getProperties());
       projectBuildingRequest.setSystemProperties(properties);
 
@@ -303,9 +303,9 @@ public final class RepositoryUtility {
     }
 
     // TODO remove this hack once we get these out of google-cloud-java's BOM
-    if (BOM_SKIP_ARTIFACT_IDS.contains(artifact.getArtifactId())) {
+ /*   if (BOM_SKIP_ARTIFACT_IDS.contains(artifact.getArtifactId())) {
       return true;
-    }
+    }*/
 
     return false;
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -303,9 +303,9 @@ public final class RepositoryUtility {
     }
 
     // TODO remove this hack once we get these out of google-cloud-java's BOM
- /*   if (BOM_SKIP_ARTIFACT_IDS.contains(artifact.getArtifactId())) {
+    if (BOM_SKIP_ARTIFACT_IDS.contains(artifact.getArtifactId())) {
       return true;
-    }*/
+    }
 
     return false;
   }

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -30,6 +30,7 @@ import com.google.cloud.tools.opensource.dependencies.ArtifactProblem;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraphBuilder;
 import com.google.cloud.tools.opensource.dependencies.FilteringZipDependencySelector;
 import com.google.cloud.tools.opensource.dependencies.NonTestDependencySelector;
+import com.google.cloud.tools.opensource.dependencies.OsProperties;
 import com.google.cloud.tools.opensource.dependencies.UnresolvableArtifactProblem;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -253,7 +254,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
       // For netty-handler referencing its dependencies with ${os.detected.classifier}
       Map<String, String> properties = new HashMap<>(); // allowing duplicate entries
       properties.putAll(fullDependencyResolutionSession.getSystemProperties());
-      properties.putAll(DependencyGraphBuilder.detectOsProperties());
+      properties.putAll(OsProperties.detectOsProperties());
       fullDependencyResolutionSession.setSystemProperties(properties);
 
       fullDependencyResolutionSession.setDependencySelector(

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -209,7 +209,7 @@ public class LinkageCheckerRuleTest {
     Map<String, String> propertiesUsedInSession =
         argumentCaptor.getValue().getRepositorySession().getSystemProperties();
     Truth.assertWithMessage(
-            "RepositorySystemSession should have variables such as os.detected.classifier")
+            "RepositorySystemSession should have variables such as os.detected.arch")
         .that(propertiesUsedInSession)
         .containsAtLeastEntriesIn(OsProperties.detectOsProperties());
     // There was a problem in resolving profiles because original properties were missing (#817)

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -209,7 +209,7 @@ public class LinkageCheckerRuleTest {
     Map<String, String> propertiesUsedInSession =
         argumentCaptor.getValue().getRepositorySession().getSystemProperties();
     Truth.assertWithMessage(
-            "RepositorySystemSession should have variables such as os.detected.arch")
+            "RepositorySystemSession should have variables such as os.detected.classifier")
         .that(propertiesUsedInSession)
         .containsAtLeastEntriesIn(OsProperties.detectOsProperties());
     // There was a problem in resolving profiles because original properties were missing (#817)

--- a/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
+++ b/enforcer-rules/src/test/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRuleTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule.DependencySection;
-import com.google.cloud.tools.opensource.dependencies.DependencyGraphBuilder;
+import com.google.cloud.tools.opensource.dependencies.OsProperties;
 import com.google.cloud.tools.opensource.dependencies.RepositoryUtility;
 import com.google.common.collect.ImmutableList;
 import com.google.common.graph.Traverser;
@@ -211,7 +211,7 @@ public class LinkageCheckerRuleTest {
     Truth.assertWithMessage(
             "RepositorySystemSession should have variables such as os.detected.classifier")
         .that(propertiesUsedInSession)
-        .containsAtLeastEntriesIn(DependencyGraphBuilder.detectOsProperties());
+        .containsAtLeastEntriesIn(OsProperties.detectOsProperties());
     // There was a problem in resolving profiles because original properties were missing (#817)
     Truth.assertWithMessage("RepositorySystemSession should have original properties")
         .that(propertiesUsedInSession)


### PR DESCRIPTION
@suztomo This helps keep the dependency graph builder more focused on building dependency graphs by pulling property detection logic out into an independent class. 