### PR TITLE
The enforcer rule to follow Maven's way for optional for non-BOM project

### DIFF
--- a/enforcer-rules/src/it/fail-build-for-linkage-errors/verify.groovy
+++ b/enforcer-rules/src/it/fail-build-for-linkage-errors/verify.groovy
@@ -1,20 +1,36 @@
 def buildLog = new File(basedir, "build.log").text.replaceAll("\\r\\n", "\n")
 
 assert buildLog.contains('''\
-[ERROR] Linkage Checker rule found 16 errors. Linkage error report:
-Class javax.jms.Connection is not found;
+[ERROR] Linkage Checker rule found 4 errors. Linkage error report:
+Class org.apache.avalon.framework.logger.Logger is not found;
   referenced by 1 class file
-    org.apache.log4j.net.JMSAppender (log4j:log4j:1.2.12)
+    org.apache.commons.logging.impl.AvalonLogger (commons-logging:commons-logging:1.1.1)
+''')
+
+assert buildLog.contains('''\
+(com.google.guava:guava:20.0) com.google.common.base.Verify's method verify(boolean, String, Object) is not found;
+  referenced by 3 class files
+    io.grpc.internal.ServiceConfigInterceptor (io.grpc:grpc-core:1.17.1)
+    io.grpc.internal.JndiResourceResolverFactory (io.grpc:grpc-core:1.17.1)
+    io.grpc.internal.DnsNameResolver (io.grpc:grpc-core:1.17.1)
 ''')
 
 assert buildLog.contains('''\
 [ERROR] Problematic artifacts in the dependency tree:
-log4j:log4j:1.2.12 is at:
+commons-logging:commons-logging:1.1.1 is at:
   com.google.cloud.tools.opensource:test-no-such-method-error-example:jar:1.0-SNAPSHOT \
 / com.google.api-client:google-api-client:1.27.0 (compile) \
 / com.google.oauth-client:google-oauth-client:1.27.0 (compile) \
 / com.google.http-client:google-http-client:1.27.0 (compile) \
 / com.google.android:android:1.5_r4 (provided) \
-/ commons-logging:commons-logging:1.1.1 (compile) \
-/ log4j:log4j:1.2.12 (compile, optional)
+/ commons-logging:commons-logging:1.1.1 (compile)
+''')
+assert buildLog.contains('''\
+com.google.guava:guava:20.0 is at:
+  com.google.cloud.tools.opensource:test-no-such-method-error-example:jar:1.0-SNAPSHOT \
+/ com.google.api-client:google-api-client:1.27.0 (compile) \
+/ com.google.guava:guava:20.0 (compile)
+io.grpc:grpc-core:1.17.1 is at:
+  com.google.cloud.tools.opensource:test-no-such-method-error-example:jar:1.0-SNAPSHOT \
+/ io.grpc:grpc-core:1.17.1 (compile)
 ''')

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -73,6 +73,7 @@ import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.transfer.ArtifactTransferException;
 import org.eclipse.aether.util.graph.selector.AndDependencySelector;
 import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
+import org.eclipse.aether.util.graph.selector.OptionalDependencySelector;
 
 /** Linkage Checker Maven Enforcer Rule. */
 public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
@@ -276,6 +277,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
           new AndDependencySelector(
               new NonTestDependencySelector(),
               new ExclusionDependencySelector(),
+              new OptionalDependencySelector(),
               new FilteringZipDependencySelector()));
       DependencyResolutionRequest dependencyResolutionRequest =
           new DefaultDependencyResolutionRequest(mavenProject, fullDependencyResolutionSession);


### PR DESCRIPTION
For BOM projects, it has been handled by https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/1530.

For non-BOM projects, this PR 1558 changes the dependency graph resolution so that the Linkage Checker Enforcer Rule follows Maven's way to handle optional (not to include transitive optional dependencies).