### PR TITLE
Gradle plugin release script with net.researchgate.release plugin

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -78,4 +78,7 @@ pluginBundle {
 
 release {
   tagTemplate = 'v$version-gradle'
+  git {
+    requireBranch = /^\d+.\d+.\d+-gradle$/  //regex
+  }
 }

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -18,6 +18,7 @@ plugins {
   id 'com.gradle.plugin-publish' version "0.12.0"
   id 'groovy'
   id 'java-gradle-plugin'
+  id 'net.researchgate.release'
 }
 
 apply from: "$rootDir/gradle/functional-test.gradle"
@@ -73,4 +74,8 @@ pluginBundle {
   vcsUrl = 'https://github.com/GoogleCloudPlatform/cloud-opensource-java.git'
   description = 'A plugin to detect Java diamond dependency conflicts'
   tags = ['google', 'java', 'dependency','verification']
+}
+
+release {
+  tagTemplate = 'v$version-gradle'
 }

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -18,7 +18,7 @@ plugins {
   id 'com.gradle.plugin-publish' version "0.12.0"
   id 'groovy'
   id 'java-gradle-plugin'
-  id 'net.researchgate.release'
+  id 'net.researchgate.release' version '2.8.1'
 }
 
 apply from: "$rootDir/gradle/functional-test.gradle"

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -78,6 +78,8 @@ pluginBundle {
 
 release {
   tagTemplate = 'v$version-gradle'
+  failOnUnversionedFiles = false
+  failOnUpdateNeeded = false
   git {
     requireBranch = /^\d+.\d+.\d+-gradle$/  //regex
   }

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -18,6 +18,7 @@ plugins {
   id 'com.gradle.plugin-publish' version "0.12.0"
   id 'groovy'
   id 'java-gradle-plugin'
+  id 'maven-publish'
   id 'net.researchgate.release' version '2.8.1'
 }
 
@@ -37,18 +38,7 @@ dependencies {
   testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
 }
 
-// Maven-publish plugin interferes with com.gradle.plugin-publish plugin
-// https://discuss.gradle.org/t/debug-an-issue-in-publish-plugin-gradle-plugin-not-being-prepended-to-groupid/32720
-if (version.contains("SNAPSHOT")) {
-
-  apply plugin: 'maven-publish'
-
-  publishing {
-    repositories {
-      mavenLocal()
-    }
-  }
-
+publishing {
   repositories {
     mavenLocal()
   }

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -61,7 +61,7 @@ repositories {
 gradlePlugin {
   plugins {
     linkageCheckerPlugin {
-      id = 'com.google.cloud.tools.linkagechecker'
+      id = 'com.google.cloud.tools.linkagechecker' // LinkageCheckerPluginTest validates this value
       displayName = 'Linkage Checker'
       description = 'Tool to verify the compatibility of the class paths of Gradle projects'
       implementationClass = 'com.google.cloud.tools.dependencies.gradle.LinkageCheckerPlugin'

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -28,10 +28,9 @@ group = 'com.google.cloud.tools'
 sourceCompatibility = 1.8
 
 dependencies {
-  implementation platform('com.google.cloud.tools:dependencies-parent:1.4.3')
   implementation 'com.google.cloud.tools:dependencies:1.4.3'
-  implementation 'com.google.guava:guava'
-  implementation 'org.apache.maven.resolver:maven-resolver-api'
+  implementation 'com.google.guava:guava:29.0-jre'
+  implementation 'org.apache.maven.resolver:maven-resolver-api:1.4.2'
 
   testImplementation 'junit:junit:4.13'
   testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -18,7 +18,6 @@ plugins {
   id 'com.gradle.plugin-publish' version "0.12.0"
   id 'groovy'
   id 'java-gradle-plugin'
-  id 'maven-publish'
   id 'net.researchgate.release' version '2.8.1'
 }
 
@@ -38,7 +37,18 @@ dependencies {
   testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
 }
 
-publishing {
+// Maven-publish plugin interferes with com.gradle.plugin-publish plugin
+// https://discuss.gradle.org/t/debug-an-issue-in-publish-plugin-gradle-plugin-not-being-prepended-to-groupid/32720
+if (version.contains("SNAPSHOT")) {
+
+  apply plugin: 'maven-publish'
+
+  publishing {
+    repositories {
+      mavenLocal()
+    }
+  }
+
   repositories {
     mavenLocal()
   }

--- a/gradle-plugin/kokoro/release.sh
+++ b/gradle-plugin/kokoro/release.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-# Fail on any error.
-set -e
-# Display commands to stderr.
-set -x
+set -o errexit
+set -o xtrace
 
 readonly PUBLISH_KEY=$(cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_key")
 readonly PUBLISH_SECRET=$(cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_secret")

--- a/gradle-plugin/kokoro/release.sh
+++ b/gradle-plugin/kokoro/release.sh
@@ -8,9 +8,9 @@ readonly PUBLISH_SECRET=$(cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_secre
 
 cd github/cloud-opensource-java/gradle-plugin
 
-./gradlew build
+./gradlew build publishToMavenLocal
 
-./gradlew  publishPlugins \
+./gradlew publishPlugins \
   -Pgradle.publish.key="${PUBLISH_KEY}" \
   -Pgradle.publish.secret="${PUBLISH_SECRET}" \
   --info --stacktrace

--- a/gradle-plugin/kokoro/release.sh
+++ b/gradle-plugin/kokoro/release.sh
@@ -8,7 +8,9 @@ readonly PUBLISH_SECRET=$(cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_secre
 
 cd github/cloud-opensource-java/gradle-plugin
 
-./gradlew build publishPlugins \
+./gradlew build
+
+./gradlew  publishPlugins \
   -Pgradle.publish.key="${PUBLISH_KEY}" \
   -Pgradle.publish.secret="${PUBLISH_SECRET}" \
   --info --stacktrace

--- a/gradle-plugin/kokoro/release.sh
+++ b/gradle-plugin/kokoro/release.sh
@@ -10,7 +10,7 @@ readonly PUBLISH_SECRET=$(cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_secre
 
 cd github/cloud-opensource-java/gradle-plugin
 
-./gradlew check publishPlugins \
+./gradlew build publishPlugins \
   -Pgradle.publish.key="${PUBLISH_KEY}" \
   -Pgradle.publish.secret="${PUBLISH_SECRET}" \
   --info --stacktrace

--- a/gradle-plugin/kokoro/release.sh
+++ b/gradle-plugin/kokoro/release.sh
@@ -8,7 +8,7 @@ readonly PUBLISH_SECRET=$(cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_secre
 
 cd github/cloud-opensource-java/gradle-plugin
 
-./gradlew build publishToMavenLocal
+./gradlew build
 
 ./gradlew publishPlugins \
   -Pgradle.publish.key="${PUBLISH_KEY}" \

--- a/gradle-plugin/src/test/groovy/com/google/cloud/tools/dependencies/gradle/LinkageCheckerPluginTest.groovy
+++ b/gradle-plugin/src/test/groovy/com/google/cloud/tools/dependencies/gradle/LinkageCheckerPluginTest.groovy
@@ -25,7 +25,7 @@ class LinkageCheckerPluginTest {
     @Test
     public void linkage_checker_plugin_should_add_task_to_project() {
         Project project = ProjectBuilder.builder().build()
-        project.getPlugins().apply 'com.google.cloud.tools.linkageChecker'
+        project.getPlugins().apply 'com.google.cloud.tools.linkagechecker'
 
         assertTrue(project.tasks.linkageCheck instanceof LinkageCheckTask)
     }

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -69,8 +69,12 @@ if [[ "${SUFFIX}" = "bom" ]]; then
   cd boms/cloud-oss-bom
 fi
 
-# Updates the pom.xml with the version to release.
-mvn versions:set versions:commit -DnewVersion=${VERSION} -DgenerateBackupPoms=false
+if [[ "${SUFFIX}" = "gradle" ]]; then
+  cd gradle-plugin
+else
+  # Updates the pom.xml with the version to release.
+  mvn versions:set versions:commit -DnewVersion=${VERSION} -DgenerateBackupPoms=false
+fi
 
 # Tags a new commit for this release.
 git commit -am "preparing release ${VERSION}-${SUFFIX}"
@@ -82,7 +86,14 @@ NEXT_SNAPSHOT=${NEXT_VERSION}
 if [[ "${NEXT_SNAPSHOT}" != *-SNAPSHOT ]]; then
   NEXT_SNAPSHOT=${NEXT_SNAPSHOT}-SNAPSHOT
 fi
-mvn versions:set versions:commit -DnewVersion=${NEXT_SNAPSHOT} -DgenerateBackupPoms=false
+
+if [[ "${SUFFIX}" = "gradle" ]]; then
+  # Changes the version for release and creates the commits/tags.
+  echo | ./gradlew release -Prelease.releaseVersion=${VERSION} \
+      ${NEXT_VERSION:+"-Prelease.newVersion=${NEXT_VERSION}"}
+else
+  mvn versions:set versions:commit -DnewVersion=${NEXT_SNAPSHOT} -DgenerateBackupPoms=false
+fi
 
 # Commits this next snapshot version.
 git commit -am "${NEXT_SNAPSHOT}"

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -16,7 +16,7 @@ Die() {
 }
 
 DieUsage() {
-  Die "Usage: ./prepare_release.sh <dependencies|bom> <release version> [<post-release-version>]"
+  Die "Usage: ./prepare_release.sh <dependencies|bom|gradle> <release version> [<post-release-version>]"
 }
 
 # Usage: CheckVersion <version>
@@ -38,7 +38,7 @@ EchoGreen '===== RELEASE SETUP SCRIPT ====='
 
 SUFFIX=$1
 
-if [[ "${SUFFIX}" != "dependencies" && "${SUFFIX}" != "bom" ]]; then
+if [[ "${SUFFIX}" != "dependencies" && "${SUFFIX}" != "bom" && "${SUFFIX}" != "gradle" ]]; then
   DieUsage
 fi
 

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -80,7 +80,7 @@ if [[ "${SUFFIX}" = "gradle" ]]; then
   cd gradle-plugin
   # Changes the version for release and creates the commits/tags.
   echo | ./gradlew release -Prelease.releaseVersion=${VERSION} \
-      ${NEXT_VERSION:+"-Prelease.newVersion=${NEXT_VERSION}"}
+      -Prelease.newVersion=${NEXT_SNAPSHOT}
 else
   # Updates the pom.xml with the version to release.
   mvn versions:set versions:commit -DnewVersion=${VERSION} -DgenerateBackupPoms=false


### PR DESCRIPTION
This PR applies net.researchgate.release plugin to add Git tag when releasing. Jib also uses this plugin. Prepare_release.sh calls the Gradle plugin when specified with "gradle" argument.

Prepare_release.sh handles 3 cases:
- "bom": `cd boms/cloud-oss-bom` and run `mvn version:set`
- "dependencies": (no `cd`) run `mvn version:set`
- "gradle": `cd gradle-plugin` and run Gradle's net.researchgate.release plugin.
