### PR TITLE
Linkage Checker to distinguish missing-class and missing-method errors for try-catch

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -294,7 +294,7 @@ public class LinkageChecker {
       }
 
       // Slf4J catches LinkageError to check the existence of other classes
-      if (classDumper.catchesLinkageError(sourceClassName)) {
+      if (classDumper.catchesLinkageErrorOnMethod(sourceClassName)) {
         return Optional.empty();
       }
 
@@ -302,7 +302,7 @@ public class LinkageChecker {
       return Optional.of(
           new SymbolProblem(symbol, ErrorType.SYMBOL_NOT_FOUND, containingClassFile));
     } catch (ClassNotFoundException ex) {
-      if (classDumper.catchesLinkageError(sourceClassName)) {
+      if (classDumper.catchesLinkageErrorOnClass(sourceClassName)) {
         return Optional.empty();
       }
       ClassSymbol classSymbol = new ClassSymbol(symbol.getClassBinaryName());
@@ -401,7 +401,7 @@ public class LinkageChecker {
       return Optional.of(
           new SymbolProblem(symbol, ErrorType.SYMBOL_NOT_FOUND, containingClassFile));
     } catch (ClassNotFoundException ex) {
-      if (classDumper.catchesLinkageError(sourceClassName)) {
+      if (classDumper.catchesLinkageErrorOnClass(sourceClassName)) {
         return Optional.empty();
       }
       ClassSymbol classSymbol = new ClassSymbol(symbol.getClassBinaryName());
@@ -483,7 +483,7 @@ public class LinkageChecker {
       return Optional.empty();
     } catch (ClassNotFoundException ex) {
       if (classDumper.isUnusedClassSymbolReference(sourceClassName, symbol)
-          || classDumper.catchesLinkageError(sourceClassName)) {
+          || classDumper.catchesLinkageErrorOnClass(sourceClassName)) {
         // The class reference is unused in the source
         return Optional.empty();
       }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassDumperTest.java
@@ -384,7 +384,7 @@ public class ClassDumperTest {
     String innerClass = "org.apache.curator.shaded.com.google.common.reflect.TypeToken$Bounds";
 
     // This should not raise an exception
-    assertFalse(classDumper.catchesLinkageError(innerClass));
+    assertFalse(classDumper.catchesLinkageErrorOnClass(innerClass));
   }
 
   @Test
@@ -410,7 +410,7 @@ public class ClassDumperTest {
     ClassDumper classDumper = ClassDumper.create(classPath);
 
     // This should not raise NullPointerException
-    boolean result = classDumper.catchesLinkageError("javax.mail.internet.MailDateFormat");
+    boolean result = classDumper.catchesLinkageErrorOnClass("javax.mail.internet.MailDateFormat");
     assertFalse(result);
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -1100,4 +1100,20 @@ public class LinkageCheckerTest {
           }
         });
   }
+
+  @Test
+  public void testFindSymbolProblems_grpcAndGuava() throws IOException {
+    // This pair of the library generates NoSuchMethodError at runtime.
+    // https://github.com/GoogleCloudPlatform/cloud-opensource-java/tree/master/example-problems/no-such-method-error-signature-mismatch
+    ImmutableList<ClassPathEntry> jars =
+        resolvePaths("io.grpc:grpc-core:1.17.0", "com.google.guava:guava:20.0");
+
+    LinkageChecker linkageChecker = LinkageChecker.create(jars);
+    ImmutableSetMultimap<SymbolProblem, ClassFile> problems = linkageChecker.findSymbolProblems();
+
+    Truth.assertThat(problems.values())
+        .comparingElementsUsing(
+            Correspondence.transforming(ClassFile::getBinaryName, "has class binary name"))
+        .contains("io.grpc.internal.DnsNameResolver");
+  }
 }

--- a/enforcer-rules/src/it/bom-project-error/verify.groovy
+++ b/enforcer-rules/src/it/bom-project-error/verify.groovy
@@ -3,8 +3,10 @@ def buildLog = new File(basedir, "build.log").text.replaceAll("\\r\\n", "\n")
 assert buildLog.contains('''\
 [ERROR] Linkage Checker rule found 1 error. Linkage error report:
 (com.google.guava:guava:20.0) com.google.common.base.Verify's method verify(boolean arg1, String arg2, Object arg3) is not found;
-  referenced by 1 class file
+  referenced by 3 class files
     io.grpc.internal.ServiceConfigInterceptor (io.grpc:grpc-core:1.17.1)
+    io.grpc.internal.JndiResourceResolverFactory (io.grpc:grpc-core:1.17.1)
+    io.grpc.internal.DnsNameResolver (io.grpc:grpc-core:1.17.1)
 ''')
 
 assert buildLog.contains('''[ERROR] Problematic artifacts in the dependency tree:

--- a/enforcer-rules/src/it/report-only-reachable/verify.groovy
+++ b/enforcer-rules/src/it/report-only-reachable/verify.groovy
@@ -1,9 +1,10 @@
 def buildLog = new File(basedir, "build.log").text.replaceAll("\\r\\n", "\n")
 
 assert buildLog.contains('''\
-[ERROR] Linkage Checker rule found 1 reachable error. Linkage error report:
 (com.google.guava:guava:20.0) com.google.common.base.Verify's method verify(boolean arg1, String arg2, Object arg3) is not found;
-  referenced by 1 class file
+  referenced by 3 class files
     io.grpc.internal.ServiceConfigInterceptor (io.grpc:grpc-core:1.17.1)
+    io.grpc.internal.JndiResourceResolverFactory (io.grpc:grpc-core:1.17.1)
+    io.grpc.internal.DnsNameResolver (io.grpc:grpc-core:1.17.1)
 
 ''')


### PR DESCRIPTION
Fixes #1379 

The problem is false negative where method-missing linkage error was suppressed because the source class has try-catch clause for ClassNotFoundException. This is false negative because the combination ("io.grpc:grpc-core:1.17.0", "com.google.guava:guava:20.0") does generate NoSuchMethodError in https://github.com/GoogleCloudPlatform/cloud-opensource-java/tree/master/example-problems/no-such-method-error-signature-mismatch.