### PR TITLE
testExclusion to use the same class path when running Linkage Checker twice

### DIFF
--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ExclusionFilesIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ExclusionFilesIntegrationTest.java
@@ -53,7 +53,8 @@ public class ExclusionFilesIntegrationTest {
         new String[] {"-a", Artifacts.toCoordinates(artifact), "-o", exclusionFile.toString()});
 
     ClassPathBuilder classPathBuilder = new ClassPathBuilder();
-    ClassPathResult classPathResult = classPathBuilder.resolve(ImmutableList.of(artifact), true);
+    // The `full: false` parameter is in line with LinkageCheckerMain.checkArtifacts
+    ClassPathResult classPathResult = classPathBuilder.resolve(ImmutableList.of(artifact), false);
 
     LinkageChecker linkagechecker =
         LinkageChecker.create(classPathResult.getClassPath(), ImmutableList.of(), exclusionFile);


### PR DESCRIPTION
Fixes #1845 .

The test was supposed to use the same class path in both  creating the exclusion file and using the file. However there was a difference in dependency graph resolution option (`full`).