### PR TITLE
Guava's dependency tree should not have srczip in dashboard

### DIFF
--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -447,7 +447,7 @@ public class DashboardTest {
     Nodes dependencyTreeParagraph = document.query("//p[@class='dependency-tree-node']");
 
     // characterization test
-    Assert.assertEquals(38392, dependencyTreeParagraph.size());
+    Assert.assertEquals(38391, dependencyTreeParagraph.size());
     Assert.assertEquals(
         "com.google.protobuf:protobuf-java:jar:3.6.1", dependencyTreeParagraph.get(0).getValue());
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
@@ -292,6 +292,11 @@ public class DependencyGraph {
           continue;
         }
       }
+
+      // Guava's zipsrc dependency is not for users but for building its Javadoc properly.
+      if (artifact != null && "zipsrc".equals(artifact.getArtifactId())) {
+        continue;
+      }
   
       // parentPath is null for the first item
       DependencyPath path =

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
@@ -294,10 +294,10 @@ public class DependencyGraph {
       }
 
       // Guava's zipsrc dependency is not for users but for building its Javadoc properly.
-      if (artifact != null && "zipsrc".equals(artifact.getArtifactId())) {
+      if (artifact != null && "jdk".equals(artifact.getGroupId())) {
         continue;
       }
-  
+
       // parentPath is null for the first item
       DependencyPath path =
           parentPath == null

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -163,7 +163,7 @@ public final class RepositoryUtility {
         new AndDependencySelector(
             // ScopeDependencySelector takes exclusions. 'Provided' scope is not here to avoid
             // false positive in LinkageChecker.
-            new ScopeDependencySelector("test", "system"),
+            new ScopeDependencySelector("test"),
             new OptionalDependencySelector(),
             new ExclusionDependencySelector(),
             new FilteringZipDependencySelector());

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -163,7 +163,7 @@ public final class RepositoryUtility {
         new AndDependencySelector(
             // ScopeDependencySelector takes exclusions. 'Provided' scope is not here to avoid
             // false positive in LinkageChecker.
-            new ScopeDependencySelector("test"),
+            new ScopeDependencySelector("test", "system"),
             new OptionalDependencySelector(),
             new ExclusionDependencySelector(),
             new FilteringZipDependencySelector());
@@ -177,7 +177,7 @@ public final class RepositoryUtility {
         new AndDependencySelector(
             // ScopeDependencySelector takes exclusions. 'Provided' scope is not here to avoid
             // false positive in LinkageChecker.
-            new ScopeDependencySelector("test"),
+            new ScopeDependencySelector("test", "system"),
             new BanOptionalDependencySelector(),
             new ExclusionDependencySelector(),
             new FilteringZipDependencySelector());

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -177,7 +177,7 @@ public final class RepositoryUtility {
         new AndDependencySelector(
             // ScopeDependencySelector takes exclusions. 'Provided' scope is not here to avoid
             // false positive in LinkageChecker.
-            new ScopeDependencySelector("test", "system"),
+            new ScopeDependencySelector("test"),
             new BanOptionalDependencySelector(),
             new ExclusionDependencySelector(),
             new FilteringZipDependencySelector());

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -247,8 +247,7 @@ public class DependencyGraphBuilderTest {
   public void testBuildVerboseDependencyGraph_systemScope() {
     DependencyGraph graph =
         dependencyGraphBuilder.buildVerboseDependencyGraph(
-            new DefaultArtifact("com.google.guava:guava:29.0-android")
-        );
+            new DefaultArtifact("com.google.guava:guava:29.0-android"));
 
     for (DependencyPath path : graph.list()) {
       Artifact leaf = path.getLeaf();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.opensource.dependencies;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -240,6 +241,19 @@ public class DependencyGraphBuilderTest {
         firstElement.getLeaf().getArtifactId());
     
     Assert.assertEquals(1, list.size()); // all dependencies are optional
+  }
+
+  @Test
+  public void testBuildVerboseDependencyGraph_systemScope() {
+    DependencyGraph graph =
+        dependencyGraphBuilder.buildVerboseDependencyGraph(
+            ImmutableList.of(new DefaultArtifact("com.google.guava:guava:29.0-jre"))
+        );
+
+    for (DependencyPath path : graph.list()) {
+      Artifact leaf = path.getLeaf();
+      assertNotEquals("srczip", leaf.getArtifactId());
+    }
   }
 
   @Test

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/DependencyGraphBuilderTest.java
@@ -247,7 +247,7 @@ public class DependencyGraphBuilderTest {
   public void testBuildVerboseDependencyGraph_systemScope() {
     DependencyGraph graph =
         dependencyGraphBuilder.buildVerboseDependencyGraph(
-            ImmutableList.of(new DefaultArtifact("com.google.guava:guava:29.0-jre"))
+            new DefaultArtifact("com.google.guava:guava:29.0-android")
         );
 
     for (DependencyPath path : graph.list()) {


### PR DESCRIPTION
Still in progress (I cannot reproduce the dependency graph in my mac)