### PR TITLE
buildVerboseDependencyGraph misses auto-service-annotations dependency

### DIFF
--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.opensource.dependencies.Bom;
 import com.google.cloud.tools.opensource.dependencies.UnresolvableArtifactProblem;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.truth.Correspondence;
 import com.google.common.truth.Truth;
 import com.google.common.truth.Truth8;
 import java.io.IOException;
@@ -248,5 +249,23 @@ public class ClassPathBuilderTest {
     // This should not throw StackOverflowError
     ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(beamZetaSqlExtensions), true);
     assertNotNull(result);
+  }
+
+  @Test
+  public void testResolve_shouldIncludeCompileDependencyOfProvidedDependency() {
+    Artifact nio = new DefaultArtifact("com.google.cloud:google-cloud-nio:0.121.2");
+    ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(nio), false);
+
+    // The dependency graph should include auto-service-annotations with dependency path
+    // com.google.cloud:google-cloud-nio:0.121.2 (compile)
+    //  \ com.google.auto.value:auto-value:1.7.3 (provided)
+    //    \ com.google.auto.service:auto-service:1.0-rc6 (provided)
+    //      \ com.google.auto.service:auto-service-annotations:1.0-rc6 (compile)
+    Truth.assertThat(result.getClassPath())
+        .comparingElementsUsing(
+            Correspondence.transforming(
+                (ClassPathEntry entry) -> entry.getArtifact().getArtifactId(),
+                "has class path entry that has artifactId of"))
+        .contains("auto-service-annotations");
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -265,7 +265,7 @@ public class ClassPathBuilderTest {
         .comparingElementsUsing(
             Correspondence.transforming(
                 (ClassPathEntry entry) -> entry.getArtifact().getArtifactId(),
-                "has class path entry that has artifactId of"))
+                "that has artifactId of"))
         .contains("auto-service-annotations");
   }
 }


### PR DESCRIPTION
Test case for #1551 

The dashboard is showing unexpected missing class ([link](https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/snapshot/com.google.cloud_google-cloud-nio_0.121.2.html#linkage-errors)).

```
Class com.google.auto.service.AutoService is not found, referenced from 1 class ▼
   com.google.auto.service.processor.AutoServiceProcessor
```

This test case shows that `classPathBuilder.resolve(..., false)` is not giving auto-service-annotations.