### PR TITLE
abstract equals and hashCode

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassSymbol.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
+import java.util.Objects;
+
 /** Symbol for a class. */
 public class ClassSymbol extends Symbol {
   public ClassSymbol(String className) {
@@ -25,5 +27,22 @@ public class ClassSymbol extends Symbol {
   @Override
   public String toString() {
     return "Class " + getClassBinaryName();
+  }
+  
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.getClassBinaryName());
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    Symbol symbol = (Symbol) other;
+    return this.getClassBinaryName().equals(symbol.getClassBinaryName());
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/FieldSymbol.java
@@ -53,16 +53,14 @@ final class FieldSymbol extends Symbol {
     if (other == null || getClass() != other.getClass()) {
       return false;
     }
-    if (!super.equals(other)) {
-      return false;
-    }
     FieldSymbol that = (FieldSymbol) other;
-    return name.equals(that.name) && descriptor.equals(that.descriptor);
+    return name.equals(that.name) && descriptor.equals(that.descriptor)
+        && this.getClassBinaryName().equals(that.getClassBinaryName());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), name, descriptor);
+    return Objects.hash(this.getClassBinaryName(), name, descriptor);
   }
 
   @Override

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MethodSymbol.java
@@ -65,18 +65,16 @@ public final class MethodSymbol extends Symbol {
     if (other == null || getClass() != other.getClass()) {
       return false;
     }
-    if (!super.equals(other)) {
-      return false;
-    }
     MethodSymbol that = (MethodSymbol) other;
     return isInterfaceMethod == that.isInterfaceMethod
         && name.equals(that.name)
-        && descriptor.equals(that.descriptor);
+        && descriptor.equals(that.descriptor)
+        && this.getClassBinaryName().equals(that.getClassBinaryName());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), name, descriptor, isInterfaceMethod);
+    return Objects.hash(this.getClassBinaryName(), name, descriptor, isInterfaceMethod);
   }
 
   @Override

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/Symbol.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/Symbol.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.opensource.classpath;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
-import java.util.Objects;
 
 /**
  * The referent of symbolic references (class, method, or field references) in the run-time constant
@@ -47,21 +46,10 @@ abstract class Symbol {
   }
 
   @Override
-  public boolean equals(Object other) {
-    if (this == other) {
-      return true;
-    }
-    if (other == null || getClass() != other.getClass()) {
-      return false;
-    }
-    Symbol symbol = (Symbol) other;
-    return classBinaryName.equals(symbol.classBinaryName);
-  }
+  public abstract boolean equals(Object other);
 
   @Override
-  public int hashCode() {
-    return Objects.hash(classBinaryName);
-  }
+  public abstract int hashCode();
 
   @Override
   public String toString() {


### PR DESCRIPTION
@suztomo I noticed a subtle issue here where two instances of different subclasses could theoretically compare equal. This prevents that by making equals and hashCode abstract in the superclass. 