### PR TITLE
PathRecordingDependencyVisitor that does not visit the same node multiple times

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilder.java
@@ -43,7 +43,6 @@ import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.aether.resolution.DependencyResult;
-import org.eclipse.aether.util.graph.visitor.PathRecordingDependencyVisitor;
 
 /**
  * This class builds dependency graphs for Maven artifacts.
@@ -237,7 +236,7 @@ public final class DependencyGraphBuilder {
         (node, parents) ->
             node.getArtifact() != null // artifact is null at a root dummy node.
                 && Artifacts.toCoordinates(node.getArtifact()).equals(coordinates);
-    PathRecordingDependencyVisitor visitor = new PathRecordingDependencyVisitor(filter);
+    UniquePathRecordingDependencyVisitor visitor = new UniquePathRecordingDependencyVisitor(filter);
     root.accept(visitor);
     return ImmutableList.copyOf(visitor.getPaths());
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/UniquePathRecordingDependencyVisitor.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/UniquePathRecordingDependencyVisitor.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.dependencies;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.graph.DependencyVisitor;
+
+/**
+ * A dependency visitor that records all paths leading to nodes matching a certain filter criteria.
+ * Compared to aether's {@link org.eclipse.aether.util.graph.visitor.PathRecordingDependencyVisitor}
+ * , this visits only unique nodes.
+ */
+final class UniquePathRecordingDependencyVisitor implements DependencyVisitor {
+
+  private final DependencyFilter filter;
+
+  private final List<List<DependencyNode>> paths;
+
+  private final List<DependencyNode> parents;
+
+  private final Set<DependencyNode> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+
+  /**
+   * Creates a new visitor that uses the specified filter to identify terminal nodes of interesting
+   * paths.
+   *
+   * @param filter The filter used to select terminal nodes of paths to record, may be {@code null}
+   *     to match any node.
+   */
+  public UniquePathRecordingDependencyVisitor(DependencyFilter filter) {
+    this.filter = filter;
+    paths = new ArrayList<>();
+    parents = new ArrayList<>();
+  }
+
+  /** Returns the recorded paths, never {@code null}. */
+  public ImmutableList<List<DependencyNode>> getPaths() {
+    return ImmutableList.copyOf(paths);
+  }
+
+  public boolean visitEnter(DependencyNode node) {
+    parents.add(node);
+
+    if (filter.accept(node, parents)) {
+      paths.add(new ArrayList<>(parents));
+
+      visited.add(node);
+      return false;
+    }
+
+    // Returning true if this node has not been visited
+    return visited.add(node);
+  }
+
+  public boolean visitLeave(DependencyNode node) {
+    parents.remove(parents.size() - 1);
+    return true;
+  }
+}

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/UniquePathRecordingDependencyVisitorTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/UniquePathRecordingDependencyVisitorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.dependencies;
+
+import static org.junit.Assert.assertSame;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.truth.Truth;
+import java.util.List;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.DependencyNode;
+import org.junit.Test;
+
+public class UniquePathRecordingDependencyVisitorTest {
+
+  @Test
+  public void testVisitingUniqueNodes() {
+    // This setup creates a dependency graph like below. There are two paths from the root to node
+    // 'y'. UniquePathRecordingDependencyVisitor avoids reporting both paths.
+    //
+    //    root
+    //   /   \
+    //  a     b
+    //   \   /
+    //     x
+    //     |
+    //     y
+
+    DefaultDependencyNode root = new DefaultDependencyNode(new DefaultArtifact("g:r:1"));
+    DefaultDependencyNode a = new DefaultDependencyNode(new DefaultArtifact("g:a:1"));
+    DefaultDependencyNode b = new DefaultDependencyNode(new DefaultArtifact("g:b:1"));
+    DefaultDependencyNode x = new DefaultDependencyNode(new DefaultArtifact("g:x:1"));
+    DefaultDependencyNode y = new DefaultDependencyNode(new DefaultArtifact("g:y:1"));
+
+    root.setChildren(ImmutableList.of(a, b));
+    a.setChildren(ImmutableList.of(x));
+    b.setChildren(ImmutableList.of(x));
+    x.setChildren(ImmutableList.of(y));
+
+    UniquePathRecordingDependencyVisitor visitor =
+        new UniquePathRecordingDependencyVisitor(
+            (DependencyNode node, List<DependencyNode> parents) ->
+                node.getArtifact().getArtifactId().equals("y"));
+
+    root.accept(visitor);
+
+    ImmutableList<List<DependencyNode>> paths = visitor.getPaths();
+    Truth.assertThat(paths).hasSize(1);
+    assertSame(root, paths.get(0).get(0));
+    assertSame(a, paths.get(0).get(1));
+    assertSame(x, paths.get(0).get(2));
+    assertSame(y, paths.get(0).get(3));
+  }
+}


### PR DESCRIPTION
Towards #1418 

Before this PR, running linkage checker for spring-cloud-gcp-dependencies got stuck at PathRecordingDependencyVisitor. After this PR, it does not stuck there. (Instead it throws [OOME](https://gist.github.com/suztomo/374e05e606eb5bade4c439f937cceead) in the same manner as #1256 )

