### PR TITLE
Dashboard: Not to fold single-element class reference

### DIFF
--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -26,19 +26,23 @@
     ${pluralize(referenceCount, "source class", "source classes")}.
   </p>
   <#list problemsToClasses as problem, sourceClasses>
-    <p class="jar-linkage-report-cause">${problem?html}, referenced from ${
-      pluralize(sourceClasses?size, "class", "classes")?html}
-      <button onclick="toggleNextSiblingVisibility(this)"
-              title="Toggle visibility of source class list">▶
-      </button>
-    </p>
-
-    <!-- The visibility of this list is toggled via the button above. Hidden by default -->
-    <ul class="jar-linkage-report-cause" style="display:none">
-      <#list sourceClasses as sourceClass>
-        <li>${sourceClass?html}</li>
-      </#list>
-    </ul>
+    <#if sourceClasses?size == 1>
+      <#assign sourceClass = sourceClasses[0] />
+      <p class="jar-linkage-report-cause">${problem?html}, referenced from ${sourceClass?html}</p>
+    <#else>
+      <p class="jar-linkage-report-cause">${problem?html}, referenced from ${
+          pluralize(sourceClasses?size, "class", "classes")?html}
+        <button onclick="toggleNextSiblingVisibility(this)"
+                title="Toggle visibility of source class list">▶
+        </button>
+      </p>
+      <!-- The visibility of this list is toggled via the button above. Hidden by default -->
+      <ul class="jar-linkage-report-cause" style="display:none">
+          <#list sourceClasses as sourceClass>
+            <li>${sourceClass?html}</li>
+          </#list>
+      </ul>
+    </#if>
   </#list>
   <#assign jarsInProblem = {} >
   <#list linkageProblems as problem>


### PR DESCRIPTION
Followup of https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1683#issuecomment-700929009 . If the number of source classes is one, then no need to fold the class list.

<img width="1336" alt="Screen Shot 2020-10-08 at 21 26 42" src="https://user-images.githubusercontent.com/28604/95530891-0bfc2c00-09ad-11eb-9fea-a59ecc04e40e.png">
