### PR TITLE
ExcludedDependency to represent a dependency is missing because of exclusions

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ExcludedDependency.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ExcludedDependency.java
@@ -16,15 +16,14 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import java.util.Objects;
 import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.graph.Dependency;
 
-/** An optional or provided-scope dependency is not supplied. */
-class MissingDependency extends LinkageProblemCause {
+/** An dependency is not supplied because {@code excludingArtifact} excludes the dependency. */
+class ExcludedDependency extends MissingDependency {
 
   /**
    * The path from {@code LinkageProblem.sourceClass}'s artifact to an artifact that contains a
@@ -32,35 +31,32 @@ class MissingDependency extends LinkageProblemCause {
    */
   private DependencyPath pathToMissingArtifact;
 
-  MissingDependency(DependencyPath pathToMissingArtifact) {
-    this.pathToMissingArtifact = checkNotNull(pathToMissingArtifact);
+  private Artifact excludingArtifact;
+
+  ExcludedDependency(DependencyPath pathToMissingArtifact, Artifact excludingArtifact) {
+    super(pathToMissingArtifact);
+    this.pathToMissingArtifact = pathToMissingArtifact;
+    this.excludingArtifact = excludingArtifact;
   }
 
   DependencyPath getPathToMissingArtifact() {
     return pathToMissingArtifact;
   }
 
+  Artifact getExcludingArtifact() {
+    return excludingArtifact;
+  }
+
   @Override
   public String toString() {
-    String missingReason = "";
-    for (int i = 0; i < pathToMissingArtifact.size() - 1; i++) {
-      Dependency dependency = pathToMissingArtifact.getDependency(i);
-      if (dependency.isOptional()) {
-        missingReason = " because the path contains an optional dependency";
-        break;
-      }
-      if ("provided".equals(dependency.getScope())) {
-        missingReason = " because the path contains a provided-scope dependency";
-        break;
-      }
-    }
     Artifact artifactContainingValidSymbol = pathToMissingArtifact.getLeaf();
     return "The valid symbol is in "
         + artifactContainingValidSymbol
         + " at "
         + pathToMissingArtifact
-        + " but it was not selected"
-        + missingReason;
+        + " but it was not selected because "
+        + Artifacts.toCoordinates(excludingArtifact)
+        + " excludes it";
   }
 
   @Override
@@ -71,12 +67,13 @@ class MissingDependency extends LinkageProblemCause {
     if (other == null || getClass() != other.getClass()) {
       return false;
     }
-    MissingDependency that = (MissingDependency) other;
-    return Objects.equals(pathToMissingArtifact, that.pathToMissingArtifact);
+    ExcludedDependency that = (ExcludedDependency) other;
+    return Objects.equals(pathToMissingArtifact, that.pathToMissingArtifact)
+        && Objects.equals(excludingArtifact, that.excludingArtifact);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(pathToMissingArtifact);
+    return Objects.hash(pathToMissingArtifact, excludingArtifact);
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ExcludedDependency.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ExcludedDependency.java
@@ -22,24 +22,17 @@ import java.util.Objects;
 import org.eclipse.aether.artifact.Artifact;
 
 /** An dependency is not supplied because {@code excludingArtifact} excludes the dependency. */
-class ExcludedDependency extends MissingDependency {
+final class ExcludedDependency extends MissingDependency {
 
   /**
    * The path from {@code LinkageProblem.sourceClass}'s artifact to an artifact that contains a
    * valid symbol.
    */
-  private DependencyPath pathToMissingArtifact;
-
   private Artifact excludingArtifact;
 
   ExcludedDependency(DependencyPath pathToMissingArtifact, Artifact excludingArtifact) {
     super(pathToMissingArtifact);
-    this.pathToMissingArtifact = pathToMissingArtifact;
     this.excludingArtifact = excludingArtifact;
-  }
-
-  DependencyPath getPathToMissingArtifact() {
-    return pathToMissingArtifact;
   }
 
   /** Returns the artifact that declares the exclusion of the missing artifact. */

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ExcludedDependency.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ExcludedDependency.java
@@ -56,7 +56,9 @@ class ExcludedDependency extends MissingDependency {
         + pathToMissingArtifact
         + " but it was not selected because "
         + Artifacts.toCoordinates(excludingArtifact)
-        + " excludes it";
+        + " excludes "
+        + Artifacts.makeKey(artifactContainingValidSymbol)
+        + ".";
   }
 
   @Override

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ExcludedDependency.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ExcludedDependency.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import java.util.Objects;
@@ -43,6 +42,7 @@ class ExcludedDependency extends MissingDependency {
     return pathToMissingArtifact;
   }
 
+  /** Returns the artifact that declares the exclusion of the missing artifact. */
   Artifact getExcludingArtifact() {
     return excludingArtifact;
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageProblemCauseAnnotator.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageProblemCauseAnnotator.java
@@ -80,7 +80,17 @@ public final class LinkageProblemCauseAnnotator {
           }
         } else {
           // No artifact that matches groupId and artifactId in rootResult.
-          linkageProblem.setCause(new MissingDependency(pathToUnselectedEntry));
+
+          // Checking exclusion elements in the dependency path
+          Artifact excludingArtifact =
+              pathToSourceEntry.findExclusion(
+                  artifactInSubtree.getGroupId(), artifactInSubtree.getArtifactId());
+          if (excludingArtifact != null) {
+            linkageProblem.setCause(
+                new ExcludedDependency(pathToUnselectedEntry, excludingArtifact));
+          } else {
+            linkageProblem.setCause(new MissingDependency(pathToUnselectedEntry));
+          }
         }
       }
     }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MissingDependency.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/MissingDependency.java
@@ -30,7 +30,7 @@ class MissingDependency extends LinkageProblemCause {
    * The path from {@code LinkageProblem.sourceClass}'s artifact to an artifact that contains a
    * valid symbol.
    */
-  private DependencyPath pathToMissingArtifact;
+  protected DependencyPath pathToMissingArtifact;
 
   MissingDependency(DependencyPath pathToMissingArtifact) {
     this.pathToMissingArtifact = checkNotNull(pathToMissingArtifact);

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.Exclusion;
 
 /**
  * A sequence of Maven artifacts and dependencies (scope and optional flag) in between.
@@ -122,6 +123,26 @@ public final class DependencyPath {
       parent.path.add(path.get(i));
     }
     return parent;
+  }
+
+  /**
+   * Returns the artifact that declares an exclusion element specified for {@code groupId} and
+   * {@code artifactId}. {@code Null} if no such artifact in the dependency path.
+   */
+  public Artifact findExclusion(String groupId, String artifactId) {
+    Artifact previousArtifact = root;
+    for (Dependency dependency : path) {
+      for (Exclusion exclusion : dependency.getExclusions()) {
+        if (artifactId.equals(exclusion.getArtifactId())
+            && groupId.equals(exclusion.getGroupId())) {
+          // The exclusion element associated to a dependency is declared by the artifact
+          // in one-level above in the dependency path
+          return previousArtifact;
+        }
+      }
+      previousArtifact = dependency.getArtifact();
+    }
+    return null;
   }
 
   @Override

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyPath.java
@@ -127,7 +127,7 @@ public final class DependencyPath {
 
   /**
    * Returns the artifact that declares an exclusion element specified for {@code groupId} and
-   * {@code artifactId}. {@code Null} if no such artifact in the dependency path.
+   * {@code artifactId}. {@code Null} if the dependency path does not have such artifact.
    */
   public Artifact findExclusion(String groupId, String artifactId) {
     Artifact previousArtifact = root;
@@ -135,8 +135,8 @@ public final class DependencyPath {
       for (Exclusion exclusion : dependency.getExclusions()) {
         if (artifactId.equals(exclusion.getArtifactId())
             && groupId.equals(exclusion.getGroupId())) {
-          // The exclusion element associated to a dependency is declared by the artifact
-          // in one-level above in the dependency path
+          // The exclusion element associated to a dependency is declared by the artifact at
+          // one-level above in the dependency path
           return previousArtifact;
         }
       }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -25,7 +25,6 @@ import com.google.cloud.tools.opensource.dependencies.Bom;
 import com.google.cloud.tools.opensource.dependencies.UnresolvableArtifactProblem;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.truth.Correspondence;
 import com.google.common.truth.Truth;
 import com.google.common.truth.Truth8;
 import java.io.IOException;
@@ -249,23 +248,5 @@ public class ClassPathBuilderTest {
     // This should not throw StackOverflowError
     ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(beamZetaSqlExtensions), true);
     assertNotNull(result);
-  }
-
-  @Test
-  public void testResolve_shouldIncludeCompileDependencyOfProvidedDependency() {
-    Artifact nio = new DefaultArtifact("com.google.cloud:google-cloud-nio:0.121.2");
-    ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(nio), false);
-
-    // The dependency graph should include auto-service-annotations with dependency path
-    // com.google.cloud:google-cloud-nio:0.121.2 (compile)
-    //  \ com.google.auto.value:auto-value:1.7.3 (provided)
-    //    \ com.google.auto.service:auto-service:1.0-rc6 (provided)
-    //      \ com.google.auto.service:auto-service-annotations:1.0-rc6 (compile)
-    Truth.assertThat(result.getClassPath())
-        .comparingElementsUsing(
-            Correspondence.transforming(
-                (ClassPathEntry entry) -> entry.getArtifact().getArtifactId(),
-                "that has artifactId of"))
-        .contains("auto-service-annotations");
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.opensource.dependencies.Bom;
 import com.google.cloud.tools.opensource.dependencies.UnresolvableArtifactProblem;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.truth.Correspondence;
 import com.google.common.truth.Truth;
 import com.google.common.truth.Truth8;
 import java.io.IOException;
@@ -248,5 +249,23 @@ public class ClassPathBuilderTest {
     // This should not throw StackOverflowError
     ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(beamZetaSqlExtensions), true);
     assertNotNull(result);
+  }
+
+  @Test
+  public void testResolve_shouldIncludeCompileDependencyOfProvidedDependency() {
+    Artifact nio = new DefaultArtifact("com.google.cloud:google-cloud-nio:0.121.2");
+    ClassPathResult result = classPathBuilder.resolve(ImmutableList.of(nio), false);
+
+    // The dependency graph should include auto-service-annotations with dependency path
+    // com.google.cloud:google-cloud-nio:0.121.2 (compile)
+    //  \ com.google.auto.value:auto-value:1.7.3 (provided)
+    //    \ com.google.auto.service:auto-service:1.0-rc6 (provided)
+    //      \ com.google.auto.service:auto-service-annotations:1.0-rc6 (compile)
+    Truth.assertThat(result.getClassPath())
+        .comparingElementsUsing(
+            Correspondence.transforming(
+                (ClassPathEntry entry) -> entry.getArtifact().getArtifactId(),
+                "has class path entry that has artifactId of"))
+        .contains("auto-service-annotations");
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -265,7 +265,7 @@ public class ClassPathBuilderTest {
         .comparingElementsUsing(
             Correspondence.transforming(
                 (ClassPathEntry entry) -> entry.getArtifact().getArtifactId(),
-                "has class path entry that has artifactId of"))
+                "that has artifactId of"))
         .contains("auto-service-annotations");
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ExcludedDependencyTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ExcludedDependencyTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.classpath;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.cloud.tools.opensource.dependencies.DependencyPath;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+import org.junit.Test;
+
+public class ExcludedDependencyTest {
+
+  @Test
+  public void testToString() {
+    Artifact root = new DefaultArtifact("a:b:1");
+    Artifact foo = new DefaultArtifact("com.google:foo:1");
+    Artifact bar = new DefaultArtifact("com.google:bar:1");
+
+    DependencyPath pathRootFooBar =
+        new DependencyPath(root)
+            .append(new Dependency(foo, "test", false))
+            .append(new Dependency(bar, "compile", true));
+
+    ExcludedDependency cause = new ExcludedDependency(pathRootFooBar, foo);
+
+    assertEquals(
+        "The valid symbol is in com.google:bar:jar:1 at a:b:jar:1 / "
+            + "com.google:foo:1 (test) / com.google:bar:1 (compile, optional) "
+            + "but it was not selected because com.google:foo:1 excludes com.google:bar.",
+        cause.toString());
+  }
+}

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageProblemCauseTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageProblemCauseTest.java
@@ -47,6 +47,8 @@ public class LinkageProblemCauseTest {
         .addEqualityGroup(new DependencyConflict(methodSymbol, path2, path2))
         .addEqualityGroup(new DependencyConflict(classSymbol, path2, path2))
         .addEqualityGroup(new MissingDependency(path1), new MissingDependency(path1))
+        .addEqualityGroup(new ExcludedDependency(path1, foo), new ExcludedDependency(path1, foo))
+        .addEqualityGroup(new ExcludedDependency(path1, bar))
         .addEqualityGroup(new MissingDependency(path2))
         .addEqualityGroup(UnknownCause.getInstance())
         .testEquals();


### PR DESCRIPTION
Fixes #1551 

ExludedDependency is a special case of MissingDependency where an artifact in the dependency path declares a dependency with an exclusion element, which results in the missing dependency.

In case of https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1551, it was auto-value that declares the exclusion:

```
    <dependency>
      <groupId>com.google.auto.service</groupId>
      <artifactId>auto-service</artifactId>
      <version>1.0-rc6</version>
      <scope>provided</scope>
      <exclusions>
        <exclusion>
          <artifactId>auto-service-annotations</artifactId>
          <groupId>com.google.auto.service</groupId>
        </exclusion>
      </exclusions>
    </dependency>
```

Because of this exclusion, the `auto-service` has linkage error for the class in auto-service-annotations.