### PR TITLE
LinkageCheckerTest.testFindLinkageProblems_referenceToJava11Method fails in Java 11 to use Assume Java 8 runtime

### DIFF
--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.opensource.classpath;
 import static com.google.cloud.tools.opensource.classpath.TestHelper.COORDINATES;
 import static com.google.cloud.tools.opensource.classpath.TestHelper.classPathEntryOfResource;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -47,6 +46,7 @@ import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.Dependency;
+import org.hamcrest.core.StringStartsWith;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
@@ -1132,7 +1132,7 @@ public class LinkageCheckerTest {
   public void testFindLinkageProblems_referenceToJava11Method() throws IOException {
     // protobuf-java 3.12.4 references a Java 11 method that does not exist in Java 8
     // https://github.com/protocolbuffers/protobuf/issues/7827
-    Assume.assumeThat(System.getProperty("java.version"), startsWith("1.8.0"));
+    Assume.assumeThat(System.getProperty("java.version"), StringStartsWith.startsWith("1.8.0"));
 
     ImmutableList<ClassPathEntry> jars =
         TestHelper.resolve("com.google.protobuf:protobuf-java:3.12.4");

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.opensource.classpath;
 import static com.google.cloud.tools.opensource.classpath.TestHelper.COORDINATES;
 import static com.google.cloud.tools.opensource.classpath.TestHelper.classPathEntryOfResource;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -46,6 +47,7 @@ import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.Dependency;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -1130,6 +1132,8 @@ public class LinkageCheckerTest {
   public void testFindLinkageProblems_referenceToJava11Method() throws IOException {
     // protobuf-java 3.12.4 references a Java 11 method that does not exist in Java 8
     // https://github.com/protocolbuffers/protobuf/issues/7827
+    Assume.assumeThat(System.getProperty("java.version"), startsWith("1.8.0"));
+
     ImmutableList<ClassPathEntry> jars =
         TestHelper.resolve("com.google.protobuf:protobuf-java:3.12.4");
 


### PR DESCRIPTION
Fixes #1822 . If we run the test on Java 11, the test says

```
org.junit.AssumptionViolatedException: got: "11.0.4", expected: a string starting with "1.8.0"
```

and JUnit ignores the test.