### PR TITLE
Dashboard: dependency paths list to be foldable

### DIFF
--- a/dashboard/src/main/resources/js/dashboard.js
+++ b/dashboard/src/main/resources/js/dashboard.js
@@ -15,13 +15,13 @@
  */
 
 /**
- * Toggles the visibility of source class list below the button.
+ * Toggles the visibility of an HTML element below the button.
  * @param button clicked button element
  */
-function toggleSourceClassListVisibility(button) {
-  const classList = button.parentElement.nextElementSibling;
-  const currentVisibility = classList.style.display !== "none";
+function toggleNextSiblingVisibility(button) {
+  const nextSibling = button.parentElement.nextElementSibling;
+  const currentVisibility = nextSibling.style.display !== "none";
   const nextVisibility = !currentVisibility;
-  classList.style.display = nextVisibility ? "" : "none";
+  nextSibling.style.display = nextVisibility ? "" : "none";
   button.innerText = nextVisibility ? "▼" : "▶";
 }

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -28,7 +28,7 @@
   <#list problemsToClasses as problem, sourceClasses>
     <p class="jar-linkage-report-cause">${problem?html}, referenced from ${
       pluralize(sourceClasses?size, "class", "classes")?html}
-      <button onclick="toggleSourceClassListVisibility(this)"
+      <button onclick="toggleNextSiblingVisibility(this)"
               title="Toggle visibility of source class list">▶
       </button>
     </p>
@@ -60,15 +60,25 @@
 
 <#macro showDependencyPath dependencyPathRootCauses classPathResult classPathEntry>
   <#assign dependencyPaths = classPathResult.getDependencyPaths(classPathEntry) />
+  <#assign hasRootCause = dependencyPathRootCauses[classPathEntry]?? />
+  <#assign hideDependencyPathsByDefault = (!hasRootCause) && (dependencyPaths?size > 5) />
   <p class="linkage-check-dependency-paths">
     The following ${plural(dependencyPaths?size, "path contains", "paths contain")} ${classPathEntry?html}:
+    <#if hideDependencyPathsByDefault>
+      <#-- The dependency paths are not summarized -->
+      <button onclick="toggleNextSiblingVisibility(this)"
+              title="Toggle visibility of source class list">▶
+      </button>
+    </#if>
   </p>
 
-  <#if dependencyPathRootCauses[classPathEntry]?? >
+  <#if hasRootCause>
     <p class="linkage-check-dependency-paths">${dependencyPathRootCauses[classPathEntry]?html}
     </p>
   <#else>
-    <ul class="linkage-check-dependency-paths">
+    <!-- The visibility of this list is toggled via the button above. Hidden by default -->
+    <ul class="linkage-check-dependency-paths"
+        style="display:${hideDependencyPathsByDefault?string('none', '')}">
         <#list dependencyPaths as dependencyPath >
           <li>${dependencyPath}</li>
         </#list>

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -216,7 +216,7 @@ public class DashboardTest {
     Nodes dependencyPaths = details.query("//p[@class='linkage-check-dependency-paths']");
     Node dependencyPathMessageOnProblem = dependencyPaths.get(dependencyPaths.size() - 1);
     Assert.assertEquals(
-        "The following paths contain com.google.guava:guava-jdk5:13.0:",
+        "The following paths contain com.google.guava:guava-jdk5:13.0: ▶",
         trimAndCollapseWhiteSpace(dependencyPathMessageOnProblem.getValue()));
 
     Node dependencyPathMessageOnSource = dependencyPaths.get(dependencyPaths.size() - 2);


### PR DESCRIPTION
Fixes #1683

When the length is longer than 5, foldable button appears:

<img width="1062" alt="Screen Shot 2020-10-08 at 18 02 14" src="https://user-images.githubusercontent.com/28604/95518798-d433bb00-0991-11eb-8375-3e14db3c1f13.png">


When the length is less than 5, the dashboard does not fold the list:

<img width="1440" alt="Screen Shot 2020-10-08 at 18 10 37" src="https://user-images.githubusercontent.com/28604/95518786-cd0cad00-0991-11eb-9b5f-cfb26d34cdc8.png">
