### PR TITLE
Adding the invalid reference from tools.jar into the default exclusion rule

### DIFF
--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -71,4 +71,18 @@
       https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1296
     </Reason>
   </LinkageError>
+  <LinkageError>
+    <Target>
+      <Class name="com.sun.xml.internal.ws.api.BindingID$SOAPHTTPImpl" />
+    </Target>
+    <Source>
+      <Class name="com.sun.tools.internal.ws.wscompile.WsgenOptions" />
+    </Source>
+    <Reason>
+      The source class in tools.jar has invalid reference to the target class in rt.jar. Because
+      Linkage Checker users cannot take any action on the invalid reference, we suppress the linkage
+      error.
+      https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1599
+    </Reason>
+  </LinkageError>
 </LinkageCheckerFilter>

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -38,6 +38,8 @@ import com.google.common.truth.Truth;
 import com.google.common.truth.Truth8;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.cli.ParseException;
@@ -1119,5 +1121,22 @@ public class LinkageCheckerTest {
                 (LinkageProblem problem) -> problem.getSourceClass().getBinaryName(),
                 "has class binary name"))
         .contains("io.grpc.internal.DnsNameResolver");
+  }
+
+  @Test
+  public void testFindLinkageProblems_referenceFromJdkToolsJarClass() throws IOException {
+    // tools.jar contains a linkage error. As it's internal class, Linkage Checker users cannot do
+    // any action on it. The reference is from com.sun.tools.internal.ws.wscompile.WsgenOptions to
+    // com.sun.xml.internal.ws.api.BindingID$SOAPHTTPImpl
+    // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1599
+    String javaHome = System.getProperty("java.home");
+    Path toolsJar = Paths.get(javaHome, "..", "lib","tools.jar");
+    ClassPathEntry entry = new ClassPathEntry(
+        new DefaultArtifact("com.sun:tools:1.8").setFile(toolsJar.toFile())
+    );
+
+    LinkageChecker linkageChecker = LinkageChecker.create(ImmutableList.of(entry));
+    ImmutableSet<LinkageProblem> linkageProblems = linkageChecker.findLinkageProblems();
+    Truth.assertThat(linkageProblems).isEmpty();
   }
 }


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/1602/files tried to check whether a class is from JDK's JAR files (tools.jar). However from the current way to check it via the ClassLoaders, it cannot tell `com.sun.tools.internal.ws.wscompile.WsgenOptions` is from JDK or not.