### PR TITLE
Renovate bot to ignore enforcer rule's integration tests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   ],
   "ignorePaths": [
     "example-problems/**",
+    "enforcer-rules/src/it/**",
     "boms/**"
   ],
   "separateMajorMinor": false,


### PR DESCRIPTION
With this PR, Renovate bot will stop reading pom.xml in the enforcer rule integration tests. This change prevents unexpected PRs such as #1364 