### PR TITLE
The Gradle plugin to use dependencies module 1.5.0

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -28,7 +28,7 @@ group = 'com.google.cloud.tools'
 sourceCompatibility = 1.8
 
 dependencies {
-  implementation 'com.google.cloud.tools:dependencies:latest.integration'
+  implementation 'com.google.cloud.tools:dependencies:1.5.0'
   implementation 'com.google.guava:guava:29.0-jre'
   implementation 'org.apache.maven.resolver:maven-resolver-api:1.4.2'
 


### PR DESCRIPTION
(This might fail until the newly released module is arrives Gradle's repository)

Closes ##1554.