### PR TITLE
Clarify that the use of version properties for a single artifact is a…

### DIFF
--- a/docs/JLBP-0016.md
+++ b/docs/JLBP-0016.md
@@ -61,6 +61,10 @@ accidentally depend on different versions in different modules.
   - The second option is to use version properties in the parent that are
     referenced by child modules.
 
+    This option should only be used in the case where you have multiple
+    artifacts that need align on the same version and the producers
+    of those artifacts have not provided a BOM.
+
     When declaring a dependency anywhere in the project, use the Maven
     property declared in the parent.
 


### PR DESCRIPTION
…n anti-pattern

Version properties have side-effects, when you have two different artifacts that need to align on the same version, a version property is less risk than duplication of the version number... a BOM would have been better, but if the producers of your dependencies have not seen fit to provide a BOM...

Having a version property that is used against one and only one `groupId:artifactId` (unless say you need to place that dependency within a `/project/build/plugins/plugin/dependencies`) exposes greater risks and complicates the pom unnecessarily