### PR TITLE
LinkageCheckerArguments.getArtifacts to return empty list if the argument is not specified

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerArguments.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerArguments.java
@@ -174,7 +174,10 @@ final class LinkageCheckerArguments {
     return options;
   }
 
-  /** Returns a list of artifacts specified in the option of BOM or coordinates list. */
+  /**
+   * Returns a list of artifacts specified in the option of BOM or coordinates list. If the argument
+   * is not specified, returns an empty list.
+   */
   ImmutableList<Artifact> getArtifacts() throws RepositoryException {
     if (cachedArtifacts != null) {
       return cachedArtifacts;
@@ -194,8 +197,7 @@ final class LinkageCheckerArguments {
               .map(DefaultArtifact::new)
               .collect(toImmutableList());
     } else {
-      throw new IllegalArgumentException(
-          "The arguments must have option 'a' or 'b' to list Maven artifacts");
+      return ImmutableList.of();
     }
   }
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
@@ -64,7 +64,6 @@ class LinkageCheckerMain {
         // classPathResult is kept null if JAR files are specified in the argument
         ClassPathResult classPathResult = null;
     
-        // FIXME the if here isn't reachable
         if (artifacts.isEmpty()) {
           // When JAR files are passed as arguments, classPathResult is null, because there is no need
           // to resolve Maven dependencies.

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -54,7 +54,7 @@ public class LinkageCheckerMainIntegrationTest {
 
     String jarArgument = googleCloudCore + "," + googleCloudFirestore + "," + guava;
 
-    // This should not raise IOException
+    // This should not raise Exception
     LinkageCheckerMain.main(new String[] {"-j", jarArgument});
 
     String output = new String(capturedOutputStream.toByteArray());
@@ -67,5 +67,28 @@ public class LinkageCheckerMainIntegrationTest {
                 + "    com.google.cloud.ExceptionHandler ("
                 + googleCloudCore
                 + ")");
+  }
+
+  @Test
+  public void testArtifacts() throws IOException, URISyntaxException, RepositoryException {
+    LinkageCheckerMain.main(
+        new String[] {"-a", "com.google.cloud:google-cloud-firestore:0.65.0-beta"});
+
+    String output = new String(capturedOutputStream.toByteArray());
+
+    Truth.assertThat(output)
+        .contains(
+            "Class com.jcraft.jzlib.JZlib is not found;\n"
+                + "  referenced by 4 class files\n"
+                + "    io.grpc.netty.shaded.io.netty.handler.codec.spdy.SpdyHeaderBlockJZlibEncoder"
+                + " (io.grpc:grpc-netty-shaded:1.13.1)");
+
+    // Show the dependency path to the problematic artifact
+    Truth.assertThat(output)
+        .contains(
+            "io.grpc:grpc-netty-shaded:1.13.1 is at:\n"
+                + "  com.google.cloud:google-cloud-firestore:0.65.0-beta (compile) /"
+                + " io.grpc:grpc-netty-shaded:1.13.1 (compile)\n"
+                + "  and 1 dependency path.");
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -64,7 +64,8 @@ public class LinkageCheckerMainIntegrationTest {
         .contains(
             "Class com.google.api.gax.retrying.ResultRetryAlgorithm is not found;\n"
                 + "  referenced by 1 class file\n"
-                + "    com.google.cloud.ExceptionHandler (/Users/suztomo/cloud-opensource-java"
-                + "/dependencies/target/test-classes/testdata/google-cloud-core-1.48.0.jar)");
+                + "    com.google.cloud.ExceptionHandler ("
+                + googleCloudCore
+                + ")");
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -16,52 +16,55 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-import static com.google.cloud.tools.opensource.classpath.TestHelper.COORDINATES;
 import static com.google.cloud.tools.opensource.classpath.TestHelper.absolutePathOfResource;
-import static com.google.cloud.tools.opensource.classpath.TestHelper.classPathEntryOfResource;
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 
-import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
-import com.google.cloud.tools.opensource.dependencies.DependencyGraphBuilder;
-import com.google.cloud.tools.opensource.dependencies.UnresolvableArtifactProblem;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.truth.Correspondence;
 import com.google.common.truth.Truth;
-import com.google.common.truth.Truth8;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import org.apache.commons.cli.ParseException;
 import org.eclipse.aether.RepositoryException;
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.graph.Dependency;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class LinkageCheckerMainIntegrationTest {
 
+  private final ByteArrayOutputStream capturedOutputStream = new ByteArrayOutputStream();
+  private final PrintStream originalStandardOut = System.out;
+
+  @Before
+  public void setup() {
+    System.setOut(new PrintStream(capturedOutputStream));
+  }
+
+  @After
+  public void restoreStreams() {
+    System.setOut(originalStandardOut);
+  }
+
   @Test
   public void testJarFiles() throws IOException, URISyntaxException, RepositoryException {
 
     Path googleCloudCore = absolutePathOfResource("testdata/google-cloud-core-1.48.0.jar");
-    Path googleCloudFirestore = absolutePathOfResource("testdata/google-cloud-firestore-0.65.0-beta.jar");
+    Path googleCloudFirestore =
+        absolutePathOfResource("testdata/google-cloud-firestore-0.65.0-beta.jar");
+    Path guava = absolutePathOfResource("testdata/guava-23.5-jre.jar");
 
-    String jarArgument = googleCloudCore + "," + googleCloudFirestore;
-    LinkageCheckerMain.main(new String[] {
-        "-j", jarArgument
-    });
+    String jarArgument = googleCloudCore + "," + googleCloudFirestore + "," + guava;
+
+    // This should not raise IOException
+    LinkageCheckerMain.main(new String[] {"-j", jarArgument});
+
+    String output = new String(capturedOutputStream.toByteArray());
+
+    // Gax is not in the JAR list
+    Truth.assertThat(output)
+        .contains(
+            "Class com.google.api.gax.retrying.ResultRetryAlgorithm is not found;\n"
+                + "  referenced by 1 class file\n"
+                + "    com.google.cloud.ExceptionHandler (/Users/suztomo/cloud-opensource-java"
+                + "/dependencies/target/test-classes/testdata/google-cloud-core-1.48.0.jar)");
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -31,11 +31,12 @@ import org.junit.Test;
 
 public class LinkageCheckerMainIntegrationTest {
 
-  private final ByteArrayOutputStream capturedOutputStream = new ByteArrayOutputStream();
-  private final PrintStream originalStandardOut = System.out;
+  private static final PrintStream originalStandardOut = System.out;
+  private ByteArrayOutputStream capturedOutputStream;
 
   @Before
   public void setup() {
+    capturedOutputStream = new ByteArrayOutputStream();
     System.setOut(new PrintStream(capturedOutputStream));
   }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.classpath;
+
+import static com.google.cloud.tools.opensource.classpath.TestHelper.COORDINATES;
+import static com.google.cloud.tools.opensource.classpath.TestHelper.absolutePathOfResource;
+import static com.google.cloud.tools.opensource.classpath.TestHelper.classPathEntryOfResource;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
+import com.google.cloud.tools.opensource.dependencies.DependencyGraphBuilder;
+import com.google.cloud.tools.opensource.dependencies.UnresolvableArtifactProblem;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.truth.Correspondence;
+import com.google.common.truth.Truth;
+import com.google.common.truth.Truth8;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.cli.ParseException;
+import org.eclipse.aether.RepositoryException;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LinkageCheckerMainIntegrationTest {
+
+  @Test
+  public void testJarFiles() throws IOException, URISyntaxException, RepositoryException {
+
+    Path googleCloudCore = absolutePathOfResource("testdata/google-cloud-core-1.48.0.jar");
+    Path googleCloudFirestore = absolutePathOfResource("testdata/google-cloud-firestore-0.65.0-beta.jar");
+
+    String jarArgument = googleCloudCore + "," + googleCloudFirestore;
+    LinkageCheckerMain.main(new String[] {
+        "-j", jarArgument
+    });
+  }
+}

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -95,4 +95,26 @@ public class LinkageCheckerMainIntegrationTest {
                 + " io.grpc:grpc-netty-shaded:1.13.1 (compile)\n"
                 + "  and 1 dependency path.");
   }
+
+  @Test
+  public void testBom() throws IOException, RepositoryException {
+    LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
+
+    String output = readCapturedStdout();
+
+    // Appengine-api-sdk is known to have invalid references
+    Truth.assertThat(output)
+        .contains(
+            "Class com.google.net.rpc3.client.RpcStubDescriptor is not found;\n"
+                + "  referenced by 21 class files\n"
+                + "    com.google.appengine.api.appidentity.AppIdentityServicePb"
+                + " (com.google.appengine:appengine-api-1.0-sdk:1.9.71)");
+
+    // Show the dependency path to the problematic artifact
+    Truth.assertThat(output)
+        .contains(
+            "com.google.appengine:appengine-api-1.0-sdk:1.9.71 is at:\n"
+                + "  com.google.http-client:google-http-client-appengine:1.29.1 (compile) "
+                + "/ com.google.appengine:appengine-api-1.0-sdk:1.9.71 (provided)");
+  }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -45,6 +45,12 @@ public class LinkageCheckerMainIntegrationTest {
     System.setOut(originalStandardOut);
   }
 
+  private String readCapturedStdout() {
+    System.out.flush();
+    String output = new String(capturedOutputStream.toByteArray());
+    return output;
+  }
+
   @Test
   public void testJarFiles() throws IOException, URISyntaxException, RepositoryException {
 
@@ -58,10 +64,9 @@ public class LinkageCheckerMainIntegrationTest {
     // This should not raise Exception
     LinkageCheckerMain.main(new String[] {"-j", jarArgument});
 
-    String output = new String(capturedOutputStream.toByteArray());
 
     // Gax is not in the JAR list
-    Truth.assertThat(output)
+    Truth.assertThat(readCapturedStdout())
         .contains(
             "Class com.google.api.gax.retrying.ResultRetryAlgorithm is not found;\n"
                 + "  referenced by 1 class file\n"
@@ -75,8 +80,7 @@ public class LinkageCheckerMainIntegrationTest {
     LinkageCheckerMain.main(
         new String[] {"-a", "com.google.cloud:google-cloud-firestore:0.65.0-beta"});
 
-    String output = new String(capturedOutputStream.toByteArray());
-
+    String output = readCapturedStdout();
     Truth.assertThat(output)
         .contains(
             "Class com.jcraft.jzlib.JZlib is not found;\n"

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC.
+ * Copyright 2020 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ public class LinkageCheckerMainIntegrationTest {
   }
 
   @After
-  public void restoreStreams() {
+  public void cleanup() {
     System.setOut(originalStandardOut);
   }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -64,7 +64,6 @@ public class LinkageCheckerMainIntegrationTest {
     // This should not raise Exception
     LinkageCheckerMain.main(new String[] {"-j", jarArgument});
 
-
     // Gax is not in the JAR list
     Truth.assertThat(readCapturedStdout())
         .contains(


### PR DESCRIPTION
Fixes #1340 