### PR TITLE
Release 8.0.0-bom

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>7.0.3-SNAPSHOT</version>
+  <version>8.0.0</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>8.0.0</version>
+  <version>8.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>7.0.3-SNAPSHOT</version>
+        <version>8.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>8.0.0</version>
+        <version>8.0.1-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Release 8.0.0-bom

It's a major version bump because https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/1496 included major version bumps.

<img width="889" alt="Screen Shot 2020-06-24 at 19 15 36" src="https://user-images.githubusercontent.com/28604/85636659-1a694680-b64f-11ea-8b41-9a318666eddf.png">

Diff since the last release:

```
suztomo-macbookpro44% git diff v7.0.2-bom v8.0.0-bom -- boms/cloud-oss-bom/pom.xml 
diff --git a/boms/cloud-oss-bom/pom.xml b/boms/cloud-oss-bom/pom.xml
index f2ab19f4..fdbb005c 100644
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>7.0.2</version>
+  <version>8.0.0</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>
@@ -45,7 +45,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>29.0-android</guava.version>
-    <google.cloud.java.version>0.129.0</google.cloud.java.version>
+    <google.cloud.java.version>0.130.0</google.cloud.java.version>
     <io.grpc.version>1.30.2</io.grpc.version>
     <protobuf.version>3.12.2</protobuf.version>
     <http.version>1.35.0</http.version>
suztomo-macbookpro44% 
```