### PR TITLE
avoid polluting local repository

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -22,9 +22,11 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Queue;
+import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -33,6 +35,7 @@ import org.eclipse.aether.graph.DefaultDependencyNode;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyRequest;
@@ -74,6 +77,7 @@ public final class DependencyGraphBuilder {
 
   /** Maven Repositories to use when resolving dependencies. */
   private final ImmutableList<RemoteRepository> repositories;
+  private Path localRepository;
 
   static {
     OsProperties.detectOsProperties().forEach(System::setProperty);
@@ -95,7 +99,14 @@ public final class DependencyGraphBuilder {
     }
     this.repositories = repositoryListBuilder.build();
   }
-
+  
+  /**
+   * Enable temporary repositories for tests.
+   */
+  void setLocalRepository(Path localRepository) {
+    this.localRepository = localRepository;
+  }
+  
   private DependencyNode resolveCompileTimeDependencies(
       List<DependencyNode> dependencyNodes, boolean fullDependencies)
       throws DependencyResolutionException {
@@ -113,10 +124,15 @@ public final class DependencyGraphBuilder {
     }
     ImmutableList<Dependency> dependencyList = dependenciesBuilder.build();
 
-    RepositorySystemSession session =
+    DefaultRepositorySystemSession session =
         fullDependencies
             ? RepositoryUtility.newSessionForFullDependency(system)
             : RepositoryUtility.newSession(system);
+            
+    if (localRepository != null) {
+      LocalRepository local = new LocalRepository(localRepository.toAbsolutePath().toString());
+      session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, local));
+    }
 
     CollectRequest collectRequest = new CollectRequest();
     if (dependencyList.size() == 1) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -156,6 +156,8 @@ public final class DependencyGraphBuilder {
   /**
    * Finds the full compile time, transitive dependency graph including duplicates, conflicting
    * versions, and dependencies with 'provided' scope.
+   * In the event of I/O errors, missing artifacts, and other problems, it can
+   * return an incomplete graph.
    *
    * @param artifacts Maven artifacts to retrieve their dependencies
    * @return dependency graph representing the tree of Maven artifacts
@@ -170,6 +172,9 @@ public final class DependencyGraphBuilder {
    * Builds the transitive dependency graph as seen by Maven. It does not include duplicates and
    * conflicting versions. That is, this resolves conflicting versions by picking the first version
    * seen. This is how Maven normally operates.
+   * 
+   * In the event of I/O errors, missing artifacts, and other problems, it can
+   * return an incomplete graph.
    */
   public DependencyGraphResult buildMavenDependencyGraph(Dependency dependency) {
     return buildDependencyGraph(

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -122,9 +122,8 @@ public final class RepositoryUtility {
    * customary ~/.m2 directory. If not found, it creates an initially empty repository in
    * a temporary location.
    */
-  public static RepositorySystemSession newSession(RepositorySystem system) {
+  public static DefaultRepositorySystemSession newSession(RepositorySystem system) {
     DefaultRepositorySystemSession session = createDefaultRepositorySystemSession(system);
-    session.setReadOnly();
     return session;
   }
 
@@ -133,7 +132,7 @@ public final class RepositoryUtility {
    *
    * @see {@link DependencyGraphBuilder}
    */
-  static RepositorySystemSession newSessionForFullDependency(RepositorySystem system) {
+  static DefaultRepositorySystemSession newSessionForFullDependency(RepositorySystem system) {
     DefaultRepositorySystemSession session = createDefaultRepositorySystemSession(system);
 
     // This combination of DependencySelector comes from the default specified in
@@ -160,21 +159,24 @@ public final class RepositoryUtility {
     // No dependency management in the full dependency graph
     session.setDependencyManager(null);
 
-    session.setReadOnly();
-
     return session;
   }
 
   private static File findLocalRepository() {
+    // TODO is there Maven code for this?
     Path home = Paths.get(System.getProperty("user.home"));
     Path localRepo = home.resolve(".m2").resolve("repository");
     if (Files.isDirectory(localRepo)) {
       return localRepo.toFile();
     } else {
-      File temporaryDirectory = com.google.common.io.Files.createTempDir();
-      temporaryDirectory.deleteOnExit();
-      return temporaryDirectory; 
+      return makeTemporaryLocalRepository(); 
    }
+  }
+
+  private static File makeTemporaryLocalRepository() {
+    File temporaryDirectory = com.google.common.io.Files.createTempDir();
+    temporaryDirectory.deleteOnExit();
+    return temporaryDirectory;
   }
 
   // TODO arguably this now belongs in the BOM class

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderIntegrationTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.dependencies;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Files;
+import com.google.common.truth.Correspondence;
+import com.google.common.truth.Truth;
+import java.io.File;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.Test;
+
+public class DependencyGraphBuilderIntegrationTest {
+
+  private Correspondence<UnresolvableArtifactProblem, String> problemOnArtifact =
+      Correspondence.transforming(
+          (UnresolvableArtifactProblem problem) -> Artifacts.toCoordinates(problem.getArtifact()),
+          "has artifact");
+
+  @Test
+  public void testConfigureAdditionalMavenRepositories_notToUseMavenCentral() {
+    DependencyGraphBuilder graphBuilder = 
+        new DependencyGraphBuilder(ImmutableList.of("https://dl.google.com/dl/android/maven2"));
+
+    File localRepository = Files.createTempDir();
+    localRepository.deleteOnExit();
+
+    graphBuilder.setLocalRepository(localRepository.toPath());
+    
+    // This artifact does not exist in Android's repository
+    Artifact artifact = new DefaultArtifact("com.google.guava:guava:15.0-rc1");
+
+    DependencyGraphResult result =
+        graphBuilder.buildFullDependencyGraph(ImmutableList.of(artifact));
+    Truth.assertThat(result.getArtifactProblems())
+        .comparingElementsUsing(problemOnArtifact)
+        .contains("com.google.guava:guava:15.0-rc1");
+  }
+
+}

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderIntegrationTest.java
@@ -17,10 +17,11 @@
 package com.google.cloud.tools.opensource.dependencies;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.Files;
 import com.google.common.truth.Correspondence;
 import com.google.common.truth.Truth;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Test;
@@ -33,11 +34,13 @@ public class DependencyGraphBuilderIntegrationTest {
           "has artifact");
 
   @Test
-  public void testConfigureAdditionalMavenRepositories_notToUseMavenCentral() {
+  public void testConfigureAdditionalMavenRepositories_notToUseMavenCentral()
+      throws IOException {
+
     DependencyGraphBuilder graphBuilder = 
         new DependencyGraphBuilder(ImmutableList.of("https://dl.google.com/dl/android/maven2"));
 
-    File localRepository = Files.createTempDir();
+    File localRepository = Files.createTempDirectory(".m2").toFile();
     localRepository.deleteOnExit();
 
     graphBuilder.setLocalRepository(localRepository.toPath());

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -210,21 +210,6 @@ public class DependencyGraphBuilderTest {
   }
 
   @Test
-  public void testConfigureAdditionalMavenRepositories_notToUseMavenCentral() {
-    DependencyGraphBuilder graphBuilder = 
-        new DependencyGraphBuilder(ImmutableList.of("https://dl.google.com/dl/android/maven2"));
-
-    // This artifact does not exist in Android's repository
-    Artifact artifact = new DefaultArtifact("com.google.guava:guava:15.0-rc1");
-
-    DependencyGraphResult result =
-        graphBuilder.buildFullDependencyGraph(ImmutableList.of(artifact));
-    Truth.assertThat(result.getArtifactProblems())
-        .comparingElementsUsing(problemOnArtifact)
-        .contains("com.google.guava:guava:15.0-rc1");
-  }
-
-  @Test
   public void testBuildLinkageCheckDependencyGraph_catchRootException() {
     // This should not throw exception
     DependencyGraphResult result =


### PR DESCRIPTION
fixes #1301

This injects a local repository into the graph builder from the test, so we avoid installing any artifacts into `~.m2`

Suggestions for making this less hacky appreciated. 