### PR TITLE
Checking Java 8-incompatible references in the latest versions of the artifacts

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/Java8IncompatibleReferenceCheck.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/Java8IncompatibleReferenceCheck.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.opensource.dependencies;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
-import com.google.cloud.tools.opensource.classpath.ClassFile;
 import com.google.cloud.tools.opensource.classpath.ClassPathBuilder;
 import com.google.cloud.tools.opensource.classpath.ClassPathEntry;
 import com.google.cloud.tools.opensource.classpath.ClassPathResult;
@@ -99,24 +98,24 @@ public class Java8IncompatibleReferenceCheck {
 
       LinkageChecker linkageChecker =
           LinkageChecker.create(result.getClassPath(), result.getClassPath(), exclusionFile);
+      /*
+            ImmutableSet<LinkageProblem> linkageProblems = linkageChecker.findLinkageProblems();
 
-      ImmutableSet<LinkageProblem> linkageProblems = linkageChecker.findLinkageProblems();
+            ImmutableSet<LinkageProblem> invalidReferencesToJavaCoreLibrary =
+                linkageProblems.stream()
+                    .filter(Java8IncompatibleReferenceCheck::isReferenceToJdkCoreLibrary)
+                    .collect(toImmutableSet());
 
-      ImmutableSet<LinkageProblem> invalidReferencesToJavaCoreLibrary =
-          linkageProblems.stream()
-              .filter(Java8IncompatibleReferenceCheck::isReferenceToJdkCoreLibrary)
-              .collect(toImmutableSet());
+            if (!invalidReferencesToJavaCoreLibrary.isEmpty()) {
+              invalidReferencesToJavaCoreLibrary.stream()
+                  .map(LinkageProblem::getSourceClass)
+                  .map(ClassFile::getClassPathEntry)
+                  .map(ClassPathEntry::getArtifact)
+                  .forEach(artifact -> problematicDependencies.put(managedDependency, artifact));
 
-      if (!invalidReferencesToJavaCoreLibrary.isEmpty()) {
-        invalidReferencesToJavaCoreLibrary.stream()
-            .map(LinkageProblem::getSourceClass)
-            .map(ClassFile::getClassPathEntry)
-            .map(ClassPathEntry::getArtifact)
-            .forEach(artifact -> problematicDependencies.put(managedDependency, artifact));
-
-        logger.severe(LinkageProblem.formatLinkageProblems(invalidReferencesToJavaCoreLibrary));
-      }
-
+              logger.severe(LinkageProblem.formatLinkageProblems(invalidReferencesToJavaCoreLibrary));
+            }
+      */
       for (ClassPathEntry entry : result.getClassPath()) {
         Artifact artifact = entry.getArtifact();
         if (artifact.getExtension().equals("jar")) {

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtilityTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtilityTest.java
@@ -52,6 +52,16 @@ public class RepositoryUtilityTest {
   }
 
   @Test
+  public void testFindVersions_nonSemanticVersions() throws MavenRepositoryException {
+    RepositorySystem system = RepositoryUtility.newRepositorySystem();
+    ImmutableList<String> versions =
+        RepositoryUtility.findVersions(system, "com.google.apis", "google-api-services-bigquery");
+    Truth.assertThat(versions)
+        .containsAtLeast("v2-rev20200818-1.30.10", "v2-rev20200827-1.30.10")
+        .inOrder(); //
+  }
+
+  @Test
   public void testFindHighestVersions()
       throws MavenRepositoryException, InvalidVersionSpecificationException {
     RepositorySystem system = RepositoryUtility.newRepositorySystem();


### PR DESCRIPTION
In draft.

Somehow it throws NullPointerException upon searching the latest version of some artifacts such as `org.khronos:opengl-api`.

```
Sep 08, 2020 11:29:49 AM com.google.cloud.tools.opensource.dependencies.Java8IncompatibleReferenceCheck main
SEVERE: Failed to find the latest version for com.google.apis:google-api-services-bigquery
Sep 08, 2020 11:29:49 AM com.google.cloud.tools.opensource.dependencies.Java8IncompatibleReferenceCheck main
SEVERE: Failed to find the latest version for com.google.apis:google-api-services-compute
Sep 08, 2020 11:29:49 AM com.google.cloud.tools.opensource.dependencies.Java8IncompatibleReferenceCheck main
SEVERE: Failed to find the latest version for com.google.apis:google-api-services-dns
Sep 08, 2020 11:29:50 AM com.google.cloud.tools.opensource.dependencies.Java8IncompatibleReferenceCheck main
SEVERE: Failed to find the latest version for com.google.apis:google-api-services-storage
Sep 08, 2020 11:29:50 AM com.google.cloud.tools.opensource.dependencies.Java8IncompatibleReferenceCheck main
SEVERE: Failed to find the latest version for com.google.apis:google-api-services-cloudresourcemanager
```