### PR TITLE
google.cloud.java.version 0.129.0

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -45,7 +45,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>29.0-android</guava.version>
-    <google.cloud.java.version>0.128.0</google.cloud.java.version>
+    <google.cloud.java.version>0.129.0</google.cloud.java.version>
     <io.grpc.version>1.30.0</io.grpc.version>
     <protobuf.version>3.12.2</protobuf.version>
     <http.version>1.35.0</http.version>


### PR DESCRIPTION
@elharo There was a mistake in 6.0.0 (which I already published to maven central); I forgot to update google-cloud-bom version before releasing. I'll make 6.0.1 release once this is merged.
