### PR TITLE
BlockHound's VirtualMachine exclusion rule for JNA

### DIFF
--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -66,7 +66,7 @@
     </Source>
     <Reason>
       BlockHound's shades ByteBuddy's VirtualMachine class. The class uses Java Native Access (JNA)
-      when the class is available by catching ClassNotFoundException. Therefore the invalid
+      only when the class is available by catching ClassNotFoundException. Therefore the invalid
       references should not cause linkage errors at runtime.
       https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1296
     </Reason>

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -65,9 +65,10 @@
       <Package name="reactor.blockhound.shaded.net.bytebuddy.agent.VirtualMachine" />
     </Source>
     <Reason>
-      BlockHound's shades ByteBuddy's VirtualMachine class. The class uses Java Native Access (JNA)
-      only when the class is available by catching ClassNotFoundException. Therefore the invalid
-      references should not cause linkage errors at runtime.
+      BlockHound shades ByteBuddy's VirtualMachine class. The class uses Java Native Access (JNA)
+      only when the com.sun.jna package is available by catching ClassNotFoundException. Therefore
+      the invalid references from the VirtualMachine class to JNA classes do not cause linkage
+      errors at runtime.
       https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1296
     </Reason>
   </LinkageError>

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -66,9 +66,8 @@
     </Source>
     <Reason>
       BlockHound shades ByteBuddy's VirtualMachine class. The class uses Java Native Access (JNA)
-      only when the com.sun.jna package is available by catching ClassNotFoundException. Therefore
-      the invalid references from the VirtualMachine class to JNA classes do not cause linkage
-      errors at runtime.
+      only when the com.sun.jna package is available. Therefore the invalid references from the
+      VirtualMachine class to JNA classes do not cause linkage errors at runtime.
       https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1296
     </Reason>
   </LinkageError>

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -68,6 +68,7 @@
       BlockHound's shades ByteBuddy's VirtualMachine class. The class uses Java Native Access (JNA)
       when the class is available by catching ClassNotFoundException. Therefore the invalid
       references should not cause linkage errors at runtime.
+      https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1296
     </Reason>
   </LinkageError>
 </LinkageCheckerFilter>

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -57,4 +57,17 @@
       https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/407
     </Reason>
   </LinkageError>
+  <LinkageError>
+    <Target>
+      <Package name="com.sun.jna" />
+    </Target>
+    <Source>
+      <Package name="reactor.blockhound.shaded.net.bytebuddy.agent.VirtualMachine" />
+    </Source>
+    <Reason>
+      BlockHound's shades ByteBuddy's VirtualMachine class. The class uses Java Native Access (JNA)
+      when the class is available by catching ClassNotFoundException. Therefore the invalid
+      references should not cause linkage errors at runtime.
+    </Reason>
+  </LinkageError>
 </LinkageCheckerFilter>

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -1044,7 +1044,7 @@ public class LinkageCheckerTest {
   }
 
   @Test
-  public void testFindSymbolProblems_classesCatchingClassNotFoundException() throws IOException {
+  public void testFindSymbolProblems_blockHoundClasses() throws IOException {
     // BlockHound is a tool to detect blocking method calls in nonblocking frameworks.
     // In our BOM dashboard, it appears in dependency path io.grpc:grpc-netty:1.28.0 (compile)
     //   / io.netty:netty-codec-http2:4.1.45.Final (compile)
@@ -1062,8 +1062,11 @@ public class LinkageCheckerTest {
     // missing classes from the integration classes.
     ImmutableList<String> unexpectedClasses =
         ImmutableList.of(
+            // The following two catch ClassNotFoundException
             "reactor.blockhound.integration.RxJava2Integration",
-            "reactor.blockhound.integration.ReactorIntegration");
+            "reactor.blockhound.integration.ReactorIntegration",
+            // This class is in exclusion rule
+            "reactor.blockhound.shaded.net.bytebuddy.agent.VirtualMachine");
 
     for (String unexpectedSourceClass : unexpectedClasses) {
       Truth.assertThat(symbolProblems.values())


### PR DESCRIPTION
Fixes #1296 .

I confirmed gRPC 1.28.0 passes `MaximumLinkageErrorsTest`.

```
suztomo-macbookpro44% git diff
diff --git a/boms/cloud-oss-bom/pom.xml b/boms/cloud-oss-bom/pom.xml
index 822c0269..2aae9b55 100644
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -46,7 +46,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>28.2-android</guava.version>
     <google.cloud.java.version>0.122.5-alpha</google.cloud.java.version>
-    <io.grpc.version>1.27.2</io.grpc.version>
+    <io.grpc.version>1.28.0</io.grpc.version>
     <protobuf.version>3.11.4</protobuf.version>
     <http.version>1.34.2</http.version>
   </properties>
suztomo-macbookpro44% cd boms 
suztomo-macbookpro44% mvn clean install
...
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.google.cloud.MaximumLinkageErrorsTest
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 120.623 s - in com.google.cloud.MaximumLinkageErrorsTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ integration-tests ---
[WARNING] JAR will be empty - no content was marked for inclusion!
[INFO] Building jar: /Users/suztomo/cloud-opensource-java/boms/integration-tests/target/integration-tests-1.2.0-SNAPSHOT.jar
[INFO] 
[INFO] --- maven-install-plugin:2.4:install (default-install) @ integration-tests ---
[INFO] Installing /Users/suztomo/cloud-opensource-java/boms/integration-tests/target/integration-tests-1.2.0-SNAPSHOT.jar to /Users/suztomo/.m2/repository/com/google/cloud/integration-tests/1.2.0-SNAPSHOT/integration-tests-1.2.0-SNAPSHOT.jar
[INFO] Installing /Users/suztomo/cloud-opensource-java/boms/integration-tests/pom.xml to /Users/suztomo/.m2/repository/com/google/cloud/integration-tests/1.2.0-SNAPSHOT/integration-tests-1.2.0-SNAPSHOT.pom
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Google Cloud Platform Supported Libraries 4.3.1-SNAPSHOT SUCCESS [  0.294 s]
[INFO] BOM Parent 1.0-SNAPSHOT ............................ SUCCESS [  0.008 s]
[INFO] Cloud Platform Supported Libraries Upper Bounds Check 2.0.0-SNAPSHOT SUCCESS [  0.730 s]
[INFO] integration-tests 1.2.0-SNAPSHOT ................... SUCCESS [02:03 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:04 min
[INFO] Finished at: 2020-03-25T13:44:30-04:00
[INFO] ------------------------------------------------------------------------
```