### PR TITLE
deps: update google-http-client to 1.37.0

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -48,7 +48,7 @@
     <google.cloud.java.version>0.141.0</google.cloud.java.version>
     <io.grpc.version>1.33.0</io.grpc.version>
     <protobuf.version>3.13.0</protobuf.version>
-    <http.version>1.36.0</http.version>
+    <http.version>1.37.0</http.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
     <gax.version>1.60.0</gax.version>


### PR DESCRIPTION
The next version of google-cloud-storage declares google-http-client 1.37.0

https://github.com/googleapis/java-cloud-bom/pull/1074