### PR TITLE
Integration test upon unresolvable Maven artifacts in BOMs

### DIFF
--- a/enforcer-rules/src/it/bom-project-missing-artifact/invoker.properties
+++ b/enforcer-rules/src/it/bom-project-missing-artifact/invoker.properties
@@ -1,2 +1,2 @@
 invoker.goals=verify
-invoker.buildResult=success
+invoker.buildResult=failure

--- a/enforcer-rules/src/it/bom-project-missing-artifact/invoker.properties
+++ b/enforcer-rules/src/it/bom-project-missing-artifact/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=verify
+invoker.buildResult=success

--- a/enforcer-rules/src/it/bom-project-missing-artifact/pom.xml
+++ b/enforcer-rules/src/it/bom-project-missing-artifact/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2020 Google LLC.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.google.cloud.tools.opensource</groupId>
+  <artifactId>bom-project-missing-artifact</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>bom-project-no-error</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- ant:ant:1.6.2 has optional dependency to xerces:xerces-impl:2.6.2, which does not exist
+       in Maven Central -->
+      <dependency>
+        <groupId>ant</groupId>
+        <artifactId>ant</artifactId>
+        <version>1.6.2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M3</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.google.cloud.tools</groupId>
+            <artifactId>linkage-checker-enforcer-rules</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>enforce-linkage-checker</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <LinkageCheckerRule
+                  implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
+                  <dependencySection>DEPENDENCY_MANAGEMENT</dependencySection>
+                  <reportOnlyReachable>true</reportOnlyReachable>
+                </LinkageCheckerRule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/enforcer-rules/src/it/bom-project-missing-artifact/verify.groovy
+++ b/enforcer-rules/src/it/bom-project-missing-artifact/verify.groovy
@@ -1,4 +1,5 @@
 def buildLog = new File(basedir, "build.log").text
 
-assert buildLog.contains("No reachable error found")
-assert buildLog.contains("xerces:xerces-impl:2.6.2")
+assert buildLog.contains("Failed to collect dependency: "
+        +"[xerces:xerces-impl:jar:2.6.2 was not resolved. "
+        +"Dependency path: ant:ant:jar:1.6.2 (compile) > xerces:xerces-impl:jar:2.6.2 (compile?)")

--- a/enforcer-rules/src/it/bom-project-missing-artifact/verify.groovy
+++ b/enforcer-rules/src/it/bom-project-missing-artifact/verify.groovy
@@ -1,0 +1,4 @@
+def buildLog = new File(basedir, "build.log").text
+
+assert buildLog.contains("No reachable error found")
+assert buildLog.contains("xerces:xerces-impl:2.6.2")


### PR DESCRIPTION
Closes #1392 , in which I raised question on logging artifact problems. Because the enforcer rule fails upon unresolvable artifacts, there's no need to log artifact problems.