### PR TITLE
RenovateBot master issue

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "ignorePaths": [
     "example-problems/**",
     "enforcer-rules/src/it/**",
-    "boms/**"
+    "boms/convergence-check"
   ],
   "separateMajorMinor": false,
   "semanticCommits": true,
@@ -31,5 +31,7 @@
       ],
       "enabled": false
     }
-  ]
+  ],
+  "masterIssue": true,
+  "masterIssueApproval": true
 }


### PR DESCRIPTION
Fixes #1475

[INTRODUCING RENOVATE’S “MASTER ISSUE”](https://renovate.whitesourcesoftware.com/blog/introducing-renovates-master-issue/) says

> To enable Master Issue Approval for all PRs in a repository, add "masterIssueApproval": true to your Renovate config. PRs will no longer be automatically created, but the Master Issue will always contain an up-to-date list.

We should be get notified on the master issue whenever a new library is released.
