### PR TITLE
after all these years, the JDK still doesn't parse XML correctly

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ExclusionFiles.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/ExclusionFiles.java
@@ -82,6 +82,7 @@ import org.xml.sax.helpers.XMLReaderFactory;
  *   <li>A FieldMatcher matches field symbol specified by className and name attribute.
  * </ul>
  */
+@SuppressWarnings("deprecation")
 class ExclusionFiles {
   private static final XMLEventFactory eventFactory = XMLEventFactory.newInstance();
 


### PR DESCRIPTION
@suztomo suppress a  very unwise deprecation in Java 11