### PR TITLE
RepositoryUtility.findHighestVersion to work with non-semantic version

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtility.java
@@ -300,7 +300,7 @@ public final class RepositoryUtility {
       String artifactId)
       throws MavenRepositoryException {
 
-    Artifact artifactWithVersionRange = new DefaultArtifact(groupId, artifactId, null, "(0,]");
+    Artifact artifactWithVersionRange = new DefaultArtifact(groupId, artifactId, null, "(,]");
     VersionRangeRequest request =
         new VersionRangeRequest(
             artifactWithVersionRange, ImmutableList.of(RepositoryUtility.CENTRAL), null);

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtilityTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtilityTest.java
@@ -96,10 +96,7 @@ public class RepositoryUtilityTest {
     Version highestGuava = versionScheme.parseVersion(bigqueryApiVersion);
     Version august2020Version = versionScheme.parseVersion("v2-rev20200818-1.30.10");
 
-    Truth.assertWithMessage(
-            "Latest google-api-services-bigquery release should be greater than or equal to August 2020 release")
-        .that(highestGuava)
-        .isAtLeast(august2020Version);
+    Truth.assertThat(highestGuava).isAtLeast(august2020Version);
   }
 
   @Test

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtilityTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/RepositoryUtilityTest.java
@@ -78,6 +78,31 @@ public class RepositoryUtilityTest {
   }
 
   @Test
+  public void testFindHighestVersions_nonNumericalVersion()
+      throws MavenRepositoryException, InvalidVersionSpecificationException {
+    RepositorySystem system = RepositoryUtility.newRepositorySystem();
+
+    // google-api-services-bigquery's version does not follow semantic versioning. For example,
+    // the latest version as of August 2020 was "v2-rev20200818-1.30.10".
+    String bigqueryApiVersion =
+        RepositoryUtility.findHighestVersion(
+            system,
+            RepositoryUtility.newSession(system),
+            "com.google.apis",
+            "google-api-services-bigquery");
+    Assert.assertNotNull(bigqueryApiVersion);
+
+    VersionScheme versionScheme = new GenericVersionScheme();
+    Version highestGuava = versionScheme.parseVersion(bigqueryApiVersion);
+    Version august2020Version = versionScheme.parseVersion("v2-rev20200818-1.30.10");
+
+    Truth.assertWithMessage(
+            "Latest google-api-services-bigquery release should be greater than or equal to August 2020 release")
+        .that(highestGuava)
+        .isAtLeast(august2020Version);
+  }
+
+  @Test
   public void testMavenRepositoryFromUrl() {
     RemoteRepository remoteRepository =
         RepositoryUtility.mavenRepositoryFromUrl("https://repo.maven.apache.org/maven2");


### PR DESCRIPTION
RepositoryUtility.findHighestVersion to work with non-semantic version such as "v2-rev20200818-1.30.10".