### PR TITLE
LinkageCheckerMainIntegrationTest.testArtifacts to use newer google-cloud-firestore that has no auto-value dependency

### DIFF
--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -90,10 +90,11 @@ public class LinkageCheckerMainIntegrationTest {
       throws IOException, RepositoryException, TransformerException, XMLStreamException {
     try {
       LinkageCheckerMain.main(
-          new String[] {"-a", "com.google.cloud:google-cloud-firestore:0.65.0-beta"});
+          // protobuf-java:3.13.0 in
+          new String[] {"-a", "com.google.cloud:google-cloud-firestore:1.35.2"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 75 linkage errors", expected.getMessage());
+      assertEquals("Found 76 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();
@@ -102,15 +103,14 @@ public class LinkageCheckerMainIntegrationTest {
             "Class com.jcraft.jzlib.JZlib is not found;\n"
                 + "  referenced by 4 class files\n"
                 + "    io.grpc.netty.shaded.io.netty.handler.codec.spdy.SpdyHeaderBlockJZlibEncoder"
-                + " (io.grpc:grpc-netty-shaded:1.13.1)");
+                + " (io.grpc:grpc-netty-shaded:1.30.2)");
 
     // Show the dependency path to the problematic artifact
     Truth.assertThat(output)
         .contains(
-            "io.grpc:grpc-netty-shaded:1.13.1 is at:\n"
-                + "  com.google.cloud:google-cloud-firestore:jar:0.65.0-beta /"
-                + " io.grpc:grpc-netty-shaded:1.13.1 (compile)\n"
-                + "  and 1 dependency path.");
+            "io.grpc:grpc-netty-shaded:1.30.2 is at:\n"
+                + "  com.google.cloud:google-cloud-firestore:jar:1.35.2 /"
+                + " io.grpc:grpc-netty-shaded:1.30.2 (compile)\n");
   }
 
   @Test


### PR DESCRIPTION
Fixes #1828 . The result of `LinkageCheckerMainIntegrationTest.testArtifacts` differed between Java 8 and Java 11, because:
- `google-cloud-firestore:0.65.0-beta` has unexpected auto-value dependency that has references to  `javax.annotation.Generated`.
- The `javax.annotation.Generated` has been removed in Java 11.

Here are the linkage errors for the artifact before and after:

- Linkage Errors before the change (with 0.65.0-beta): https://gist.github.com/suztomo/b0a19b75b2a79960ab4a978b4ba70c8d
- Linkage Errors after the change (with 1.35.2): https://gist.github.com/suztomo/9a44b2d6994200fd5fe3110830e0e01b 

The linkage errors are from the grpc-netty-shaded and logger. Different versions of this library contains different number of missing classes.

