### PR TITLE
Linkage Checker 1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.3.0
 * LinkageCheckerMain has an option (`-o`) to output linkage errors into a file ([document](
   https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/LinkageCheckerMain#exclusion-files
-  )). This feature is currently alpha; we may change the behavior/format in later release.
+  )). This feature is currently alpha; we may change the behavior/format in later releases.
 * LinkageCheckerMain throws LinkageCheckResultException if it finds linkage errors.
 
 ## 1.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Linkage Checker Enforcer Rule Change Log
 
+## 1.3.0
+* LinkageCheckerMain has an option (`-o`) to output linkage errors into a file.
+* LinkageCheckerMain throws LinkageCheckResultException if it finds linkage errors.
+
 ## 1.2.1
 * Linkage Checker handles class files containing methods without a body.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Linkage Checker Enforcer Rule Change Log
 
 ## 1.3.0
-* LinkageCheckerMain has an option (`-o`) to output linkage errors into a file.
+* LinkageCheckerMain has an option (`-o`) to output linkage errors into a file ([document](
+  https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/LinkageCheckerMain#exclusion-files
+  )). This feature is currently alpha; we may change the behavior in later release.
 * LinkageCheckerMain throws LinkageCheckResultException if it finds linkage errors.
 
 ## 1.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.3.0
 * LinkageCheckerMain has an option (`-o`) to output linkage errors into a file ([document](
   https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/LinkageCheckerMain#exclusion-files
-  )). This feature is currently alpha; we may change the behavior in later release.
+  )). This feature is currently alpha; we may change the behavior/format in later release.
 * LinkageCheckerMain throws LinkageCheckResultException if it finds linkage errors.
 
 ## 1.2.1

--- a/boms/integration-tests/pom.xml
+++ b/boms/integration-tests/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>dependencies</artifactId>
-      <version>1.3.0</version>
+      <version>1.3.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/boms/integration-tests/pom.xml
+++ b/boms/integration-tests/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>dependencies</artifactId>
-      <version>1.2.2-SNAPSHOT</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
   <artifactId>dashboard</artifactId>
 

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
   <artifactId>dashboard</artifactId>
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>linkage-checker-enforcer-rules</artifactId>

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>linkage-checker-enforcer-rules</artifactId>

--- a/linkage-monitor/pom.xml
+++ b/linkage-monitor/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>linkage-monitor</artifactId>

--- a/linkage-monitor/pom.xml
+++ b/linkage-monitor/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>linkage-monitor</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>dependencies-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.2.2-SNAPSHOT</version>
+  <version>1.3.0</version>
 
   <name>Cloud Tools Open Source Code Hygiene Tooling</name>
   <url>https://github.com/GoogleCloudPlatform/cloud-opensource-java/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>dependencies-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.3.0</version>
+  <version>1.3.1-SNAPSHOT</version>
 
   <name>Cloud Tools Open Source Code Hygiene Tooling</name>
   <url>https://github.com/GoogleCloudPlatform/cloud-opensource-java/</url>


### PR DESCRIPTION
Minor version bump as It has a new functionality to output linkage errors as a file. 