### PR TITLE
InaccessibleClassProblem.toString shouldn't rely on targetClass which may be null

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/InaccessibleClassProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/InaccessibleClassProblem.java
@@ -28,7 +28,6 @@ import javax.annotation.Nullable;
  */
 final class InaccessibleClassProblem extends LinkageProblem {
   private AccessModifier modifier;
-  private ClassSymbol classSymbol;
 
   InaccessibleClassProblem(
       ClassFile sourceClass,
@@ -37,13 +36,12 @@ final class InaccessibleClassProblem extends LinkageProblem {
       AccessModifier modifier) {
     super("is not accessible", sourceClass, classSymbol, targetClass);
     this.modifier = modifier;
-    this.classSymbol = classSymbol;
   }
 
   @Override
   public final String toString() {
     StringBuilder message = new StringBuilder();
-    message.append("Class " + classSymbol.getClassBinaryName());
+    message.append("Class " + getSymbol().getClassBinaryName());
     switch (modifier) {
       case PUBLIC:
         message.append(" is public");

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/InaccessibleClassProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/InaccessibleClassProblem.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.opensource.classpath;
 
+import javax.annotation.Nullable;
+
 /**
  * The {@code classSymbol} with {@code modifier} is inaccessible to the {@code sourceClass} as per
  * {@code sourceClass}'s definition of the class symbol.
@@ -26,17 +28,22 @@ package com.google.cloud.tools.opensource.classpath;
  */
 final class InaccessibleClassProblem extends LinkageProblem {
   private AccessModifier modifier;
+  private ClassSymbol classSymbol;
 
   InaccessibleClassProblem(
-      ClassFile sourceClass, ClassFile targetClass, Symbol classSymbol, AccessModifier modifier) {
+      ClassFile sourceClass,
+      @Nullable ClassFile targetClass,
+      ClassSymbol classSymbol,
+      AccessModifier modifier) {
     super("is not accessible", sourceClass, classSymbol, targetClass);
     this.modifier = modifier;
+    this.classSymbol = classSymbol;
   }
 
   @Override
   public final String toString() {
     StringBuilder message = new StringBuilder();
-    message.append("Class " + getTargetClass().getBinaryName());
+    message.append("Class " + classSymbol.getClassBinaryName());
     switch (modifier) {
       case PUBLIC:
         message.append(" is public");

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -266,7 +266,11 @@ public class LinkageChecker {
       if (!isClassAccessibleFrom(targetJavaClass, sourceClassName)) {
         AccessModifier modifier = AccessModifier.fromFlag(targetJavaClass.getModifiers());
         return Optional.of(
-            new InaccessibleClassProblem(sourceClassFile, targetClassFile, symbol, modifier));
+            new InaccessibleClassProblem(
+                sourceClassFile,
+                targetClassFile,
+                new ClassSymbol(symbol.getClassBinaryName()),
+                modifier));
       }
 
       if (targetJavaClass.isInterface() != symbol.isInterfaceMethod()) {
@@ -436,7 +440,11 @@ public class LinkageChecker {
       if (!isClassAccessibleFrom(targetJavaClass, sourceClassName)) {
         AccessModifier modifier = AccessModifier.fromFlag(targetJavaClass.getModifiers());
         return Optional.of(
-            new InaccessibleClassProblem(sourceClassFile, targetClassFile, symbol, modifier));
+            new InaccessibleClassProblem(
+                sourceClassFile,
+                targetClassFile,
+                new ClassSymbol(symbol.getClassBinaryName()),
+                modifier));
       }
 
       for (JavaClass javaClass : getClassHierarchy(targetJavaClass)) {

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageProblem.java
@@ -60,7 +60,10 @@ public abstract class LinkageProblem {
    *     not exist in the class path.
    */
   LinkageProblem(
-      String symbolProblemMessage, ClassFile sourceClass, Symbol symbol, ClassFile targetClass) {
+      String symbolProblemMessage,
+      ClassFile sourceClass,
+      Symbol symbol,
+      @Nullable ClassFile targetClass) {
     this.symbolProblemMessage = Preconditions.checkNotNull(symbolProblemMessage);
     Preconditions.checkNotNull(symbol);
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/InaccessibleClassProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/InaccessibleClassProblemTest.java
@@ -25,42 +25,42 @@ import org.junit.Test;
 public class InaccessibleClassProblemTest {
   
   private ClassFile file;
-  private Symbol symbol;
-  
+  private ClassSymbol symbol;
+
   @Before
   public void setUp() {
     Path path = Paths.get("/usr/tmp");
     ClassPathEntry entry = new ClassPathEntry(path);
     file = new ClassFile(entry, "foo");
-    symbol = new ClassSymbol("");
+    symbol = new ClassSymbol("Foo");
   }
 
   @Test
   public void testProtected() {
     InaccessibleClassProblem problem =
         new InaccessibleClassProblem(file, file, symbol, AccessModifier.PROTECTED);
-    Assert.assertEquals("Class foo is protected and is referenced by foo", problem.toString());
+    Assert.assertEquals("Class Foo is protected and is referenced by foo", problem.toString());
   }
 
   @Test
   public void testPrivate() {
     InaccessibleClassProblem problem =
         new InaccessibleClassProblem(file, file, symbol, AccessModifier.PRIVATE);
-    Assert.assertEquals("Class foo is private and is referenced by foo", problem.toString());
+    Assert.assertEquals("Class Foo is private and is referenced by foo", problem.toString());
   }
 
   @Test
   public void testPublic() {
     InaccessibleClassProblem problem =
         new InaccessibleClassProblem(file, file, symbol, AccessModifier.PUBLIC);
-    Assert.assertEquals("Class foo is public and is referenced by foo", problem.toString());
+    Assert.assertEquals("Class Foo is public and is referenced by foo", problem.toString());
   }
 
   @Test
   public void testDefault() {
     InaccessibleClassProblem problem =
         new InaccessibleClassProblem(file, file, symbol, AccessModifier.DEFAULT);
-    Assert.assertEquals("Class foo has default access and is referenced by foo (different package)",
+    Assert.assertEquals("Class Foo has default access and is referenced by foo (different package)",
         problem.toString());
   }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/InaccessibleClassProblemTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/InaccessibleClassProblemTest.java
@@ -60,8 +60,18 @@ public class InaccessibleClassProblemTest {
   public void testDefault() {
     InaccessibleClassProblem problem =
         new InaccessibleClassProblem(file, file, symbol, AccessModifier.DEFAULT);
-    Assert.assertEquals("Class Foo has default access and is referenced by foo (different package)",
+    Assert.assertEquals(
+        "Class Foo has default access and is referenced by foo (different package)",
         problem.toString());
   }
 
+  @Test
+  public void testToString_nullTargetClass() {
+    InaccessibleClassProblem problem =
+        new InaccessibleClassProblem(file, null, symbol, AccessModifier.DEFAULT);
+
+    Assert.assertEquals(
+        "Class Foo has default access and is referenced by foo (different package)",
+        problem.toString());
+  }
 }


### PR DESCRIPTION
Towards https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1825, where NullPointerException was thrown upon null targetClass.

TargetClass parameter may be null. See the javadoc https://github.com/GoogleCloudPlatform/cloud-opensource-java/blob/master/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageProblem.java#L59
