### PR TITLE
ReturnTypeChangedProblem's error message should clarify the expected and actual return types

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ReturnTypeChangedProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ReturnTypeChangedProblem.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
+import com.sun.org.apache.bcel.internal.classfile.Utility;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -24,15 +26,30 @@ import javax.annotation.Nullable;
  * actualTypeName}).
  */
 class ReturnTypeChangedProblem extends LinkageProblem {
+  private String actualType;
+
   ReturnTypeChangedProblem(
       ClassFile sourceClass,
       @Nullable ClassFile targetClass,
       MethodSymbol expectedMethodSymbol,
       String actualType) {
     super(
-        "is not found. The expected return type does not match the actual type " + actualType,
+        "is expected to return "+
+            Utility.methodSignatureReturnType(expectedMethodSymbol.getDescriptor())
+             +" but the actual type is " + actualType,
         sourceClass,
         expectedMethodSymbol,
         targetClass);
+    this.actualType = actualType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), actualType);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return super.equals(other) && Objects.equals(actualType,((ReturnTypeChangedProblem) other).actualType);
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ReturnTypeChangedProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ReturnTypeChangedProblem.java
@@ -34,9 +34,10 @@ class ReturnTypeChangedProblem extends LinkageProblem {
       MethodSymbol expectedMethodSymbol,
       String actualType) {
     super(
-        "is expected to return "+
-            Utility.methodSignatureReturnType(expectedMethodSymbol.getDescriptor())
-             +" but the actual type is " + actualType,
+        "is expected to return "
+            + Utility.methodSignatureReturnType(expectedMethodSymbol.getDescriptor())
+            + " but the actual type is "
+            + actualType,
         sourceClass,
         expectedMethodSymbol,
         targetClass);
@@ -50,6 +51,7 @@ class ReturnTypeChangedProblem extends LinkageProblem {
 
   @Override
   public boolean equals(Object other) {
-    return super.equals(other) && Objects.equals(actualType,((ReturnTypeChangedProblem) other).actualType);
+    return super.equals(other) // this checks the class equality
+        && Objects.equals(actualType, ((ReturnTypeChangedProblem) other).actualType);
   }
 }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ReturnTypeChangedProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ReturnTypeChangedProblem.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-import com.sun.org.apache.bcel.internal.classfile.Utility;
+import org.apache.bcel.classfile.Utility;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
@@ -36,7 +36,7 @@ class ReturnTypeChangedProblem extends LinkageProblem {
     super(
         "is expected to return "
             + Utility.methodSignatureReturnType(expectedMethodSymbol.getDescriptor())
-            + " but the actual type is "
+            + " but instead returns "
             + actualType,
         sourceClass,
         expectedMethodSymbol,

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ReturnTypeChangedProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ReturnTypeChangedProblem.java
@@ -16,9 +16,9 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
-import org.apache.bcel.classfile.Utility;
 import java.util.Objects;
 import javax.annotation.Nullable;
+import org.apache.bcel.classfile.Utility;
 
 /**
  * The {@code sourceClass} references the {@code expectedMethodSymbol}, but the {@code

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -1145,7 +1145,7 @@ public class LinkageCheckerTest {
             new ClassFile(jars.get(0), "com.google.protobuf.TextFormat"),
             null,
             methodSymbol,
-            "java.nio.CharBuffer");
+            "java.nio.Buffer");
 
     Truth.assertThat(linkageProblems).contains(expectedProblem);
   }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageProblemTest.java
@@ -75,13 +75,24 @@ public class LinkageProblemTest {
             new AbstractMethodProblem(
                 new ClassFile(new ClassPathEntry(Paths.get("foo", "bar.jar")), "java.lang.A"),
                 new MethodSymbol("java.lang.Integer", "intValue", "()Z", false),
-                new ClassFile(new ClassPathEntry(Paths.get("foo", "bar.jar")), "java.lang.B")
-            ))
+                new ClassFile(new ClassPathEntry(Paths.get("foo", "bar.jar")), "java.lang.B")))
         .addEqualityGroup(
             new IncompatibleClassChangeProblem( // Only type is different from the one above
                 new ClassFile(new ClassPathEntry(Paths.get("foo", "bar.jar")), "java.lang.A"),
                 new ClassFile(new ClassPathEntry(Paths.get("foo", "bar.jar")), "java.lang.B"),
                 new ClassSymbol("java.lang.Integer")))
+        .addEqualityGroup(
+            new ReturnTypeChangedProblem( // Only type is different from the one above
+                new ClassFile(new ClassPathEntry(Paths.get("foo", "bar.jar")), "java.lang.A"),
+                new ClassFile(new ClassPathEntry(Paths.get("foo", "bar.jar")), "java.lang.B"),
+                new MethodSymbol("java.lang.Integer", "intValue", "()Z", false),
+                "java.lang.String"))
+        .addEqualityGroup(
+            new ReturnTypeChangedProblem( // Only type is different from the one above
+                new ClassFile(new ClassPathEntry(Paths.get("foo", "bar.jar")), "java.lang.A"),
+                new ClassFile(new ClassPathEntry(Paths.get("foo", "bar.jar")), "java.lang.B"),
+                new MethodSymbol("java.lang.Integer", "intValue", "()Z", false),
+                "java.lang.Float"))
         .testEquals();
   }
 

--- a/enforcer-rules/src/it/return-type-mismatch/invoker.properties
+++ b/enforcer-rules/src/it/return-type-mismatch/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=verify
+invoker.buildResult=failure

--- a/enforcer-rules/src/it/return-type-mismatch/pom.xml
+++ b/enforcer-rules/src/it/return-type-mismatch/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2020 Google LLC.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.google.cloud.tools.opensource</groupId>
+  <artifactId>return-type-mismatch</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>return-type-mismatch</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <!-- protobuf-java 3.12.4 references a Java 11 method that does not exist in Java 8
+        https://github.com/protocolbuffers/protobuf/issues/7827 -->
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>3.12.4</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M3</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.google.cloud.tools</groupId>
+            <artifactId>linkage-checker-enforcer-rules</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>enforce-linkage-checker</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <LinkageCheckerRule
+                  implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
+                </LinkageCheckerRule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/enforcer-rules/src/it/return-type-mismatch/verify.groovy
+++ b/enforcer-rules/src/it/return-type-mismatch/verify.groovy
@@ -4,7 +4,7 @@ def buildLog = new File(basedir, "build.log").text.replaceAll("\\r\\n", "\n")
 // In this message below, the expectation is wrong.
 assert buildLog.contains('''\
 java.nio.ByteBuffer's method position(int) is expected to return java.nio.ByteBuffer\
- but the actual type is java.nio.Buffer;
+ but instead returns java.nio.Buffer;
   referenced by 8 class files
     com.google.protobuf.AllocatedBuffer (com.google.protobuf:protobuf-java:3.12.4)
     com.google.protobuf.BinaryWriter (com.google.protobuf:protobuf-java:3.12.4)

--- a/enforcer-rules/src/it/return-type-mismatch/verify.groovy
+++ b/enforcer-rules/src/it/return-type-mismatch/verify.groovy
@@ -1,0 +1,16 @@
+def buildLog = new File(basedir, "build.log").text.replaceAll("\\r\\n", "\n")
+
+// protobuf-java 3.12.4 has wrong reference to ByteBuffer's methods that are unavailable in Java 8.
+// In this message below, the expectation is wrong.
+assert buildLog.contains('''\
+java.nio.ByteBuffer's method position(int) is expected to return java.nio.ByteBuffer\
+ but the actual type is java.nio.Buffer;
+  referenced by 8 class files
+    com.google.protobuf.AllocatedBuffer (com.google.protobuf:protobuf-java:3.12.4)
+    com.google.protobuf.BinaryWriter (com.google.protobuf:protobuf-java:3.12.4)
+    com.google.protobuf.ByteBufferWriter (com.google.protobuf:protobuf-java:3.12.4)
+    com.google.protobuf.CodedInputStream (com.google.protobuf:protobuf-java:3.12.4)
+    com.google.protobuf.CodedOutputStream (com.google.protobuf:protobuf-java:3.12.4)
+    com.google.protobuf.IterableByteBufferInputStream (com.google.protobuf:protobuf-java:3.12.4)
+    com.google.protobuf.NioByteString (com.google.protobuf:protobuf-java:3.12.4)
+    com.google.protobuf.Utf8 (com.google.protobuf:protobuf-java:3.12.4)''')


### PR DESCRIPTION
Fixes #1541.

This implements Elliotte's idea:

> This strikes me as overly verbose. If the problem is that the method is found but the return type has changed, then that's what we should say. We shouldn't say the method is missing at all.

