### PR TITLE
CycleBreakerGraphTransformer to avoid checking children of a node twice

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/CycleBreakerGraphTransformer.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/CycleBreakerGraphTransformer.java
@@ -55,7 +55,7 @@ final class CycleBreakerGraphTransformer implements DependencyGraphTransformer {
       return;
     }
 
-    if (shouldCheckChildren(node)) {
+    if (shouldVisitChildren(node)) {
       ancestors.add(artifact);
       for (DependencyNode child : node.getChildren()) {
         removeCycle(node, child, ancestors);
@@ -66,7 +66,7 @@ final class CycleBreakerGraphTransformer implements DependencyGraphTransformer {
 
   /** Returns true if {@code node} is not visited yet and marks the node as visited. */
   @VisibleForTesting
-  boolean shouldCheckChildren(DependencyNode node) {
+  boolean shouldVisitChildren(DependencyNode node) {
     return visitedNodes.add(node);
   }
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/CycleBreakerGraphTransformer.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/CycleBreakerGraphTransformer.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.opensource.dependencies;
 
 import com.google.common.collect.ImmutableList;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Set;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
@@ -33,6 +34,8 @@ import org.eclipse.aether.graph.DependencyNode;
  */
 final class CycleBreakerGraphTransformer implements DependencyGraphTransformer {
 
+  private IdentityHashMap<DependencyNode, Boolean> visited = new IdentityHashMap<>();
+
   @Override
   public DependencyNode transformGraph(
       DependencyNode dependencyNode, DependencyGraphTransformationContext context)
@@ -42,13 +45,18 @@ final class CycleBreakerGraphTransformer implements DependencyGraphTransformer {
     return dependencyNode;
   }
 
-  private static void removeCycle(
+  private void removeCycle(
       DependencyNode parent, DependencyNode node, Set<Artifact> ancestors) {
     Artifact artifact = node.getArtifact();
 
     if (ancestors.contains(artifact)) { // Set (rather than List) gives O(1) lookup here
       // parent is not null when ancestors is not empty
       removeChildFromParent(node, parent);
+      return;
+    }
+
+    if (visited.put(node, true) != null) {
+      // No need to check the children of this node because we visited this node already
       return;
     }
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/CycleBreakerGraphTransformer.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/CycleBreakerGraphTransformer.java
@@ -18,7 +18,9 @@ package com.google.cloud.tools.opensource.dependencies;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Set;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
@@ -34,8 +36,8 @@ import org.eclipse.aether.graph.DependencyNode;
  */
 final class CycleBreakerGraphTransformer implements DependencyGraphTransformer {
 
-  // DependencyNode inherits Object's equality. No two instances are equal to each other.
-  private Set<DependencyNode> visitedNodes = new HashSet<>();
+  private final Set<DependencyNode> visitedNodes =
+      Collections.newSetFromMap(new IdentityHashMap<>());
 
   @Override
   public DependencyNode transformGraph(

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -25,8 +25,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
+import java.util.Set;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.artifact.Artifact;
@@ -192,11 +194,16 @@ public final class DependencyGraphBuilder {
     } catch (DependencyResolutionException ex) {
       DependencyResult result = ex.getResult();
       node = result.getRoot();
+
+      Set<Artifact> checkedArtifacts = new HashSet<>();
       for (ArtifactResult artifactResult : result.getArtifactResults()) {
         Artifact resolvedArtifact = artifactResult.getArtifact();
+
         if (resolvedArtifact == null) {
           Artifact requestedArtifact = artifactResult.getRequest().getArtifact();
-          artifactProblems.add(createUnresolvableArtifactProblem(node, requestedArtifact));
+          if (checkedArtifacts.add(requestedArtifact)) {
+            artifactProblems.add(createUnresolvableArtifactProblem(node, requestedArtifact));
+          }
         }
       }
     }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/CycleBreakerGraphTransformerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/CycleBreakerGraphTransformerTest.java
@@ -16,12 +16,18 @@
 
 package com.google.cloud.tools.opensource.dependencies;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import com.google.common.collect.ImmutableList;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.graph.DefaultDependencyNode;
 import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.aether.util.graph.selector.ScopeDependencySelector;
@@ -54,5 +60,17 @@ public class CycleBreakerGraphTransformerTest {
 
     // This should not raise StackOverflowError
     system.resolveDependencies(session, request);
+  }
+
+  @Test
+  public void testShouldVisitChildren() {
+    CycleBreakerGraphTransformer transformer = new CycleBreakerGraphTransformer();
+    Artifact artifact = new DefaultArtifact("g:a:1");
+    DependencyNode node1 = new DefaultDependencyNode(artifact);
+    DependencyNode node2 = new DefaultDependencyNode(artifact);
+
+    assertTrue(transformer.shouldCheckChildren(node1));
+    assertFalse(transformer.shouldCheckChildren(node1));
+    assertTrue(transformer.shouldCheckChildren(node2));
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/CycleBreakerGraphTransformerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/CycleBreakerGraphTransformerTest.java
@@ -69,8 +69,8 @@ public class CycleBreakerGraphTransformerTest {
     DependencyNode node1 = new DefaultDependencyNode(artifact);
     DependencyNode node2 = new DefaultDependencyNode(artifact);
 
-    assertTrue(transformer.shouldCheckChildren(node1));
-    assertFalse(transformer.shouldCheckChildren(node1));
-    assertTrue(transformer.shouldCheckChildren(node2));
+    assertTrue(transformer.shouldVisitChildren(node1));
+    assertFalse(transformer.shouldVisitChildren(node1));
+    assertTrue(transformer.shouldVisitChildren(node2));
   }
 }


### PR DESCRIPTION
Towards https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1418#issuecomment-634749982 . Before this PR, CycleBreakerGraphTransformer visits the children of a node multiple times if there are multiple path to the node.

I've added a package-private method to confirm the behavior. This makes the test clear. From caller's perspective, CycleBreakerGraphTransformer's behavior does not change. It just became faster when dealing with non-tree graph. Such as spring-cloud-gcp-dependencies's graph with 645,977 unique nodes.