### PR TITLE
Dependency Trees in BOM Dashboard

### DIFF
--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/ArtifactResults.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/ArtifactResults.java
@@ -16,6 +16,10 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
+import com.google.cloud.tools.opensource.dependencies.DependencyPath;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.ListMultimap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,6 +37,7 @@ public final class ArtifactResults {
   private final Map<String, Integer> results = new HashMap<>();
   private final Artifact artifact;
   private String exceptionMessage;
+  private ImmutableListMultimap<DependencyPath, DependencyPath> dependencyTree;
 
   public ArtifactResults(Artifact artifact) {
     this.artifact = artifact;
@@ -44,6 +49,18 @@ public final class ArtifactResults {
 
   void addResult(String testName, int failures) {
     results.put(testName, failures);
+  }
+
+  void setDependencyTree(ListMultimap<DependencyPath, DependencyPath> dependencyTree) {
+    this.dependencyTree = ImmutableListMultimap.copyOf(dependencyTree);
+  }
+
+  public ImmutableListMultimap<DependencyPath, DependencyPath> getDependencyTree() {
+    return dependencyTree;
+  }
+
+  public DependencyPath getDependencyRoot() {
+    return Iterables.getFirst(dependencyTree.values(), null);
   }
 
   /**

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/ArtifactResults.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/ArtifactResults.java
@@ -16,10 +16,6 @@
 
 package com.google.cloud.tools.opensource.dashboard;
 
-import com.google.cloud.tools.opensource.dependencies.DependencyPath;
-import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.ListMultimap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,7 +33,6 @@ public final class ArtifactResults {
   private final Map<String, Integer> results = new HashMap<>();
   private final Artifact artifact;
   private String exceptionMessage;
-  private ImmutableListMultimap<DependencyPath, DependencyPath> dependencyTree;
 
   public ArtifactResults(Artifact artifact) {
     this.artifact = artifact;
@@ -49,18 +44,6 @@ public final class ArtifactResults {
 
   void addResult(String testName, int failures) {
     results.put(testName, failures);
-  }
-
-  void setDependencyTree(ListMultimap<DependencyPath, DependencyPath> dependencyTree) {
-    this.dependencyTree = ImmutableListMultimap.copyOf(dependencyTree);
-  }
-
-  public ImmutableListMultimap<DependencyPath, DependencyPath> getDependencyTree() {
-    return dependencyTree;
-  }
-
-  public DependencyPath getDependencyRoot() {
-    return Iterables.getFirst(dependencyTree.values(), null);
   }
 
   /**

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -39,6 +39,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
@@ -74,6 +75,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 import org.apache.commons.cli.ParseException;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.RepositorySystem;
@@ -393,6 +395,7 @@ public class DashboardMain {
       results.addResult(TEST_NAME_GLOBAL_UPPER_BOUND, globalUpperBoundFailures.size());
       results.addResult(TEST_NAME_DEPENDENCY_CONVERGENCE, convergenceIssues.size());
       results.addResult(TEST_NAME_LINKAGE_CHECK, (int) totalLinkageErrorCount);
+      results.setDependencyTree(dependencyTree);
 
       return results;
     }
@@ -496,6 +499,13 @@ public class DashboardMain {
     try (Writer out = new OutputStreamWriter(
         new FileOutputStream(unstable), StandardCharsets.UTF_8)) {
       Template details = configuration.getTemplate("/templates/unstable_artifacts.ftl");
+      details.process(templateData, out);
+    }
+
+    File dependencyTrees = output.resolve("dependency_trees.html").toFile();
+    try (Writer out = new OutputStreamWriter(
+        new FileOutputStream(dependencyTrees), StandardCharsets.UTF_8)) {
+      Template details = configuration.getTemplate("/templates/dependency_trees.ftl");
       details.process(templateData, out);
     }
   }

--- a/dashboard/src/main/resources/templates/component.ftl
+++ b/dashboard/src/main/resources/templates/component.ftl
@@ -145,8 +145,8 @@
 
     <h2>Dependencies</h2>
 
-    <#if dependencyRootNode?? >
-      <@formatDependencyNode dependencyRootNode dependencyRootNode />
+    <#if dependencyGraph?? >
+      <@formatDependencyGraph dependencyGraph dependencyGraph.getRootPath() "" />
     <#else>
       <p>Dependency information is unavailable</p>
     </#if>

--- a/dashboard/src/main/resources/templates/dependency_trees.ftl
+++ b/dashboard/src/main/resources/templates/dependency_trees.ftl
@@ -10,15 +10,10 @@
   <body>
     <h1>Dependency Tree of the Artifacts in ${coordinates}</h1>
     <p class="bom-coordinates">BOM: ${coordinates?html}</p>
-    <#list table as row>
-      <h2>Dependency Tree of ${row.getCoordinates()?html}</h2>
-      <#assign dependencyTree = row.getDependencyTree() />
-      <#assign dependencyRootNode = row.getDependencyRoot() />
-      <#if dependencyRootNode?? >
-          <@formatDependencyNode dependencyRootNode dependencyRootNode />
-      <#else>
-        <p>Dependency information is unavailable</p>
-      </#if>
+    <#list dependencyGraphs as graph>
+      <#assign rootPath = graph.getRootPath() />
+      <h2>Dependency Tree of ${rootPath.getLeaf()?html}</h2>
+      <@formatDependencyGraph graph rootPath "" />
     </#list>
 
     <hr />

--- a/dashboard/src/main/resources/templates/dependency_trees.ftl
+++ b/dashboard/src/main/resources/templates/dependency_trees.ftl
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <#include "macros.ftl">
+  <head>
+    <meta charset="utf-8" />
+    <title>Google Cloud Platform Java Open Source Dependency Dashboard: Dependency Trees</title>
+    <link rel="stylesheet" href="dashboard.css" />
+    <script src="dashboard.js"></script>
+  </head>
+  <body>
+    <h1>Dependency Tree of the Artifacts in ${coordinates}</h1>
+    <p class="bom-coordinates">BOM: ${coordinates?html}</p>
+    <#list table as row>
+      <h2>Dependency Tree ${row.getCoordinates()?html}</h2>
+      <#assign dependencyTree = row.getDependencyTree() />
+      <#assign dependencyRootNode = row.getDependencyRoot() />
+      <#if dependencyRootNode?? >
+          <@formatDependencyNode dependencyRootNode dependencyRootNode />
+      <#else>
+        <p>Dependency information is unavailable</p>
+      </#if>
+    </#list>
+
+    <hr />
+    <p id='updated'>Last generated at ${lastUpdated}</p>
+  </body>
+</html>

--- a/dashboard/src/main/resources/templates/dependency_trees.ftl
+++ b/dashboard/src/main/resources/templates/dependency_trees.ftl
@@ -11,7 +11,7 @@
     <h1>Dependency Tree of the Artifacts in ${coordinates}</h1>
     <p class="bom-coordinates">BOM: ${coordinates?html}</p>
     <#list table as row>
-      <h2>Dependency Tree ${row.getCoordinates()?html}</h2>
+      <h2>Dependency Tree of ${row.getCoordinates()?html}</h2>
       <#assign dependencyTree = row.getDependencyTree() />
       <#assign dependencyRootNode = row.getDependencyRoot() />
       <#if dependencyRootNode?? >

--- a/dashboard/src/main/resources/templates/index.ftl
+++ b/dashboard/src/main/resources/templates/index.ftl
@@ -148,10 +148,6 @@
     </p>
 
     <p>
-      <a href="dependency_trees.html">Dependency Trees</a>
-    </p>
-
-    <p>
     <a href="unstable_artifacts.html">Pre 1.0 Artifacts</a>
     </p>
 
@@ -164,7 +160,11 @@
         <li><code>${artifact}:${version}</code></li>
       </#list>
     </ul>
- 
+
+    <p>
+      <a href="dependency_trees.html">Dependency Trees</a>
+    </p>
+
     <hr />
 
     <p id='updated'>Last generated at ${lastUpdated}</p>

--- a/dashboard/src/main/resources/templates/index.ftl
+++ b/dashboard/src/main/resources/templates/index.ftl
@@ -148,6 +148,10 @@
     </p>
 
     <p>
+      <a href="dependency_trees.html">Dependency Trees</a>
+    </p>
+
+    <p>
     <a href="unstable_artifacts.html">Pre 1.0 Artifacts</a>
     </p>
 

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -79,7 +79,7 @@
   </#if>
   <p class="dependency-tree-node" title="${label}">${node.getLeaf()}</p>
   <ul>
-    <#list graph.getChildPaths(node) as childNode>
+    <#list graph.getChildren(node) as childNode>
       <#if node != childNode>
         <li class="dependency-tree-node">
             <@formatDependencyGraph graph childNode node />

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -71,18 +71,18 @@
   </#if>
 </#macro>
 
-<#macro formatDependencyNode currentNode parent>
-  <#if parent == currentNode>
-    <#assign label = 'root' />
+<#macro formatDependencyGraph graph node parent>
+  <#if node == graph.getRootPath() >
+      <#assign label = 'root' />
   <#else>
-    <#assign label = 'parent: ' + parent.getLeaf() />
+      <#assign label = 'parent: ' + parent.getLeaf() />
   </#if>
-  <p class="dependency-tree-node" title="${label}">${currentNode.getLeaf()}</p>
+  <p class="dependency-tree-node" title="${label}">${node.getLeaf()}</p>
   <ul>
-    <#list dependencyTree.get(currentNode) as childNode>
-      <#if currentNode != childNode>
+    <#list graph.getChildPaths(node) as childNode>
+      <#if node != childNode>
         <li class="dependency-tree-node">
-            <@formatDependencyNode childNode currentNode />
+            <@formatDependencyGraph graph childNode node />
         </li>
       </#if>
     </#list>

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -440,6 +440,16 @@ public class DashboardTest {
   }
 
   @Test
+  public void testDependencyTrees() throws IOException, ParsingException {
+    Document document = parseOutputFile("dependency_trees.html");
+    Nodes dependencyTreeParagraph = document.query("//p[@class='dependency-tree-node']");
+
+    Assert.assertEquals(53144, dependencyTreeParagraph.size());
+    Assert.assertEquals(
+        "com.google.protobuf:protobuf-java:jar:3.6.1", dependencyTreeParagraph.get(0).getValue());
+  }
+
+  @Test
   public void testOutputDirectory() {
     Assert.assertTrue(
         "The dashboard should be created at target/com.google.cloud/libraries-bom/1.0.0",

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardUnavailableArtifactTest.java
@@ -20,7 +20,9 @@ import com.google.cloud.tools.opensource.classpath.ClassPathResult;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.Bom;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
+import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.io.MoreFiles;
@@ -118,12 +120,17 @@ public class DashboardUnavailableArtifactTest {
     validArtifactResult.addResult(DashboardMain.TEST_NAME_UPPER_BOUND, 0);
     validArtifactResult.addResult(DashboardMain.TEST_NAME_DEPENDENCY_CONVERGENCE, 0);
     validArtifactResult.addResult(DashboardMain.TEST_NAME_GLOBAL_UPPER_BOUND, 0);
+    DependencyPath rootValid = new DependencyPath(validArtifact);
+    validArtifactResult.setDependencyTree(ImmutableListMultimap.of(rootValid, rootValid));
 
     Artifact invalidArtifact = new DefaultArtifact("io.grpc:nonexistent:jar:1.15.0");
     ArtifactResults errorArtifactResult = new ArtifactResults(invalidArtifact);
     errorArtifactResult.setExceptionMessage(
         "Could not find artifact io.grpc:nonexistent:jar:1.15.0 in central"
             + " (https://repo1.maven.org/maven2/)");
+    DependencyPath rootInvalid = new DependencyPath(invalidArtifact);
+    errorArtifactResult.setDependencyTree(ImmutableListMultimap.of(rootInvalid, rootInvalid));
+
     List<ArtifactResults> table = new ArrayList<>();
     table.add(validArtifactResult);
     table.add(errorArtifactResult);

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -23,9 +23,7 @@ import com.google.cloud.tools.opensource.classpath.ErrorType;
 import com.google.cloud.tools.opensource.classpath.SymbolProblem;
 import com.google.cloud.tools.opensource.dependencies.Bom;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
-import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.LinkedListMultimap;
@@ -96,15 +94,10 @@ public class FreemarkerTest {
     Artifact artifact1 = new DefaultArtifact("io.grpc:grpc-context:1.15.0");
     ArtifactResults results1 = new ArtifactResults(artifact1);
     results1.addResult("Linkage Errors", 56);
-    DependencyPath root1 = new DependencyPath(artifact1);
-    results1.setDependencyTree(ImmutableListMultimap.of(root1, root1));
 
     Artifact artifact2 = new DefaultArtifact("grpc:grpc:1.15.0");
     ArtifactResults results2 = new ArtifactResults(artifact2);
     results2.addResult("Linkage Errors", 0);
-    DependencyPath root2 = new DependencyPath(artifact2);
-    results2.setDependencyTree(ImmutableListMultimap.of(root2, root2,
-        root2, root1));
 
     List<ArtifactResults> table = ImmutableList.of(results1, results2);
     List<DependencyGraph> globalDependencies = ImmutableList.of();

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/FreemarkerTest.java
@@ -23,7 +23,9 @@ import com.google.cloud.tools.opensource.classpath.ErrorType;
 import com.google.cloud.tools.opensource.classpath.SymbolProblem;
 import com.google.cloud.tools.opensource.dependencies.Bom;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
+import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.LinkedListMultimap;
@@ -94,11 +96,16 @@ public class FreemarkerTest {
     Artifact artifact1 = new DefaultArtifact("io.grpc:grpc-context:1.15.0");
     ArtifactResults results1 = new ArtifactResults(artifact1);
     results1.addResult("Linkage Errors", 56);
-    
+    DependencyPath root1 = new DependencyPath(artifact1);
+    results1.setDependencyTree(ImmutableListMultimap.of(root1, root1));
+
     Artifact artifact2 = new DefaultArtifact("grpc:grpc:1.15.0");
     ArtifactResults results2 = new ArtifactResults(artifact2);
     results2.addResult("Linkage Errors", 0);
-    
+    DependencyPath root2 = new DependencyPath(artifact2);
+    results2.setDependencyTree(ImmutableListMultimap.of(root2, root2,
+        root2, root1));
+
     List<ArtifactResults> table = ImmutableList.of(results1, results2);
     List<DependencyGraph> globalDependencies = ImmutableList.of();
     DashboardMain.generateDashboard(

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.opensource.dependencies;
 
 import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.ListMultimap;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -81,7 +80,7 @@ public class DependencyGraph {
   // map of groupId:artifactId:version to paths
   private SetMultimap<String, DependencyPath> paths = HashMultimap.create();
 
-  private final ListMultimap<DependencyPath, DependencyPath> parentToChildren =
+  private final LinkedListMultimap<DependencyPath, DependencyPath> parentToChildren =
       LinkedListMultimap.create();
 
   private DependencyNode root;
@@ -137,7 +136,10 @@ public class DependencyGraph {
     return graph.get(0);
   }
 
-  /** Returns the dependency paths of the children of the node at {@code dependencyPath}. */
+  /**
+   * Returns dependency paths from the root to the dependencies of the node at {@code
+   * dependencyPath}.
+   */
   public List<DependencyPath> getChildPaths(DependencyPath dependencyPath) {
     return parentToChildren.get(dependencyPath);
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.opensource.dependencies;
 
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.ListMultimap;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -79,6 +81,9 @@ public class DependencyGraph {
   // map of groupId:artifactId:version to paths
   private SetMultimap<String, DependencyPath> paths = HashMultimap.create();
 
+  private final ListMultimap<DependencyPath, DependencyPath> parentToChildren =
+      LinkedListMultimap.create();
+
   private DependencyNode root;
 
   public DependencyGraph(DependencyNode root) {
@@ -115,16 +120,29 @@ public class DependencyGraph {
     return result;
   }
 
-  /**
-   * @return a mutable copy of the paths in this graph, usually in breadth first order
-   */
+  /** Returns a mutable copy of the paths in this graph, usually in breadth first order. */
   public List<DependencyPath> list() {
     return new ArrayList<>(graph);
   }
 
   /**
-   * @return all paths to the specified artifact
+   * Returns dependency path of the root node.
+   *
+   * @throws IllegalStateException if the graph is empty
    */
+  public DependencyPath getRootPath() {
+    if (graph.isEmpty()) {
+      throw new IllegalStateException("The graph is empty");
+    }
+    return graph.get(0);
+  }
+
+  /** Returns the dependency paths of the children of the node at {@code dependencyPath}. */
+  public List<DependencyPath> getChildPaths(DependencyPath dependencyPath) {
+    return parentToChildren.get(dependencyPath);
+  }
+
+  /** Returns all paths to the specified artifact. */
   public Set<DependencyPath> getPaths(String coordinates) {
     return paths.get(coordinates);
   }
@@ -281,7 +299,9 @@ public class DependencyGraph {
               ? new DependencyPath(artifact)
               : parentPath.append(dependencyNode.getDependency());
       graph.addPath(path);
-  
+
+      graph.parentToChildren.put(parentPath, path);
+
       for (DependencyNode child : dependencyNode.getChildren()) {
         queue.add(new DependencyGraph.LevelOrderQueueItem(child, path));
       }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
@@ -137,7 +137,7 @@ public class DependencyGraph {
   }
 
   /**
-   * Returns dependency paths from the root to the children of the node at {@code dependencyPath}.
+   * Returns dependency paths from the root to the children of {@code parent}.
    */
   public List<DependencyPath> getChildren(DependencyPath parent) {
     return parentToChildren.get(parent);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
@@ -137,11 +137,10 @@ public class DependencyGraph {
   }
 
   /**
-   * Returns dependency paths from the root to the dependencies of the node at {@code
-   * dependencyPath}.
+   * Returns dependency paths from the root to the children of the node at {@code dependencyPath}.
    */
-  public List<DependencyPath> getChildPaths(DependencyPath dependencyPath) {
-    return parentToChildren.get(dependencyPath);
+  public List<DependencyPath> getChildren(DependencyPath parent) {
+    return parentToChildren.get(parent);
   }
 
   /** Returns all paths to the specified artifact. */


### PR DESCRIPTION
This "dependency tree" page shows all dependency trees of the artifacts in the BOM. With browser's search function, this page helps to locate the Maven artifacts that depends on certain artifacts, such as `com.google.auto:auto-common:0.10` and `net.ltgt.gradle.incap:incap:0.2`.

# Showing dependency tree for each of the artifacts in the BOM

<img width="1387" alt="Screen Shot 2020-06-26 at 14 16 45" src="https://user-images.githubusercontent.com/28604/85888490-aeeeb880-b7b7-11ea-8aca-0a0dece3a5c0.png">

# Search for artifacts

The mouse-hover tells the node's parent.

<img width="717" alt="Screen Shot 2020-06-26 at 14 17 16" src="https://user-images.githubusercontent.com/28604/85888526-bf069800-b7b7-11ea-99e9-c68eb28234bc.png">
