### PR TITLE
Cont. of The Gradle plugin to show the cause of linkage problems

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageProblemCauseAnnotator.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageProblemCauseAnnotator.java
@@ -25,6 +25,8 @@ import org.eclipse.aether.artifact.Artifact;
 /** Annotates {@link LinkageProblem}s with {@link LinkageProblemCause}s. */
 public final class LinkageProblemCauseAnnotator {
 
+  private LinkageProblemCauseAnnotator() {}
+
   /**
    * Annotates the cause field of {@link LinkageProblem}s with the {@link LinkageProblemCause}.
    *
@@ -32,7 +34,7 @@ public final class LinkageProblemCauseAnnotator {
    * @param linkageProblems linkage problems to annotate
    * @throws IOException when there is a problem reading JAR files
    */
-  static void annotate(ClassPathResult rootResult, Iterable<LinkageProblem> linkageProblems)
+  public static void annotate(ClassPathResult rootResult, Iterable<LinkageProblem> linkageProblems)
       throws IOException {
 
     Map<Artifact, ClassPathResult> cache = new HashMap<>();

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
@@ -254,7 +254,7 @@ public class DependencyGraph {
     while (!queue.isEmpty()) {
       LevelOrderQueueItem<DependencyNode> item = queue.poll();
       DependencyNode dependencyNode = item.getNode();
-  
+
       DependencyPath parentPath = item.getParentPath();
       Artifact artifact = dependencyNode.getArtifact();
       if (artifact != null && parentPath != null) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
@@ -16,11 +16,7 @@
 
 package com.google.cloud.tools.opensource.dependencies;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.SetMultimap;
-import com.google.common.collect.TreeMultimap;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,9 +29,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.graph.DependencyNode;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.TreeMultimap;
 
 /**
  * A complete non-cyclic transitive dependency graph of a Maven dependency.
@@ -315,7 +317,7 @@ public class DependencyGraph {
       graph.parentToChildren.put(parentPath, path);
 
       for (DependencyNode child : dependencyNode.getChildren()) {
-        queue.add(new DependencyGraph.LevelOrderQueueItem(child, path));
+        queue.add(new DependencyGraph.LevelOrderQueueItem<>(child, path));
       }
     }
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
@@ -52,28 +52,6 @@ import com.google.common.collect.TreeMultimap;
  */
 public class DependencyGraph {
 
-  public static final class LevelOrderQueueItem<T> {
-    final T dependencyNode;
-
-    // Null for the first item
-    final DependencyPath parentPath;
-
-    /** Returns the node in the graph traversal. */
-    public T getDependencyNode() {
-      return dependencyNode;
-    }
-
-    /** Returns the path from the root of the graph to the parent of the node. */
-    public DependencyPath getParentPath() {
-      return parentPath;
-    }
-
-    public LevelOrderQueueItem(T dependencyNode, DependencyPath parentPath) {
-      this.dependencyNode = dependencyNode;
-      this.parentPath = parentPath;
-    }
-  }
-
   // DependencyGraphBuilder builds this in breadth first order, unless explicitly stated otherwise.
   // That is, this list contains the paths to each node in breadth first order 
   private final List<DependencyPath> graph = new ArrayList<>();
@@ -270,14 +248,14 @@ public class DependencyGraph {
 
   // this modifies the argument
   private static void levelOrder(DependencyGraph graph) {
-    Queue<DependencyGraph.LevelOrderQueueItem<DependencyNode>> queue = new ArrayDeque<>();
-    queue.add(new DependencyGraph.LevelOrderQueueItem<>(graph.root, null));
+    Queue<LevelOrderQueueItem<DependencyNode>> queue = new ArrayDeque<>();
+    queue.add(new LevelOrderQueueItem<>(graph.root, null));
 
     while (!queue.isEmpty()) {
-      DependencyGraph.LevelOrderQueueItem<DependencyNode> item = queue.poll();
-      DependencyNode dependencyNode = item.dependencyNode;
+      LevelOrderQueueItem<DependencyNode> item = queue.poll();
+      DependencyNode dependencyNode = item.getNode();
   
-      DependencyPath parentPath = item.parentPath;
+      DependencyPath parentPath = item.getParentPath();
       Artifact artifact = dependencyNode.getArtifact();
       if (artifact != null && parentPath != null) {
         // When requesting dependencies of 2 or more artifacts, root DependencyNode's artifact is
@@ -316,7 +294,7 @@ public class DependencyGraph {
       graph.parentToChildren.put(parentPath, path);
 
       for (DependencyNode child : dependencyNode.getChildren()) {
-        queue.add(new DependencyGraph.LevelOrderQueueItem<>(child, path));
+        queue.add(new LevelOrderQueueItem<>(child, path));
       }
     }
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/DependencyGraph.java
@@ -33,7 +33,6 @@ import java.util.Set;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.graph.DependencyNode;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.SetMultimap;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/LevelOrderQueueItem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/LevelOrderQueueItem.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.dependencies;
+
+/**
+ * The item in the queue for the level order graph traversal when constructing {@link
+ * DependencyGraph}.
+ *
+ * @param <T> The type of the input graph node. It's {@code DependencyNode} for Maven's graphand
+ * {@code ResolvedDependency} for Gradle's graph.
+ */
+public final class LevelOrderQueueItem<T> {
+  private final T node;
+
+  // This may be null for the root
+  private final DependencyPath parentPath;
+
+  /** Returns the node in the graph traversal. */
+  public T getNode() {
+    return node;
+  }
+
+  /** Returns the path from the root of the graph to the parent of the node. */
+  public DependencyPath getParentPath() {
+    return parentPath;
+  }
+
+  public LevelOrderQueueItem(T node, DependencyPath parentPath) {
+    this.node = node;
+    this.parentPath = parentPath;
+  }
+}

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/LevelOrderQueueItem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/LevelOrderQueueItem.java
@@ -16,12 +16,14 @@
 
 package com.google.cloud.tools.opensource.dependencies;
 
+import java.util.Objects;
+
 /**
  * The item in the queue for the level order graph traversal when constructing {@link
  * DependencyGraph}.
  *
  * @param <T> The type of the input graph node. It's {@code DependencyNode} for Maven's graphand
- * {@code ResolvedDependency} for Gradle's graph.
+ *     {@code ResolvedDependency} for Gradle's graph.
  */
 public final class LevelOrderQueueItem<T> {
   private final T node;
@@ -42,5 +44,22 @@ public final class LevelOrderQueueItem<T> {
   public LevelOrderQueueItem(T node, DependencyPath parentPath) {
     this.node = node;
     this.parentPath = parentPath;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    LevelOrderQueueItem<?> that = (LevelOrderQueueItem<?>) other;
+    return Objects.equals(node, that.node) && Objects.equals(parentPath, that.parentPath);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(node, parentPath);
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/LevelOrderQueueItem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/LevelOrderQueueItem.java
@@ -19,10 +19,9 @@ package com.google.cloud.tools.opensource.dependencies;
 import java.util.Objects;
 
 /**
- * The item in the queue for the level order graph traversal when constructing {@link
- * DependencyGraph}.
+ * The item in the queue for the graph traversal when constructing {@link DependencyGraph}.
  *
- * @param <T> The type of the input graph node. It's {@code DependencyNode} for Maven's graphand
+ * @param <T> The type of the input graph node. It's {@code DependencyNode} for Maven's graph and
  *     {@code ResolvedDependency} for Gradle's graph.
  */
 public final class LevelOrderQueueItem<T> {

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/LevelOrderQueueItemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/LevelOrderQueueItemTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.dependencies;
+
+import com.google.common.testing.EqualsTester;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+import org.junit.Test;
+
+public class LevelOrderQueueItemTest {
+
+  @Test
+  public void testEquality() {
+    Artifact foo = new DefaultArtifact("com.google:foo:1");
+    Artifact bar = new DefaultArtifact("com.google:bar:1");
+    DependencyPath path1 = new DependencyPath(null).append(new Dependency(foo, "compile"));
+    DependencyPath path2 =
+        new DependencyPath(null)
+            .append(new Dependency(foo, "compile"))
+            .append(new Dependency(bar, "compile"));
+
+    new EqualsTester()
+        .addEqualityGroup(new LevelOrderQueueItem<>(1, path1), new LevelOrderQueueItem<>(1, path1))
+        .addEqualityGroup(new LevelOrderQueueItem<>(1, path2))
+        .addEqualityGroup(new LevelOrderQueueItem<>(2, path2), new LevelOrderQueueItem<>(2, path2))
+        .testEquals();
+  }
+}

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -23,8 +23,13 @@ linkage-checker-gradle-plugin-0.1.0-SNAPSHOT.pom
 ./gradlew check --stacktrace  -Dorg.gradle.debug=true --no-daemon
 ```
 
-## Debugging Tests
-For IntelliJ, install Spock Framework Enhancement to add breakpoints in the Groovy scripts.
+## Debugging Functional Tests (src/functionalTest)
 
-To enable break points in Java code during the functional tests, add
-`-Dorg.gradle.testkit.debug=true` to the VM argument.
+To enable break points in the Groovy scripts in IntelliJ, install 'Spock Framework Enhancement'.
+
+To enable break points in the Java code of the Gradle plugin during the functional tests, add
+`-Dorg.gradle.testkit.debug=true` to the VM argument (
+[Testing Build Logic with TestKit: Debugging build logic](
+https://docs.gradle.org/current/userguide/test_kit.html#sub:test-kit-debug)).
+When you see IntelliJ has outdated class files, run `./gradlew build publishToMavenLocal` to
+reflect the latest code.

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -28,7 +28,7 @@ group = 'com.google.cloud.tools'
 sourceCompatibility = 1.8
 
 dependencies {
-  implementation 'com.google.cloud.tools:dependencies:1.4.3'
+  implementation 'com.google.cloud.tools:dependencies:latest.integration'
   implementation 'com.google.guava:guava:29.0-jre'
   implementation 'org.apache.maven.resolver:maven-resolver-api:1.4.2'
 

--- a/gradle-plugin/src/functionalTest/groovy/com/google/cloud/tools/dependencies/gradle/BuildStatusFunctionalTest.groovy
+++ b/gradle-plugin/src/functionalTest/groovy/com/google/cloud/tools/dependencies/gradle/BuildStatusFunctionalTest.groovy
@@ -98,7 +98,13 @@ class BuildStatusFunctionalTest extends Specification {
         .buildAndFail()
 
     then:
-    result.output.contains("Class io.grpc.internal.BaseDnsNameResolverProvider is not found")
+    result.output.contains('''Class io.grpc.internal.BaseDnsNameResolverProvider is not found;
+        |  referenced by 1 class file
+        |    io.grpc.grpclb.SecretGrpclbNameResolverProvider (io.grpc:grpc-grpclb:1.28.1)
+        |  Cause:
+        |    Dependency conflict: io.grpc:grpc-core:1.29.0 does not define Class io.grpc.internal.BaseDnsNameResolverProvider but io.grpc:grpc-core:1.28.1 defines it.
+        |      selected: io.grpc:grpc-core:1.29.0 (compile)
+        |      unselected: com.google.cloud:google-cloud-logging:1.101.1 (compile) / com.google.api:gax-grpc:1.56.0 (compile) / io.grpc:grpc-alts:1.28.1 (compile) / io.grpc:grpc-grpclb:1.28.1 (compile) / io.grpc:grpc-core:1.28.1 (compile)'''.stripMargin())
 
     result.output.contains("Problematic artifacts in the dependency tree:")
     result.output.contains("""

--- a/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/LinkageCheckTask.java
+++ b/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/LinkageCheckTask.java
@@ -27,8 +27,8 @@ import com.google.cloud.tools.opensource.classpath.LinkageProblem;
 import com.google.cloud.tools.opensource.classpath.LinkageProblemCauseAnnotator;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
-import com.google.cloud.tools.opensource.dependencies.DependencyGraph.LevelOrderQueueItem;
 import com.google.cloud.tools.opensource.dependencies.DependencyPath;
+import com.google.cloud.tools.opensource.dependencies.LevelOrderQueueItem;
 import com.google.cloud.tools.opensource.dependencies.UnresolvableArtifactProblem;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
@@ -301,7 +301,7 @@ public class LinkageCheckTask extends DefaultTask {
     Set<ResolvedDependency> visited = new HashSet<>();
     while (!queue.isEmpty()) {
       LevelOrderQueueItem<ResolvedDependency> item = queue.poll();
-      ResolvedDependency node = item.getDependencyNode();
+      ResolvedDependency node = item.getNode();
 
       DependencyPath parentPath = item.getParentPath();
 

--- a/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/LinkageCheckTask.java
+++ b/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/LinkageCheckTask.java
@@ -113,10 +113,6 @@ public class LinkageCheckTask extends DefaultTask {
         createClassPathResult(configuration.getResolvedConfiguration());
     ImmutableList.Builder<ClassPathEntry> classPathBuilder = ImmutableList.builder();
 
-    DependencyGraph graph = createDependencyGraph(configuration.getResolvedConfiguration());
-
-    // TODO(suztomo): Should this include optional dependencies?
-    //  Once we decide what to do with the optional dependencies, let's revisit this logic.
     for (ResolvedArtifact resolvedArtifact :
         configuration.getResolvedConfiguration().getResolvedArtifacts()) {
       ModuleVersionIdentifier moduleVersionId = resolvedArtifact.getModuleVersion().getId();
@@ -286,11 +282,12 @@ public class LinkageCheckTask extends DefaultTask {
   }
 
   private static DependencyGraph createDependencyGraph(ResolvedConfiguration configuration) {
-    // Why this method is not part of DependencyGraph? Because dependencies module DependencyGraph
-    // belongs to is Maven project and Gradle does not provide good Maven artifacts to develop
-    // code with Gradle-related class in Maven.
+    // Why this method is not part of the DependencyGraph? Because the dependencies module
+    // which the DependencyGraph belongs to is a Maven project, and Gradle does not provide good
+    // Maven artifacts to develop code with Gradle-related classes.
+    // For the details, see https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1556
 
-    // What's the root of the graph for Gradle? I think it's the project's artifact. Does it exist?
+    // The root Gradle project is not available in `configuration`.
     DependencyGraph graph = new DependencyGraph(null);
 
     ArrayDeque<LevelOrderQueueItem<ResolvedDependency>> queue = new ArrayDeque<>();

--- a/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/LinkageCheckTask.java
+++ b/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/LinkageCheckTask.java
@@ -20,27 +20,38 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.google.cloud.tools.opensource.classpath.ClassFile;
 import com.google.cloud.tools.opensource.classpath.ClassPathEntry;
+import com.google.cloud.tools.opensource.classpath.ClassPathResult;
+import com.google.cloud.tools.opensource.classpath.IncompatibleLinkageProblem;
 import com.google.cloud.tools.opensource.classpath.LinkageChecker;
-import com.google.cloud.tools.opensource.classpath.SymbolProblem;
+import com.google.cloud.tools.opensource.classpath.LinkageProblem;
+import com.google.cloud.tools.opensource.classpath.LinkageProblemCauseAnnotator;
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
+import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
+import com.google.cloud.tools.opensource.dependencies.DependencyGraph.LevelOrderQueueItem;
+import com.google.cloud.tools.opensource.dependencies.DependencyPath;
+import com.google.cloud.tools.opensource.dependencies.UnresolvableArtifactProblem;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Multimap;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayDeque;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.ResolvedConfiguration;
+import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
@@ -97,7 +108,12 @@ public class LinkageCheckTask extends DefaultTask {
 
   /** Returns true iff {@code configuration}'s artifacts contain linkage errors. */
   private boolean findLinkageErrors(Configuration configuration) throws IOException {
+
+    ClassPathResult classPathResult =
+        createClassPathResult(configuration.getResolvedConfiguration());
     ImmutableList.Builder<ClassPathEntry> classPathBuilder = ImmutableList.builder();
+
+    DependencyGraph graph = createDependencyGraph(configuration.getResolvedConfiguration());
 
     // TODO(suztomo): Should this include optional dependencies?
     //  Once we decide what to do with the optional dependencies, let's revisit this logic.
@@ -130,22 +146,24 @@ public class LinkageCheckTask extends DefaultTask {
       // TODO(suztomo): Specify correct entry points if reportOnlyReachable is true.
       LinkageChecker linkageChecker = LinkageChecker.create(classPath, classPath, exclusionFile);
 
-      ImmutableSetMultimap<SymbolProblem, ClassFile> symbolProblems =
-          linkageChecker.findSymbolProblems();
+      ImmutableSet<LinkageProblem> linkageProblems = linkageChecker.findLinkageProblems();
 
-      int errorCount = symbolProblems.keySet().size();
+      LinkageProblemCauseAnnotator.annotate(classPathResult, linkageProblems);
+
+      int errorCount = linkageProblems.size();
 
       // TODO(suztomo): Show the dependency paths to the problematic artifacts.
       if (errorCount > 0) {
-        getLogger().error(
-            "Linkage Checker rule found {} error{}. Linkage error report:\n{}",
-            errorCount,
-            errorCount > 1 ? "s" : "",
-            SymbolProblem.formatSymbolProblems(symbolProblems));
+        getLogger()
+            .error(
+                "Linkage Checker rule found {} error{}. Linkage error report:\n{}",
+                errorCount,
+                errorCount > 1 ? "s" : "",
+                LinkageProblem.formatLinkageProblems(linkageProblems));
 
         ResolutionResult result = configuration.getIncoming().getResolutionResult();
         ResolvedComponentResult root = result.getRoot();
-        String dependencyPaths = dependencyPathsOfProblematicJars(root, symbolProblems);
+        String dependencyPaths = dependencyPathsOfProblematicJars(root, linkageProblems);
         getLogger().error(dependencyPaths);
         getLogger()
             .info(
@@ -159,17 +177,17 @@ public class LinkageCheckTask extends DefaultTask {
   }
 
   private String dependencyPathsOfProblematicJars(
-      ResolvedComponentResult componentResult, Multimap<SymbolProblem, ClassFile> symbolProblems) {
+      ResolvedComponentResult componentResult, Set<LinkageProblem> symbolProblems) {
     ImmutableSet.Builder<ClassPathEntry> problematicJars = ImmutableSet.builder();
-    for (SymbolProblem problem : symbolProblems.keySet()) {
-      ClassFile containingClass = problem.getContainingClass();
-      if (containingClass != null) {
-        problematicJars.add(containingClass.getClassPathEntry());
+    for (LinkageProblem problem : symbolProblems) {
+
+      if (problem instanceof IncompatibleLinkageProblem) {
+        ClassFile targetClass = ((IncompatibleLinkageProblem) problem).getTargetClass();
+        problematicJars.add(targetClass.getClassPathEntry());
       }
 
-      for (ClassFile classFile : symbolProblems.get(problem)) {
-        problematicJars.add(classFile.getClassPathEntry());
-      }
+      ClassFile sourceClass = problem.getSourceClass();
+      problematicJars.add(sourceClass.getClassPathEntry());
     }
 
     return "Problematic artifacts in the dependency tree:\n"
@@ -245,5 +263,78 @@ public class LinkageCheckTask extends DefaultTask {
     }
 
     return output.toString();
+  }
+
+  private static Artifact artifactFrom(ResolvedDependency resolvedDependency) {
+    ModuleVersionIdentifier moduleVersionId = resolvedDependency.getModule().getId();
+    File file = resolvedDependency.getModuleArtifacts().iterator().next().getFile();
+    DefaultArtifact artifact =
+        new DefaultArtifact(
+            moduleVersionId.getGroup(),
+            moduleVersionId.getName(),
+            null,
+            null,
+            moduleVersionId.getVersion(),
+            null,
+            file);
+    return artifact;
+  }
+
+  private static Dependency dependencyFrom(ResolvedDependency resolvedDependency) {
+    Artifact artifact = artifactFrom(resolvedDependency);
+    return new Dependency(artifact, "compile");
+  }
+
+  private static DependencyGraph createDependencyGraph(ResolvedConfiguration configuration) {
+    // Why this method is not part of DependencyGraph? Because dependencies module DependencyGraph
+    // belongs to is Maven project and Gradle does not provide good Maven artifacts to develop
+    // code with Gradle-related class in Maven.
+
+    // What's the root of the graph for Gradle? I think it's the project's artifact. Does it exist?
+    DependencyGraph graph = new DependencyGraph(null);
+
+    ArrayDeque<LevelOrderQueueItem<ResolvedDependency>> queue = new ArrayDeque<>();
+
+    DependencyPath root = new DependencyPath(null);
+    for (ResolvedDependency firstLevelDependency :
+        configuration.getFirstLevelModuleDependencies()) {
+      queue.add(new LevelOrderQueueItem<>(firstLevelDependency, root));
+    }
+
+    Set<ResolvedDependency> visited = new HashSet<>();
+    while (!queue.isEmpty()) {
+      LevelOrderQueueItem<ResolvedDependency> item = queue.poll();
+      ResolvedDependency node = item.getDependencyNode();
+
+      DependencyPath parentPath = item.getParentPath();
+
+      // parentPath is null for the first item
+      DependencyPath path =
+          parentPath == null
+              ? new DependencyPath(artifactFrom(node))
+              : parentPath.append(dependencyFrom(node));
+
+      graph.addPath(path);
+
+      for (ResolvedDependency child : node.getChildren()) {
+        if (visited.add(child)) {
+          queue.add(new LevelOrderQueueItem<>(child, path));
+        }
+      }
+    }
+
+    return graph;
+  }
+
+  private static ClassPathResult createClassPathResult(ResolvedConfiguration configuration) {
+    DependencyGraph dependencyGraph = createDependencyGraph(configuration);
+    ImmutableListMultimap.Builder<ClassPathEntry, DependencyPath> builder =
+        ImmutableListMultimap.builder();
+    ImmutableList.Builder<UnresolvableArtifactProblem> problems = ImmutableList.builder();
+    for (DependencyPath path : dependencyGraph.list()) {
+      Artifact artifact = path.getLeaf();
+      builder.put(new ClassPathEntry(artifact), path);
+    }
+    return new ClassPathResult(builder.build(), problems.build());
   }
 }

--- a/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/LinkageCheckTask.java
+++ b/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/LinkageCheckTask.java
@@ -327,11 +327,11 @@ public class LinkageCheckTask extends DefaultTask {
     DependencyGraph dependencyGraph = createDependencyGraph(configuration);
     ImmutableListMultimap.Builder<ClassPathEntry, DependencyPath> builder =
         ImmutableListMultimap.builder();
-    ImmutableList.Builder<UnresolvableArtifactProblem> problems = ImmutableList.builder();
+
     for (DependencyPath path : dependencyGraph.list()) {
       Artifact artifact = path.getLeaf();
       builder.put(new ClassPathEntry(artifact), path);
     }
-    return new ClassPathResult(builder.build(), problems.build());
+    return new ClassPathResult(builder.build(), ImmutableList.of());
   }
 }


### PR DESCRIPTION
Cont of https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/1555, without touching LinkageProblem's immutability.

Gradle plugin to construct `com.google.cloud.tools.opensource.dependencies.DependencyGraph`. LinkageProblemCauseAnnotator uses this graph to explain the cause of linkage problems.