### PR TITLE
Gradle plugin release script fix

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -84,5 +84,5 @@ release {
   }
 }
 
-System.setProperty('gradle.publish.key', project.properties['gradle.publish.key'] ?: '')
-System.setProperty('gradle.publish.secret', project.properties['gradle.publish.secret'] ?: '')
+// System.setProperty('gradle.publish.key', project.properties['gradle.publish.key'] ?: '')
+// System.setProperty('gradle.publish.secret', project.properties['gradle.publish.secret'] ?: '')

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -83,3 +83,6 @@ release {
     requireBranch = /^\d+.\d+.\d+-gradle$/  //regex
   }
 }
+
+System.setProperty('gradle.publish.key', project.properties['gradle.publish.key'] ?: '')
+System.setProperty('gradle.publish.secret', project.properties['gradle.publish.secret'] ?: '')

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -83,6 +83,3 @@ release {
     requireBranch = /^\d+.\d+.\d+-gradle$/  //regex
   }
 }
-
-// System.setProperty('gradle.publish.key', project.properties['gradle.publish.key'] ?: '')
-// System.setProperty('gradle.publish.secret', project.properties['gradle.publish.secret'] ?: '')

--- a/gradle-plugin/kokoro/release.sh
+++ b/gradle-plugin/kokoro/release.sh
@@ -5,14 +5,15 @@ set -o xtrace
 
 mkdir -p $HOME/.gradle
 readonly HOME_GRADLE_PROPERTY="$HOME/.gradle/gradle.properties"
-export GRADLE_USER_HOME=$HOME/.gradle
+export GRADLE_USER_HOME="$HOME/.gradle"
 
 # Recommended way to store API key in
 # https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/
 # and go/yaqs/5342701566951424 for ISE check.
-echo -n 'systemProp.gradle.publish.key=' >> $HOME_GRADLE_PROPERTY
+echo -n 'gradle.publish.key=' >> $HOME_GRADLE_PROPERTY
 cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_key" >> $HOME_GRADLE_PROPERTY
-echo -n 'systemProp.gradle.publish.secret=' >> $HOME_GRADLE_PROPERTY
+echo >> $HOME_GRADLE_PROPERTY
+echo -n 'gradle.publish.secret=' >> $HOME_GRADLE_PROPERTY
 cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_secret" >> $HOME_GRADLE_PROPERTY
 
 
@@ -22,4 +23,4 @@ cat $HOME_GRADLE_PROPERTY >> gradle.properties
 
 ./gradlew build
 
-./gradlew publishPlugins --debug --stacktrace
+./gradlew -Dgradle.user.home="$GRADLE_USER_HOME" publishPlugins --debug --stacktrace

--- a/gradle-plugin/kokoro/release.sh
+++ b/gradle-plugin/kokoro/release.sh
@@ -10,9 +10,9 @@ export GRADLE_USER_HOME=$HOME/.gradle
 # Recommended way to store API key in
 # https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/
 # and go/yaqs/5342701566951424 for ISE check.
-echo -n 'gradle.publish.key=' >> $HOME_GRADLE_PROPERTY
+echo -n 'systemProp.gradle.publish.key=' >> $HOME_GRADLE_PROPERTY
 cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_key" >> $HOME_GRADLE_PROPERTY
-echo -n 'gradle.publish.secret=' >> $HOME_GRADLE_PROPERTY
+echo -n 'systemProp.gradle.publish.secret=' >> $HOME_GRADLE_PROPERTY
 cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_secret" >> $HOME_GRADLE_PROPERTY
 
 

--- a/gradle-plugin/kokoro/release.sh
+++ b/gradle-plugin/kokoro/release.sh
@@ -4,8 +4,7 @@ set -o errexit
 set -o xtrace
 
 mkdir -p $HOME/.gradle
-export GRADLE_USER_HOME="$HOME/.gradle"
-readonly HOME_GRADLE_PROPERTY="${GRADLE_USER_HOME}/gradle.properties"
+readonly HOME_GRADLE_PROPERTY="$HOME/.gradle/gradle.properties"
 
 # Recommended way to store API key in
 # https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/
@@ -16,12 +15,8 @@ echo >> $HOME_GRADLE_PROPERTY
 echo -n 'gradle.publish.secret=' >> $HOME_GRADLE_PROPERTY
 cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_secret" >> $HOME_GRADLE_PROPERTY
 
-
 cd github/cloud-opensource-java/gradle-plugin
-
-# cat $HOME_GRADLE_PROPERTY >> gradle.properties
 
 ./gradlew build
 
-./gradlew -Dgradle.user.home="${GRADLE_USER_HOME}" publishPlugins --debug --stacktrace
-
+./gradlew publishPlugins --info --stacktrace

--- a/gradle-plugin/kokoro/release.sh
+++ b/gradle-plugin/kokoro/release.sh
@@ -4,7 +4,8 @@ set -o errexit
 set -o xtrace
 
 mkdir -p $HOME/.gradle
-readonly HOME_GRADLE_PROPERTY="$HOME/.gradle/gradle.properties"
+export GRADLE_USER_HOME="$HOME/.gradle"
+readonly HOME_GRADLE_PROPERTY="$GRADLE_USER_HOME/gradle.properties"
 
 # Recommended way to store API key in
 # https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/

--- a/gradle-plugin/kokoro/release.sh
+++ b/gradle-plugin/kokoro/release.sh
@@ -5,6 +5,7 @@ set -o xtrace
 
 mkdir -p $HOME/.gradle
 readonly HOME_GRADLE_PROPERTY="$HOME/.gradle/gradle.properties"
+export GRADLE_USER_HOME=$HOME/.gradle
 
 # Recommended way to store API key in
 # https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/

--- a/gradle-plugin/kokoro/release.sh
+++ b/gradle-plugin/kokoro/release.sh
@@ -22,4 +22,4 @@ cat $HOME_GRADLE_PROPERTY >> gradle.properties
 
 ./gradlew build
 
-./gradlew publishPlugins --info --stacktrace
+./gradlew publishPlugins --debug --stacktrace

--- a/gradle-plugin/kokoro/release.sh
+++ b/gradle-plugin/kokoro/release.sh
@@ -4,8 +4,8 @@ set -o errexit
 set -o xtrace
 
 mkdir -p $HOME/.gradle
-readonly HOME_GRADLE_PROPERTY="$HOME/.gradle/gradle.properties"
 export GRADLE_USER_HOME="$HOME/.gradle"
+readonly HOME_GRADLE_PROPERTY="${GRADLE_USER_HOME}/gradle.properties"
 
 # Recommended way to store API key in
 # https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/
@@ -19,8 +19,9 @@ cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_secret" >> $HOME_GRADLE_PROPERT
 
 cd github/cloud-opensource-java/gradle-plugin
 
-cat $HOME_GRADLE_PROPERTY >> gradle.properties
+# cat $HOME_GRADLE_PROPERTY >> gradle.properties
 
 ./gradlew build
 
-./gradlew -Dgradle.user.home="$GRADLE_USER_HOME" publishPlugins --debug --stacktrace
+./gradlew -Dgradle.user.home="${GRADLE_USER_HOME}" publishPlugins --debug --stacktrace
+

--- a/gradle-plugin/kokoro/release.sh
+++ b/gradle-plugin/kokoro/release.sh
@@ -15,7 +15,10 @@ cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_key" >> $HOME_GRADLE_PROPERTY
 echo -n 'gradle.publish.secret=' >> $HOME_GRADLE_PROPERTY
 cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_secret" >> $HOME_GRADLE_PROPERTY
 
+
 cd github/cloud-opensource-java/gradle-plugin
+
+cat $HOME_GRADLE_PROPERTY >> gradle.properties
 
 ./gradlew build
 


### PR DESCRIPTION
#1519 had two issues

- The gradle property file needs a new line character to split the two variable
- Gradle needs the `GRADLE_USER_HOME` environment variable. (The default value uses `USER_HOME`, which is usually undefined)

I confirmed that this change #1575 worked good in Rapid.