### PR TITLE
TODOs for discussion

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathResult.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathResult.java
@@ -34,7 +34,7 @@ public final class ClassPathResult {
   private final ImmutableList<ClassPathEntry> classPath;
 
   /**
-   * An ordered map from class path elements to one or more Maven dependency paths.
+   * An ordered map from class path entries to one or more Maven dependency paths.
    *
    * <p>The keys of the returned map represent Maven artifacts in the resolved class path,
    * including transitive dependencies. The return value of {@link LinkedListMultimap#keySet()}
@@ -43,10 +43,13 @@ public final class ClassPathResult {
    * <p>The values of the returned map for a key (class path entry) represent the different Maven
    * dependency paths from {@code artifacts} to the Maven artifact.
    */
+  // TODO rather than a multimap this should be a DependencyGraph or a DependencyGraphResult to
+  // support alternate representations
   private final ImmutableListMultimap<ClassPathEntry, DependencyPath> dependencyPaths;
 
   private final ImmutableList<UnresolvableArtifactProblem> artifactProblems;
 
+  
   public ClassPathResult(
       ListMultimap<ClassPathEntry, DependencyPath> dependencyPaths,
       Iterable<UnresolvableArtifactProblem> artifactProblems) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
@@ -25,7 +25,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
+import java.util.stream.Collectors;
 import org.eclipse.aether.artifact.Artifact;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -98,6 +98,13 @@ public class DependencyGraph {
    */
   public List<DependencyPath> list() {
     return new ArrayList<>(graph);
+  }
+  
+  /**
+   * @return a mutable copy of the artifacts in this graph in breadth first order
+   */
+  public List<Artifact> getArtifacts() {
+    return graph.stream().map(dependency -> dependency.getLeaf()).collect(Collectors.toList());
   }
 
   /**

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -336,8 +336,9 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
         ImmutableListMultimap.builder();
     ImmutableList.Builder<UnresolvableArtifactProblem> problems = ImmutableList.builder();
     for (DependencyPath path : dependencyGraph.list()) {
+      // TODO unresolved artifacts should be stored as part of the 
+      // DependencyGraph or DependencyGraphResult
       Artifact artifact = path.getLeaf();
-
       if (unresolvedArtifacts.contains(artifact)) {
         problems.add(new UnresolvableArtifactProblem(artifact));
       } else {


### PR DESCRIPTION
@suztomo @netdpb 

To consider and possibly migrate to an alternate graph representation, it could be useful to have a higher layer of abstraction that doesn't expose the implementation as lists of dependency paths and multimaps.