### PR TITLE
Making LinkageProblem cause field final

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/AbstractMethodProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/AbstractMethodProblem.java
@@ -22,7 +22,23 @@ package com.google.cloud.tools.opensource.classpath;
  * as {@link AbstractMethodError}s at runtime.
  */
 final class AbstractMethodProblem extends IncompatibleLinkageProblem {
+  private final MethodSymbol methodSymbol;
+
   AbstractMethodProblem(ClassFile sourceClass, ClassFile targetClass, MethodSymbol methodSymbol) {
-    super("is not implemented in the class", sourceClass, targetClass, methodSymbol);
+    this(sourceClass, targetClass, methodSymbol, null);
+  }
+
+  private AbstractMethodProblem(
+      ClassFile sourceClass,
+      ClassFile targetClass,
+      MethodSymbol methodSymbol,
+      LinkageProblemCause cause) {
+    super("is not implemented in the class", sourceClass, targetClass, methodSymbol, cause);
+    this.methodSymbol = methodSymbol;
+  }
+
+  @Override
+  LinkageProblem withCause(LinkageProblemCause cause) {
+    return new AbstractMethodProblem(getSourceClass(), getTargetClass(), methodSymbol, cause);
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassNotFoundProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ClassNotFoundProblem.java
@@ -18,8 +18,21 @@ package com.google.cloud.tools.opensource.classpath;
 
 /** The {@code classSymbol}, referenced by {@code sourceClass} is not found in the class path. */
 public final class ClassNotFoundProblem extends LinkageProblem {
+  private final ClassSymbol classSymbol;
 
   public ClassNotFoundProblem(ClassFile sourceClass, ClassSymbol classSymbol) {
     super("is not found", sourceClass, classSymbol);
+    this.classSymbol = classSymbol;
+  }
+
+  private ClassNotFoundProblem(
+      ClassFile sourceClass, ClassSymbol classSymbol, LinkageProblemCause cause) {
+    super("is not found", sourceClass, classSymbol, cause);
+    this.classSymbol = classSymbol;
+  }
+
+  @Override
+  LinkageProblem withCause(LinkageProblemCause cause) {
+    return new ClassNotFoundProblem(getSourceClass(), classSymbol, cause);
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/InaccessibleClassProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/InaccessibleClassProblem.java
@@ -25,7 +25,18 @@ package com.google.cloud.tools.opensource.classpath;
  * its enclosing types is private.
  */
 final class InaccessibleClassProblem extends IncompatibleLinkageProblem {
+
   InaccessibleClassProblem(ClassFile sourceClass, ClassFile targetClass, Symbol classSymbol) {
-    super("is not accessible", sourceClass, targetClass, classSymbol);
+    this(sourceClass, targetClass, classSymbol, null);
+  }
+
+  private InaccessibleClassProblem(
+      ClassFile sourceClass, ClassFile targetClass, Symbol classSymbol, LinkageProblemCause cause) {
+    super("is not accessible", sourceClass, targetClass, classSymbol, cause);
+  }
+
+  @Override
+  LinkageProblem withCause(LinkageProblemCause cause) {
+    return new InaccessibleClassProblem(getSourceClass(), getTargetClass(), getSymbol(), cause);
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/InaccessibleMemberProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/InaccessibleMemberProblem.java
@@ -26,6 +26,16 @@ package com.google.cloud.tools.opensource.classpath;
  */
 final class InaccessibleMemberProblem extends IncompatibleLinkageProblem {
   InaccessibleMemberProblem(ClassFile sourceClass, ClassFile targetClass, Symbol symbol) {
-    super("is not accessible", sourceClass, targetClass, symbol);
+    this(sourceClass, targetClass, symbol, null);
   }
-}
+
+  private InaccessibleMemberProblem(
+      ClassFile sourceClass, ClassFile targetClass, Symbol symbol, LinkageProblemCause cause) {
+    super("is not accessible", sourceClass, targetClass, symbol, cause);
+  }
+
+  @Override
+  LinkageProblem withCause(LinkageProblemCause cause) {
+    return new InaccessibleMemberProblem(getSourceClass(), getTargetClass(), getSymbol(), cause);
+  }
+  }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/IncompatibleClassChangeProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/IncompatibleClassChangeProblem.java
@@ -33,6 +33,17 @@ package com.google.cloud.tools.opensource.classpath;
 final class IncompatibleClassChangeProblem extends IncompatibleLinkageProblem {
 
   IncompatibleClassChangeProblem(ClassFile sourceClass, ClassFile targetClass, Symbol symbol) {
-    super("has changed incompatibly", sourceClass, targetClass, symbol);
+    this(sourceClass, targetClass, symbol, null);
+  }
+
+  private IncompatibleClassChangeProblem(
+      ClassFile sourceClass, ClassFile targetClass, Symbol symbol, LinkageProblemCause cause) {
+    super("has changed incompatibly", sourceClass, targetClass, symbol, cause);
+  }
+
+  @Override
+  LinkageProblem withCause(LinkageProblemCause cause) {
+    return new IncompatibleClassChangeProblem(
+        getSourceClass(), getTargetClass(), getSymbol(), cause);
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/IncompatibleLinkageProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/IncompatibleLinkageProblem.java
@@ -26,8 +26,12 @@ public abstract class IncompatibleLinkageProblem extends LinkageProblem {
   private final ClassFile targetClass;
 
   IncompatibleLinkageProblem(
-      String symbolProblemMessage, ClassFile sourceClass, ClassFile targetClass, Symbol symbol) {
-    super(symbolProblemMessage, sourceClass, symbol);
+      String symbolProblemMessage,
+      ClassFile sourceClass,
+      ClassFile targetClass,
+      Symbol symbol,
+      LinkageProblemCause cause) {
+    super(symbolProblemMessage, sourceClass, symbol, cause);
     this.targetClass = targetClass;
   }
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMain.java
@@ -100,7 +100,7 @@ class LinkageCheckerMain {
         }
 
         if (classPathResult != null) {
-          LinkageProblemCauseAnnotator.annotate(classPathResult, linkageProblems);
+          linkageProblems = LinkageProblemCauseAnnotator.annotate(classPathResult, linkageProblems);
         }
 
         Path writeAsExclusionFile = linkageCheckerArguments.getOutputExclusionFile();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageProblem.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -60,6 +58,18 @@ public abstract class LinkageProblem {
     this.symbol =
         symbol instanceof SuperClassSymbol ? new ClassSymbol(symbol.getClassBinaryName()) : symbol;
     this.sourceClass = Preconditions.checkNotNull(sourceClass);
+    this.cause = null;
+  }
+
+  protected LinkageProblem(
+      String symbolProblemMessage,
+      ClassFile sourceClass,
+      Symbol symbol,
+      LinkageProblemCause cause) {
+    this.symbolProblemMessage = symbolProblemMessage;
+    this.symbol = symbol;
+    this.sourceClass = sourceClass;
+    this.cause = cause;
   }
 
   /** Returns the target symbol that was not resolved. */
@@ -72,9 +82,7 @@ public abstract class LinkageProblem {
     return sourceClass;
   }
 
-  void setCause(LinkageProblemCause cause) {
-    this.cause = checkNotNull(cause);
-  }
+  abstract LinkageProblem withCause(LinkageProblemCause cause);
 
   LinkageProblemCause getCause() {
     return cause;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolNotFoundProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/SymbolNotFoundProblem.java
@@ -21,7 +21,18 @@ package com.google.cloud.tools.opensource.classpath;
  * the symbol.
  */
 public final class SymbolNotFoundProblem extends IncompatibleLinkageProblem {
+
   public SymbolNotFoundProblem(ClassFile sourceClass, ClassFile targetClass, Symbol symbol) {
-    super("is not found", sourceClass, targetClass, symbol);
+    this(sourceClass, targetClass, symbol, null);
+  }
+
+  private SymbolNotFoundProblem(
+      ClassFile sourceClass, ClassFile targetClass, Symbol symbol, LinkageProblemCause cause) {
+    super("is not found", sourceClass, targetClass, symbol, cause);
+  }
+
+  @Override
+  LinkageProblem withCause(LinkageProblemCause cause) {
+    return new SymbolNotFoundProblem(getSourceClass(), getTargetClass(), getSymbol(), cause);
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageProblemCauseAnnotatorTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageProblemCauseAnnotatorTest.java
@@ -82,9 +82,10 @@ public class LinkageProblemCauseAnnotatorTest {
     SymbolNotFoundProblem problem = (SymbolNotFoundProblem) foundProblem.get();
     assertEquals("verify", ((MethodSymbol) problem.getSymbol()).getName());
 
-    LinkageProblemCauseAnnotator.annotate(classPathResult, ImmutableSet.of(problem));
+    ImmutableSet<LinkageProblem> annotated =
+        LinkageProblemCauseAnnotator.annotate(classPathResult, ImmutableSet.of(problem));
 
-    LinkageProblemCause cause = problem.getCause();
+    LinkageProblemCause cause = annotated.iterator().next().getCause();
     assertTrue(cause instanceof DependencyConflict);
     DependencyPath pathToSelectedArtifact =
         ((DependencyConflict) cause).getPathToSelectedArtifact();
@@ -126,9 +127,10 @@ public class LinkageProblemCauseAnnotatorTest {
                 autoServiceEntry, "com.google.auto.service.processor.AutoServiceProcessor"),
             new ClassSymbol("com.google.auto.service.AutoService"));
 
-    LinkageProblemCauseAnnotator.annotate(classPathResult, ImmutableSet.of(problem));
+    ImmutableSet<LinkageProblem> annotated =
+        LinkageProblemCauseAnnotator.annotate(classPathResult, ImmutableSet.of(problem));
 
-    LinkageProblemCause cause = problem.getCause();
+    LinkageProblemCause cause = annotated.iterator().next().getCause();
     assertEquals(ExcludedDependency.class, cause.getClass());
     ExcludedDependency excludedDependency = (ExcludedDependency) cause;
     DependencyPath pathToMissingArtifact = excludedDependency.getPathToMissingArtifact();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageProblemCauseAnnotatorTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageProblemCauseAnnotatorTest.java
@@ -48,9 +48,10 @@ public class LinkageProblemCauseAnnotatorTest {
             new ClassFile(dom4jEntry, "org.dom4j.DocumentHelper"),
             new ClassSymbol("org.jaxen.VariableContext"));
 
-    LinkageProblemCauseAnnotator.annotate(classPathResult, ImmutableSet.of(problem));
+    ImmutableSet<LinkageProblem> annotated =
+        LinkageProblemCauseAnnotator.annotate(classPathResult, ImmutableSet.of(problem));
 
-    LinkageProblemCause cause = problem.getCause();
+    LinkageProblemCause cause = annotated.iterator().next().getCause();
     assertEquals(MissingDependency.class, cause.getClass());
     DependencyPath pathToMissingArtifact = ((MissingDependency) cause).getPathToMissingArtifact();
     Artifact leaf = pathToMissingArtifact.getLeaf();


### PR DESCRIPTION
Followup of  https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/1555#discussion_r465093781 .

LinkageProblem's cause field has been mutable because we do not know the cause when we create LinkageProblem instances. This PR makes it final to make the class immutable.