### PR TITLE
LinkageCheckerMain to throw LinkageCheckResultException when it finds error

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckResultException.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckResultException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.classpath;
+
+/**
+ * {@link LinkageCheckerMain} throws this exception when it finds linkage errors.
+ *
+ * <p>The caller of the tool can tell the existence of linkage errors by checking the exit status of
+ * the {@link LinkageCheckerMain}.
+ */
+final class LinkageCheckResultException extends Exception {
+  LinkageCheckResultException(int linkageErrorCount) {
+    super(
+        "Found "
+            + (linkageErrorCount == 1
+                ? "1 linkage error"
+                : (linkageErrorCount + " linkage errors")));
+  }
+  ;
+}

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckResultException.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckResultException.java
@@ -30,5 +30,4 @@ final class LinkageCheckResultException extends Exception {
                 ? "1 linkage error"
                 : (linkageErrorCount + " linkage errors")));
   }
-  ;
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
@@ -106,7 +106,9 @@ class LinkageCheckerMain {
           return;
         }
 
-        System.out.println(SymbolProblem.formatSymbolProblems(symbolProblems));
+        if (!symbolProblems.isEmpty()) {
+          System.out.println(SymbolProblem.formatSymbolProblems(symbolProblems));
+        }
 
         if (classPathResult != null && !symbolProblems.isEmpty()) {
           Builder<ClassPathEntry> problematicJars = ImmutableSet.builder();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
@@ -47,7 +47,8 @@ class LinkageCheckerMain {
    *     files
    */
   public static void main(String[] arguments)
-      throws IOException, RepositoryException, TransformerException, XMLStreamException {
+      throws IOException, RepositoryException, TransformerException, XMLStreamException,
+          LinkageCheckResultException {
 
     try {
       LinkageCheckerArguments linkageCheckerArguments =
@@ -98,13 +99,14 @@ class LinkageCheckerMain {
                       symbolProblems, classFile -> graph.isReachable(classFile.getBinaryName())));
         }
 
-        System.out.println(SymbolProblem.formatSymbolProblems(symbolProblems));
-
         Path writeAsExclusionFile = linkageCheckerArguments.getOutputExclusionFile();
         if (writeAsExclusionFile != null) {
           ExclusionFiles.write(writeAsExclusionFile, symbolProblems);
           System.out.println("Wrote the linkage errors as exclusion file: " + writeAsExclusionFile);
+          return;
         }
+
+        System.out.println(SymbolProblem.formatSymbolProblems(symbolProblems));
 
         if (classPathResult != null && !symbolProblems.isEmpty()) {
           Builder<ClassPathEntry> problematicJars = ImmutableSet.builder();
@@ -123,6 +125,12 @@ class LinkageCheckerMain {
         if (!artifactProblems.isEmpty()) {
           System.out.println("\n");
           System.out.println(ArtifactProblem.formatProblems(artifactProblems));
+        }
+
+        if (!symbolProblems.isEmpty()) {
+          // Throwing an exception is more test-friendly compared with System.exit(1). The latter
+          // abruptly stops test execution.
+          throw new LinkageCheckResultException(symbolProblems.size());
         }
       }
     } catch (ParseException ex) {

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ExclusionFilesIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ExclusionFilesIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
+
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSetMultimap;
@@ -43,7 +44,8 @@ public class ExclusionFilesIntegrationTest {
 
   @Test
   public void testExclusion()
-      throws IOException, RepositoryException, TransformerException, XMLStreamException {
+      throws IOException, RepositoryException, TransformerException, XMLStreamException,
+          LinkageCheckResultException {
 
     Artifact artifact =
         new DefaultArtifact("org.apache.beam:beam-runners-google-cloud-dataflow-java:2.19.0");

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ExclusionFilesIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ExclusionFilesIntegrationTest.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSetMultimap;

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckResultExceptionTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckResultExceptionTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.classpath;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class LinkageCheckResultExceptionTest {
+
+  @Test
+  public void testSingular() {
+    LinkageCheckResultException exception = new LinkageCheckResultException(1);
+    assertEquals("Found 1 linkage error", exception.getMessage());
+  }
+
+  @Test
+  public void testPlurla() {
+    LinkageCheckResultException exception = new LinkageCheckResultException(2);
+    assertEquals("Found 2 linkage errors", exception.getMessage());
+  }
+}

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -169,6 +169,8 @@ public class LinkageCheckerMainIntegrationTest {
         });
 
     String output = readCapturedStdout();
-    assertEquals("Wrote the linkage errors as exclusion file: " + exclusionFile + "\n", output);
+    assertEquals(
+        "Wrote the linkage errors as exclusion file: " + exclusionFile + System.lineSeparator(),
+        output);
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -17,6 +17,8 @@
 package com.google.cloud.tools.opensource.classpath;
 
 import static com.google.cloud.tools.opensource.classpath.TestHelper.absolutePathOfResource;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import com.google.common.truth.Truth;
 import java.io.ByteArrayOutputStream;
@@ -64,8 +66,13 @@ public class LinkageCheckerMainIntegrationTest {
 
     String jarArgument = googleCloudCore + "," + googleCloudFirestore + "," + guava;
 
-    // This should not raise Exception
-    LinkageCheckerMain.main(new String[] {"-j", jarArgument});
+    try {
+      LinkageCheckerMain.main(new String[] {"-j", jarArgument});
+      fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
+    } catch (LinkageCheckResultException expected) {
+      // pass
+      assertEquals("Found 369 linkage errors", expected.getMessage());
+    }
 
     // Gax is not in the JAR list
     Truth.assertThat(readCapturedStdout())
@@ -79,9 +86,15 @@ public class LinkageCheckerMainIntegrationTest {
 
   @Test
   public void testArtifacts()
-      throws IOException, URISyntaxException, RepositoryException, TransformerException, XMLStreamException {
-    LinkageCheckerMain.main(
-        new String[] {"-a", "com.google.cloud:google-cloud-firestore:0.65.0-beta"});
+      throws IOException, RepositoryException, TransformerException, XMLStreamException {
+    try {
+      LinkageCheckerMain.main(
+          new String[] {"-a", "com.google.cloud:google-cloud-firestore:0.65.0-beta"});
+      fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
+    } catch (LinkageCheckResultException expected) {
+      // pass
+      assertEquals("Found 69 linkage errors", expected.getMessage());
+    }
 
     String output = readCapturedStdout();
     Truth.assertThat(output)
@@ -103,7 +116,13 @@ public class LinkageCheckerMainIntegrationTest {
   @Test
   public void testBom()
       throws IOException, RepositoryException, TransformerException, XMLStreamException {
-    LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
+    try {
+      LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
+      fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
+    } catch (LinkageCheckResultException expected) {
+      // pass
+      assertEquals("Found 583 linkage errors", expected.getMessage());
+    }
 
     String output = readCapturedStdout();
 


### PR DESCRIPTION
Fixes #1348 

Status code (success/failure) logic:

```
if "--output-exclusion-file" is specified:
  writes linkage errors to file
  exits with success
else
  if linkage errors are found:
    print linkage error
    exits with failure
  else
    exits with success
```

I confirmed Gradle can detect non-zero exit code upon an exception: https://gist.github.com/suztomo/9ddfae0ec141042ca6ba9b0434b6de54