### PR TITLE
Suppress Linkage Errors from classes that check ClassNotFoundException

### DIFF
--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -211,7 +211,7 @@ public class DashboardTest {
     // appengine-api-sdk, shown as first item in linkage errors, has these errors
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
         .isEqualTo(
-            "106 target classes causing linkage errors referenced from 516 source classes.");
+            "91 target classes causing linkage errors referenced from 501 source classes.");
 
     Nodes dependencyPaths = details.query("//p[@class='linkage-check-dependency-paths']");
     Node dependencyPathMessageOnProblem = dependencyPaths.get(dependencyPaths.size() - 4);
@@ -300,7 +300,7 @@ public class DashboardTest {
     Nodes reports = document.query("//p[@class='jar-linkage-report']");
     Assert.assertEquals(1, reports.size());
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
-        .isEqualTo("106 target classes causing linkage errors referenced from 516 source classes.");
+        .isEqualTo("91 target classes causing linkage errors referenced from 501 source classes.");
 
     Nodes causes = document.query("//p[@class='jar-linkage-report-cause']");
     Truth.assertWithMessage(

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassDumper.java
@@ -512,7 +512,8 @@ class ClassDumper {
       ImmutableSet.of(
           LinkageError.class.getName(),
           NoClassDefFoundError.class.getName(),
-          NoSuchMethodError.class.getName());
+          NoSuchMethodError.class.getName(),
+          ClassNotFoundException.class.getName());
 
   /**
    * Returns true if {@code sourceClassName} has a method that has an exception handler for {@link


### PR DESCRIPTION
From the investigation of #1296 . Some classes in BlockHound checks whether certain classes are available or not before using them.
