### PR TITLE
Removing ClassPathEntry.of in favor of new constructor

### DIFF
--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -70,7 +70,8 @@ public class FreemarkerTest {
             "abc.def.G");
     symbolProblemTable =
         ImmutableMap.of(
-            new ClassPathEntry("com.google:foo:1.0.0", "foo/bar-1.2.3.jar"), dummyProblems);
+            new ClassPathEntry("com.google:foo:1.0.0", Paths.get("foo/bar-1.2.3.jar")),
+            dummyProblems);
   }
 
   @AfterClass

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -70,7 +70,7 @@ public class FreemarkerTest {
             "abc.def.G");
     symbolProblemTable =
         ImmutableMap.of(
-            ClassPathEntry.of("com.google:foo:1.0.0", "foo/bar-1.2.3.jar"), dummyProblems);
+            new ClassPathEntry("com.google:foo:1.0.0", "foo/bar-1.2.3.jar"), dummyProblems);
   }
 
   @AfterClass

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathEntry.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathEntry.java
@@ -20,10 +20,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.ClassPath.ClassInfo;
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -54,9 +52,9 @@ public final class ClassPathEntry {
     this.artifact = artifact;
   }
 
-  /** An entry for Maven artifact with {@code coordinates} and a JAR file at {@code jarFileName}. */
-  public ClassPathEntry(String coordinates, String jarFileName) {
-    this(new DefaultArtifact(coordinates).setFile(new File(jarFileName)));
+  /** An entry for Maven artifact with {@code coordinates} and {@code jarFile}. */
+  public ClassPathEntry(String coordinates, Path jarFile) {
+    this(new DefaultArtifact(coordinates).setFile(jarFile.toFile()));
   }
 
   /** Returns the path to JAR file. */

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathEntry.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathEntry.java
@@ -54,6 +54,11 @@ public final class ClassPathEntry {
     this.artifact = artifact;
   }
 
+  /** An entry for Maven artifact with {@code coordinates} and a JAR file at {@code jarFileName}. */
+  public ClassPathEntry(String coordinates, String jarFileName) {
+    this(new DefaultArtifact(coordinates).setFile(new File(jarFileName)));
+  }
+
   /** Returns the path to JAR file. */
   Path getJar() {
     return jar;
@@ -93,12 +98,6 @@ public final class ClassPathEntry {
     } else {
       return jar.toString();
     }
-  }
-
-  @VisibleForTesting
-  public static ClassPathEntry of(String coordinates, String filePath) {
-    Artifact artifact = new DefaultArtifact(coordinates);
-    return new ClassPathEntry(artifact.setFile(new File(filePath)));
   }
 
   /**

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolProblemTest.java
@@ -104,13 +104,17 @@ public class SymbolProblemTest {
             new FieldSymbol("java.lang.Integer", "MAX_VALUE", "I"),
             ErrorType.SYMBOL_NOT_FOUND,
             new ClassFile(
-                new ClassPathEntry("com.google:ccc:1.2.3", "ccc-1.2.3.jar"), "java.lang.Integer"));
+                new ClassPathEntry("com.google:ccc:1.2.3", Paths.get("ccc-1.2.3.jar")),
+                "java.lang.Integer"));
 
     ClassFile source1 =
-        new ClassFile(ClassPathEntry.of("com.google:foo:0.0.1", "foo/foo.jar"), "java.lang.Object");
+        new ClassFile(
+            new ClassPathEntry("com.google:foo:0.0.1", Paths.get("foo/foo.jar")),
+            "java.lang.Object");
     ClassFile source2 =
         new ClassFile(
-            new ClassPathEntry("com.google:bar:0.0.1", "bar/bar.jar"), "java.lang.Integer");
+            new ClassPathEntry("com.google:bar:0.0.1", Paths.get("bar/bar.jar")),
+            "java.lang.Integer");
 
     ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems =
         ImmutableSetMultimap.of(

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/SymbolProblemTest.java
@@ -104,13 +104,13 @@ public class SymbolProblemTest {
             new FieldSymbol("java.lang.Integer", "MAX_VALUE", "I"),
             ErrorType.SYMBOL_NOT_FOUND,
             new ClassFile(
-                ClassPathEntry.of("com.google:ccc:1.2.3", "ccc-1.2.3.jar"), "java.lang.Integer"));
+                new ClassPathEntry("com.google:ccc:1.2.3", "ccc-1.2.3.jar"), "java.lang.Integer"));
 
     ClassFile source1 =
         new ClassFile(ClassPathEntry.of("com.google:foo:0.0.1", "foo/foo.jar"), "java.lang.Object");
     ClassFile source2 =
         new ClassFile(
-            ClassPathEntry.of("com.google:bar:0.0.1", "bar/bar.jar"), "java.lang.Integer");
+            new ClassPathEntry("com.google:bar:0.0.1", "bar/bar.jar"), "java.lang.Integer");
 
     ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems =
         ImmutableSetMultimap.of(

--- a/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
+++ b/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
@@ -106,7 +106,7 @@ public class LinkageMonitorTest {
               "(Lcom/google/protobuf/Message;)Lio/grpc/MethodDescriptor$Marshaller;",
               false),
           ErrorType.SYMBOL_NOT_FOUND,
-          new ClassFile(ClassPathEntry.of("foo:b:1.0.0", "foo/b-1.0.0.jar"), "java.lang.Object"));
+          new ClassFile(new ClassPathEntry("foo:b:1.0.0", "foo/b-1.0.0.jar"), "java.lang.Object"));
 
   @Test
   public void generateMessageForNewError() {

--- a/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
+++ b/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
@@ -106,13 +106,14 @@ public class LinkageMonitorTest {
               "(Lcom/google/protobuf/Message;)Lio/grpc/MethodDescriptor$Marshaller;",
               false),
           ErrorType.SYMBOL_NOT_FOUND,
-          new ClassFile(new ClassPathEntry("foo:b:1.0.0", "foo/b-1.0.0.jar"), "java.lang.Object"));
+          new ClassFile(
+              new ClassPathEntry("foo:b:1.0.0", Paths.get("foo/b-1.0.0.jar")), "java.lang.Object"));
 
   @Test
   public void generateMessageForNewError() {
     Set<SymbolProblem> baselineProblems = ImmutableSet.of(classNotFoundProblem);
-    ClassPathEntry jarA = ClassPathEntry.of("foo:a:1.2.3", "foo/a-1.2.3.jar");
-    ClassPathEntry jarB = ClassPathEntry.of("foo:b:1.0.0", "foo/b-1.0.0.jar");
+    ClassPathEntry jarA = new ClassPathEntry("foo:a:1.2.3", Paths.get("foo/a-1.2.3.jar"));
+    ClassPathEntry jarB = new ClassPathEntry("foo:b:1.0.0", Paths.get("foo/b-1.0.0.jar"));
     ImmutableSetMultimap<SymbolProblem, ClassFile> snapshotProblems =
         ImmutableSetMultimap.of(
             classNotFoundProblem, // This is in baseline. It should not be printed


### PR DESCRIPTION
The previous usage of `@VisibleForTesting` was wrong. This PR treats ClassPathEntry instance creation with coordinates and JAR location as a normal constructor. Nothing special for tests.