### PR TITLE
Excluding JVM-internal classes referenced by Substrate VM (part of GraalVM project)

### DIFF
--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -43,6 +43,68 @@
   </LinkageError>
   <LinkageError>
     <Target>
+      <Package name="sun.text.normalizer" />
+    </Target>
+    <Source>
+      <Package name="com.oracle.svm.core.jdk8" />
+    </Source>
+    <Reason>
+      Substratevm is part of GraalVM and the virtual machine references classes in the JVM-internal
+      package 'sun.text.normalizer' that are not available in JVM runtime.
+      https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1825
+    </Reason>
+  </LinkageError>
+  <LinkageError>
+    <Target>
+      <Class name="sun.util.logging.LoggingSupport" />
+    </Target>
+    <Source>
+      <Class name="com.oracle.svm.core.jdk.FormatAccessors" />
+    </Source>
+    <Reason>
+      Substratevm references the JVM-internal class 'sun.util.logging.LoggingSupport' that are not
+      available in JVM runtime.
+      https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1825
+    </Reason>
+  </LinkageError>
+  <LinkageError>
+    <Target>
+      <Class name="sun.misc.JavaUtilZipFileAccess" />
+    </Target>
+    <Source>
+      <Class name="com.oracle.svm.core.jdk8.zipfile.ZipFileUtil" />
+    </Source>
+    <Reason>
+      Substratevm references the class that are only available in Java 8.
+      https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1825
+    </Reason>
+  </LinkageError>
+  <LinkageError>
+    <Target>
+      <Class name="sun.misc.SharedSecrets" />
+    </Target>
+    <Source>
+      <Package name="com.oracle.svm.core.jdk8" />
+    </Source>
+    <Reason>
+      Substratevm references the class that are only available in Java 8.
+      https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1825
+    </Reason>
+  </LinkageError>
+  <LinkageError>
+    <Target>
+      <Class name="sun.misc.PerfCounter" />
+    </Target>
+    <Source>
+      <Package name="com.oracle.svm.core.jdk8" />
+    </Source>
+    <Reason>
+      Substratevm references the class that are only available in Java 8.
+      https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1825
+    </Reason>
+  </LinkageError>
+  <LinkageError>
+    <Target>
       <Class name="org.mockito.internal.creation.bytebuddy.MockMethodDispatcher" />
     </Target>
     <Source>

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -49,7 +49,7 @@
       <Package name="com.oracle.svm.core.jdk8" />
     </Source>
     <Reason>
-      Substratevm is part of GraalVM and the virtual machine references classes in the JVM-internal
+      Substrate VM is part of GraalVM and the virtual machine references classes in the JVM-internal
       package 'sun.text.normalizer' that are not available in JVM runtime.
       https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1825
     </Reason>
@@ -62,7 +62,7 @@
       <Class name="com.oracle.svm.core.jdk.FormatAccessors" />
     </Source>
     <Reason>
-      Substratevm references the JVM-internal class 'sun.util.logging.LoggingSupport' that are not
+      Substrate VM references the JVM-internal class 'sun.util.logging.LoggingSupport' that are not
       available in JVM runtime.
       https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1825
     </Reason>
@@ -75,7 +75,7 @@
       <Class name="com.oracle.svm.core.jdk8.zipfile.ZipFileUtil" />
     </Source>
     <Reason>
-      Substratevm references the class that are only available in Java 8.
+      Substrate VM references the class that are only available in Java 8.
       https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1825
     </Reason>
   </LinkageError>
@@ -87,7 +87,7 @@
       <Package name="com.oracle.svm.core.jdk8" />
     </Source>
     <Reason>
-      Substratevm references the class that are only available in Java 8.
+      Substrate VM references the class that are only available in Java 8.
       https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1825
     </Reason>
   </LinkageError>
@@ -99,7 +99,7 @@
       <Package name="com.oracle.svm.core.jdk8" />
     </Source>
     <Reason>
-      Substratevm references the class that are only available in Java 8.
+      Substrate VM references the class that are only available in Java 8.
       https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1825
     </Reason>
   </LinkageError>


### PR DESCRIPTION
Fixes #1825 .