### PR TITLE
To use gradle.properties under $HOME/.gradle

### DIFF
--- a/gradle-plugin/kokoro/release.sh
+++ b/gradle-plugin/kokoro/release.sh
@@ -6,8 +6,9 @@ set -o xtrace
 mkdir -p $HOME/.gradle
 readonly HOME_GRADLE_PROPERTY="$HOME/.gradle/gradle.properties"
 
-# Recommended way to store API key
+# Recommended way to store API key in
 # https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/
+# and go/yaqs/5342701566951424 for ISE check.
 echo -n 'gradle.publish.key=' >> $HOME_GRADLE_PROPERTY
 cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_key" >> $HOME_GRADLE_PROPERTY
 echo -n 'gradle.publish.secret=' >> $HOME_GRADLE_PROPERTY

--- a/gradle-plugin/kokoro/release.sh
+++ b/gradle-plugin/kokoro/release.sh
@@ -3,14 +3,18 @@
 set -o errexit
 set -o xtrace
 
-readonly PUBLISH_KEY=$(cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_key")
-readonly PUBLISH_SECRET=$(cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_secret")
+mkdir -p $HOME/.gradle
+readonly HOME_GRADLE_PROPERTY="$HOME/.gradle/gradle.properties"
+
+# Recommended way to store API key
+# https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/
+echo -n 'gradle.publish.key=' >> $HOME_GRADLE_PROPERTY
+cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_key" >> $HOME_GRADLE_PROPERTY
+echo -n 'gradle.publish.secret=' >> $HOME_GRADLE_PROPERTY
+cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_secret" >> $HOME_GRADLE_PROPERTY
 
 cd github/cloud-opensource-java/gradle-plugin
 
 ./gradlew build
 
-./gradlew publishPlugins \
-  -Pgradle.publish.key="${PUBLISH_KEY}" \
-  -Pgradle.publish.secret="${PUBLISH_SECRET}" \
-  --info --stacktrace
+./gradlew publishPlugins --info --stacktrace


### PR DESCRIPTION
`$HOME/.gradle/gradle.properties` file is a recommended way to use API key: https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/