### PR TITLE
clarify JavaDoc around references

### DIFF
--- a/boms/integration-tests/src/test/java/com/google/cloud/MaximumLinkageErrorsTest.java
+++ b/boms/integration-tests/src/test/java/com/google/cloud/MaximumLinkageErrorsTest.java
@@ -52,7 +52,7 @@ public class MaximumLinkageErrorsTest {
     LinkageChecker checker = LinkageChecker.create(bom);
     ImmutableSet<LinkageProblem> currentProblems = checker.findLinkageProblems();
 
-    // This only tests for newly missing methods, not new references to
+    // This only tests for newly missing methods, not new invocations of
     // previously missing methods.
     SetView<LinkageProblem> newProblems = Sets.difference(currentProblems, oldProblems);
 

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/AbstractMethodProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/AbstractMethodProblem.java
@@ -21,12 +21,12 @@ import com.google.cloud.tools.opensource.dependencies.DependencyPath;
 import org.eclipse.aether.artifact.Artifact;
 
 /**
- * A class does not implement the abstract method declared
- * by its supertype (an interface or an abstract class). Such unimplemented methods manifest as
+ * A class does not implement an abstract method declared by its supertype
+ * (an interface or an abstract class). Such unimplemented methods manifest as
  * {@link AbstractMethodError}s at runtime.
  */
 final class AbstractMethodProblem extends LinkageProblem {
-  MethodSymbol methodSymbol;
+  private MethodSymbol methodSymbol;
 
   AbstractMethodProblem(
       ClassFile implementationClass, MethodSymbol methodSymbol, ClassFile supertype) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/AbstractMethodProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/AbstractMethodProblem.java
@@ -17,7 +17,7 @@
 package com.google.cloud.tools.opensource.classpath;
 
 /**
- * The referenced {@code methodSymbol} is not implemented in the {@code targetClass} but the class
+ * A {@code methodSymbol} is not implemented in the {@code targetClass} but the class
  * is declared to implement the method by {@code sourceClass}. Such unimplemented methods manifest
  * as {@link AbstractMethodError}s at runtime.
  */

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageProblem.java
@@ -65,12 +65,12 @@ public abstract class LinkageProblem {
       this.targetClass = targetClass;
   }
 
-  /** Returns the target symbol that was not resolved. */
+  /** Returns the symbol that was not resolved. */
   public Symbol getSymbol() {
     return symbol;
   }
 
-  /** Returns the source of the invalid reference which this linkage error represents. */
+  /** Returns the class that cannot find a symbol it depends on. */
   public ClassFile getSourceClass() {
     return sourceClass;
   }
@@ -78,8 +78,8 @@ public abstract class LinkageProblem {
   /**
    * Returns the class that is expected to contain the symbol. If the symbol is a method or a field,
    * then this is the class where the symbol was expected to be found. If the symbol is an inner
-   * class, this is the outer class that was expected to contain the inner class. If the target class
-   * is unknown or missing, this is null.
+   * class, this is the outer class that was expected to contain the inner class. If the symbol is
+   * an outer class that is unknown or missing, this is null.
    */
   @Nullable
   public ClassFile getTargetClass() {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageProblem.java
@@ -70,7 +70,7 @@ public abstract class LinkageProblem {
     return symbol;
   }
 
-  /** Returns the class that cannot find a symbol it depends on. */
+  /** Returns the class that contains a symbolic reference to a symbol that is not available. */
   public ClassFile getSourceClass() {
     return sourceClass;
   }


### PR DESCRIPTION
@suztomo less circular definitions