### PR TITLE
Gradle Plugin to show Dependency Paths for Conflicting Artifacts

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathEntry.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassPathEntry.java
@@ -56,10 +56,10 @@ public final class ClassPathEntry {
   }
 
   /**
-   * Returns the Maven artifact associated with the JAR file, or null 
-   * if the JAR file does not have Maven coordinates.
+   * Returns the Maven artifact associated with the JAR file, or null if the JAR file does not have
+   * Maven coordinates.
    */
-  Artifact getArtifact() {
+  public Artifact getArtifact() {
     return artifact;
   }
 

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -22,3 +22,9 @@ linkage-checker-gradle-plugin-0.1.0-SNAPSHOT.pom
 ```
 ./gradlew check --stacktrace  -Dorg.gradle.debug=true --no-daemon
 ```
+
+## Debugging Tests
+For IntelliJ, install Spock Framework Enhancement to add breakpoints in the Groovy scripts.
+
+To enable break points in Java code during the functional tests, add
+`-Dorg.gradle.testkit.debug=true` to the VM argument.

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -28,7 +28,8 @@ version = '0.1.0-SNAPSHOT'
 sourceCompatibility = 1.8
 
 dependencies {
-  implementation 'com.google.cloud.tools:dependencies:1.4.2'
+  // TODO(suztomo): Place a concrete version once ClassPathEntry.getArtifact becomes public.
+  implementation 'com.google.cloud.tools:dependencies:latest.integration'
 
   testImplementation 'junit:junit:4.13'
   testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -29,7 +29,10 @@ sourceCompatibility = 1.8
 
 dependencies {
   // TODO(suztomo): Place a concrete version once ClassPathEntry.getArtifact becomes public.
+  implementation platform('com.google.cloud.tools:dependencies-parent:latest.integration')
   implementation 'com.google.cloud.tools:dependencies:latest.integration'
+  implementation 'com.google.guava:guava'
+  implementation 'org.apache.maven.resolver:maven-resolver-api'
 
   testImplementation 'junit:junit:4.13'
   testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'

--- a/gradle-plugin/gradle/functional-test.gradle
+++ b/gradle-plugin/gradle/functional-test.gradle
@@ -18,7 +18,6 @@ task functionalTest(type: Test) {
     testClassesDirs = sourceSets.functionalTest.output.classesDirs
     classpath = sourceSets.functionalTest.runtimeClasspath
     mustRunAfter test
-    debug true
 }
 
 check.dependsOn functionalTest

--- a/gradle-plugin/gradle/functional-test.gradle
+++ b/gradle-plugin/gradle/functional-test.gradle
@@ -18,6 +18,7 @@ task functionalTest(type: Test) {
     testClassesDirs = sourceSets.functionalTest.output.classesDirs
     classpath = sourceSets.functionalTest.runtimeClasspath
     mustRunAfter test
+    debug true
 }
 
 check.dependsOn functionalTest

--- a/gradle-plugin/src/functionalTest/groovy/com/google/cloud/tools/dependencies/gradle/BuildStatusFunctionalTest.groovy
+++ b/gradle-plugin/src/functionalTest/groovy/com/google/cloud/tools/dependencies/gradle/BuildStatusFunctionalTest.groovy
@@ -27,6 +27,8 @@ class BuildStatusFunctionalTest extends Specification {
   @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
   File buildFile
 
+  File settingsFile;
+
   def setup() {
     buildFile = testProjectDir.newFile('build.gradle')
     buildFile << """
@@ -35,6 +37,10 @@ class BuildStatusFunctionalTest extends Specification {
             id 'com.google.cloud.tools.linkagechecker'
         }
         """
+    settingsFile = testProjectDir.newFile("settings.gradle")
+    settingsFile << """
+        rootProject.name = 'test-123'
+    """
   }
 
   def "can validate a project with no dependency conflicts"() {
@@ -71,7 +77,9 @@ class BuildStatusFunctionalTest extends Specification {
         repositories {
           mavenCentral()
         }
-        
+        group = 'g'
+        version = '0.1.0-SNAPSHOT'
+
         // These two have incompatible dependencies
         // https://github.com/grpc/grpc-java/issues/7002
         dependencies {
@@ -93,6 +101,12 @@ class BuildStatusFunctionalTest extends Specification {
 
     then:
     result.output.contains("Class io.grpc.internal.BaseDnsNameResolverProvider is not found")
+
+    result.output.contains("Problematic artifacts in the dependency tree:")
+    result.output.contains("""
+        |io.grpc:grpc-grpclb:1.28.1 is at:
+        |  g:test-123:0.1.0-SNAPSHOT / com.google.cloud:google-cloud-logging:1.101.1 / com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-alts:1.28.1 / io.grpc:grpc-grpclb:1.28.1
+        |""".stripMargin())
     result.task(":linkageCheck").outcome == TaskOutcome.FAILED
   }
 }

--- a/gradle-plugin/src/functionalTest/groovy/com/google/cloud/tools/dependencies/gradle/BuildStatusFunctionalTest.groovy
+++ b/gradle-plugin/src/functionalTest/groovy/com/google/cloud/tools/dependencies/gradle/BuildStatusFunctionalTest.groovy
@@ -27,8 +27,6 @@ class BuildStatusFunctionalTest extends Specification {
   @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
   File buildFile
 
-  File settingsFile;
-
   def setup() {
     buildFile = testProjectDir.newFile('build.gradle')
     buildFile << """
@@ -37,7 +35,7 @@ class BuildStatusFunctionalTest extends Specification {
             id 'com.google.cloud.tools.linkagechecker'
         }
         """
-    settingsFile = testProjectDir.newFile("settings.gradle")
+    File settingsFile = testProjectDir.newFile("settings.gradle")
     settingsFile << """
         rootProject.name = 'test-123'
     """

--- a/gradle-plugin/src/functionalTest/groovy/com/google/cloud/tools/dependencies/gradle/ExclusionFileFunctionalTest.groovy
+++ b/gradle-plugin/src/functionalTest/groovy/com/google/cloud/tools/dependencies/gradle/ExclusionFileFunctionalTest.groovy
@@ -94,7 +94,8 @@ class ExclusionFileFunctionalTest extends Specification {
   }
 
   def "can suppress linkage errors listed in exclusion files (absolute path)"() {
-    Path exclusionFileNameAbsolutePath = Paths.get(exclusionFileName).toAbsolutePath()
+    File exclusionFile = testProjectDir.newFile(exclusionFileName)
+    Path exclusionFileNameAbsolutePath = exclusionFile.toPath().toAbsolutePath()
 
     buildFile << """
         repositories {
@@ -114,7 +115,6 @@ class ExclusionFileFunctionalTest extends Specification {
         }
         """
 
-    File exclusionFile = exclusionFileNameAbsolutePath.toFile()
     exclusionFile << """
         <LinkageCheckerFilter>
           <LinkageError>

--- a/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/LinkageCheckTask.java
+++ b/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/LinkageCheckTask.java
@@ -34,7 +34,6 @@ import java.nio.file.Paths;
 import java.util.ArrayDeque;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -96,18 +95,12 @@ public class LinkageCheckTask extends DefaultTask {
     }
   }
 
-  String formatComponentResult(ResolvedComponentResult componentResult) {
-    ModuleVersionIdentifier identifier = componentResult.getModuleVersion();
-    return identifier.toString();
-  }
-
   /** Returns true iff {@code configuration}'s artifacts contain linkage errors. */
   private boolean findLinkageErrors(Configuration configuration) throws IOException {
     ImmutableList.Builder<ClassPathEntry> classPathBuilder = ImmutableList.builder();
 
     // TODO(suztomo): Should this include optional dependencies?
     //  Once we decide what to do with the optional dependencies, let's revisit this logic.
-    ImmutableList.Builder<Artifact> artifactsBuilder = ImmutableList.builder();
     for (ResolvedArtifact resolvedArtifact :
         configuration.getResolvedConfiguration().getResolvedArtifacts()) {
       ModuleVersionIdentifier moduleVersionId = resolvedArtifact.getModuleVersion().getId();
@@ -121,7 +114,6 @@ public class LinkageCheckTask extends DefaultTask {
               null,
               resolvedArtifact.getFile());
       classPathBuilder.add(new ClassPathEntry(artifact));
-      artifactsBuilder.add(artifact);
     }
 
     ImmutableList<ClassPathEntry> classPath = classPathBuilder.build();
@@ -178,6 +170,11 @@ public class LinkageCheckTask extends DefaultTask {
 
     return "Problematic artifacts in the dependency tree:\n"
         + dependencyPathToArtifacts(componentResult, problematicJars.build());
+  }
+
+  String formatComponentResult(ResolvedComponentResult componentResult) {
+    ModuleVersionIdentifier identifier = componentResult.getModuleVersion();
+    return identifier.toString();
   }
 
   private void recordDependencyPaths(


### PR DESCRIPTION
Fixes #1478 

Example output: https://gist.github.com/suztomo/f7a6694cf232965900f73201295f358b

```
Problematic artifacts in the dependency tree:
commons-logging:commons-logging:1.2 is at:
   g:test-123:0.1.0-SNAPSHOT / com.google.cloud:google-cloud-logging:1.101.1 / com.google.api:gax:1.56.0 / com.google.auth:google-auth-library-oauth2-http:0.20.0 / com.google.http-client:google-http-client:1.34.2 / org.apache.httpcomponents:httpclient:4.5.11 / commons-logging:commons-logging:1.2
   g:test-123:0.1.0-SNAPSHOT / com.google.cloud:google-cloud-logging:1.101.1 / com.google.api:gax:1.56.0 / com.google.auth:google-auth-library-oauth2-http:0.20.0 / com.google.http-client:google-http-client-jackson2:1.34.2 / com.google.http-client:google-http-client:1.34.2 / org.apache.httpcomponents:httpclient:4.5.11 / commons-logging:commons-logging:1.2
...
```