### PR TITLE
AnnotatedJar class to replace java.nio.Path

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/AnnotatedJar.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/AnnotatedJar.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.classpath;
+
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.eclipse.aether.artifact.Artifact;
+
+/**
+ * JAR file annotated with an optional Maven artifact.
+ */
+final class AnnotatedJar {
+  private Path jar;
+
+  private Artifact artifact;
+
+  AnnotatedJar(Path jar, @Nullable Artifact artifact) {
+    this.jar = checkNotNull(jar);
+    this.artifact = artifact;
+  }
+
+  AnnotatedJar(Path jar) {
+    this(jar, null);
+  }
+
+  /**
+   * The Maven artifact that holds the JAR file, if the JAR is downloaded for a Maven artifact.
+   * {@code Null} if the JAR file is not from a Maven artifact.
+   */
+  @Nullable
+  Artifact getArtifact() {
+    return artifact;
+  }
+
+  /**
+   * Path to the JAR file.
+   */
+  Path getJar() {
+    return jar;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    AnnotatedJar that = (AnnotatedJar) other;
+    return Objects.equals(jar, that.jar) &&
+        Objects.equals(artifact, that.artifact);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(jar, artifact);
+  }
+}

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/AnnotatedJar.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/AnnotatedJar.java
@@ -39,15 +39,15 @@ final class AnnotatedJar {
   }
 
   /**
-   * The Maven artifact that holds the JAR file, if the JAR is downloaded for a Maven artifact.
-   * {@code Null} if the JAR file is not from a Maven artifact.
+   * Returns the Maven artifact that holds the JAR file, if the JAR is downloaded for a Maven
+   * artifact. {@code Null} if the JAR file is not from a Maven artifact.
    */
   @Nullable
   Artifact getArtifact() {
     return artifact;
   }
 
-  /** Path to the JAR file. */
+  /** Returns path to the JAR file. */
   Path getJar() {
     return jar;
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/AnnotatedJar.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/AnnotatedJar.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.nio.file.Path;
@@ -24,9 +23,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 import org.eclipse.aether.artifact.Artifact;
 
-/**
- * JAR file annotated with an optional Maven artifact.
- */
+/** JAR file annotated with an optional Maven artifact. */
 final class AnnotatedJar {
   private Path jar;
 
@@ -50,9 +47,7 @@ final class AnnotatedJar {
     return artifact;
   }
 
-  /**
-   * Path to the JAR file.
-   */
+  /** Path to the JAR file. */
   Path getJar() {
     return jar;
   }
@@ -66,8 +61,7 @@ final class AnnotatedJar {
       return false;
     }
     AnnotatedJar that = (AnnotatedJar) other;
-    return Objects.equals(jar, that.jar) &&
-        Objects.equals(artifact, that.artifact);
+    return Objects.equals(jar, that.jar) && Objects.equals(artifact, that.artifact);
   }
 
   @Override

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/AnnotatedJarTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/AnnotatedJarTest.java
@@ -16,12 +16,39 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
 import com.google.common.testing.EqualsTester;
 import java.nio.file.Paths;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Test;
 
 public class AnnotatedJarTest {
+
+  @Test
+  public void testGetters() {
+    AnnotatedJar jar = new AnnotatedJar(Paths.get("foo"), new DefaultArtifact("com.foo:bar:1.0.0"));
+    assertEquals(Paths.get("foo"), jar.getJar());
+    assertEquals(new DefaultArtifact("com.foo:bar:1.0.0"), jar.getArtifact());
+  }
+
+  @Test
+  public void testNullArtifact() {
+    AnnotatedJar jar = new AnnotatedJar(Paths.get("foo"));
+    assertNull(jar.getArtifact());
+  }
+
+  @Test
+  public void testNullJar() {
+    try {
+      new AnnotatedJar(null, new DefaultArtifact("com.foo:bar:1.0.0"));
+      fail("AnnotatedJar should invalidate null jar file");
+    } catch (NullPointerException expected) {
+      // pass
+    }
+  }
 
   @Test
   public void testEquals() {

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/AnnotatedJarTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/AnnotatedJarTest.java
@@ -17,8 +17,6 @@
 package com.google.cloud.tools.opensource.classpath;
 
 import com.google.common.testing.EqualsTester;
-import com.google.common.testing.NullPointerTester;
-import com.google.common.testing.NullPointerTester.Visibility;
 import java.nio.file.Paths;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Test;
@@ -32,12 +30,10 @@ public class AnnotatedJarTest {
             new AnnotatedJar(Paths.get("foo"), new DefaultArtifact("com.foo:bar:1.0.0")),
             new AnnotatedJar(Paths.get("foo"), new DefaultArtifact("com.foo:bar:1.0.0")))
         .addEqualityGroup(
-            new AnnotatedJar(Paths.get("foo"), null),
-            new AnnotatedJar(Paths.get("foo"), null))
+            new AnnotatedJar(Paths.get("foo"), null), new AnnotatedJar(Paths.get("foo"), null))
         .addEqualityGroup(
             new AnnotatedJar(Paths.get("foo", "bar"), null),
             new AnnotatedJar(Paths.get("foo", "bar"), null))
         .testEquals();
   }
-
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/AnnotatedJarTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/AnnotatedJarTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.classpath;
+
+import com.google.common.testing.EqualsTester;
+import com.google.common.testing.NullPointerTester;
+import com.google.common.testing.NullPointerTester.Visibility;
+import java.nio.file.Paths;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.Test;
+
+public class AnnotatedJarTest {
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new AnnotatedJar(Paths.get("foo"), new DefaultArtifact("com.foo:bar:1.0.0")),
+            new AnnotatedJar(Paths.get("foo"), new DefaultArtifact("com.foo:bar:1.0.0")))
+        .addEqualityGroup(
+            new AnnotatedJar(Paths.get("foo"), null),
+            new AnnotatedJar(Paths.get("foo"), null))
+        .addEqualityGroup(
+            new AnnotatedJar(Paths.get("foo", "bar"), null),
+            new AnnotatedJar(Paths.get("foo", "bar"), null))
+        .testEquals();
+  }
+
+}


### PR DESCRIPTION
Towards #1179 . Once this is merged, I'll create another PR to replace `ImmutableList<Path>` with `ImmutableList<AnnotatedJar>` in many places.

Linkage Checker will be able to use the artifact part to filter linkage errors based on Maven artifact coordinates.