### PR TITLE
Release 0.0.1-gradle

### DIFF
--- a/gradle-plugin/gradle.properties
+++ b/gradle-plugin/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.0.1
+version = 0.0.2-SNAPSHOT

--- a/gradle-plugin/gradle.properties
+++ b/gradle-plugin/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.1.0-SNAPSHOT
+version = 0.0.1


### PR DESCRIPTION
Release 0.0.1-gradle.

The Gradle release plugin created tag v0.0.1-gradle: https://github.com/GoogleCloudPlatform/cloud-opensource-java/commit/fab3b14ae3fbcb811c111db1b09183f559ada7a1
