### PR TITLE
Split testComponent_linkageCheckResult into Java 8 and Java 11

### DIFF
--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -297,7 +297,7 @@ public class DashboardTest {
   @Test
   public void testComponent_linkageCheckResult_java8() throws IOException, ParsingException {
     Assume.assumeThat(System.getProperty("java.version"), StringStartsWith.startsWith("1.8."));
-    // version used in libraries-bom 1.0.0
+    // The version used in libraries-bom 1.0.0
     Document document = parseOutputFile(
         "com.google.http-client_google-http-client-appengine_1.29.1.html");
     Nodes reports = document.query("//p[@class='jar-linkage-report']");
@@ -324,12 +324,17 @@ public class DashboardTest {
     int javaMajorVersion = Integer.parseInt(javaVersion.split("\\.")[0]);
     Assume.assumeTrue(javaMajorVersion >= 11);
 
-    // version used in libraries-bom 1.0.0
+    // The version used in libraries-bom 1.0.0. The google-http-client-appengine has been known to
+    // have linkage errors in its dependencies ("commons-logging:commons-logging:1.2" and
+    // "com.google.appengine:appengine-api-1.0-sdk:1.9.71").
     Document document = parseOutputFile(
         "com.google.http-client_google-http-client-appengine_1.29.1.html");
     Nodes reports = document.query("//p[@class='jar-linkage-report']");
     Assert.assertEquals(2, reports.size());
-    // This number differs between Java 8 and Java 11
+
+    // This number of linkage errors differs between Java 8 and Java 11 for the javax.activation
+    // package removal (JEP 320: Remove the Java EE and CORBA Modules). For the detail, see
+    // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1849.
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
         .isEqualTo("105 target classes causing linkage errors referenced from 562 source classes.");
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(1).getValue()))


### PR DESCRIPTION
Fixes #1849 . As explained in this issue, the difference comes from the 5 removed classes in Java 11:

```
Class javax.activation.DataSource is not found;
  referenced by 9 class files
    com.google.appengine.api.utils.HttpRequestParser (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
    com.google.apphosting.utils.servlet.MultipartMimeUtils (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
    javax.mail.MultipartDataSource (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
    javax.mail.internet.MimeMultipart (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
    javax.mail.internet.MimePartDataSource (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
    javax.mail.internet.MimeUtility (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
    javax.mail.util.ByteArrayDataSource (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
    org.apache.geronimo.mail.handlers.MessageHandler (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
    org.apache.geronimo.mail.handlers.TextHandler (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
  Cause:
    Unknown
Class javax.activation.FileDataSource is not found;
  referenced by 1 class file
    javax.mail.internet.MimeBodyPart (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
  Cause:
    Unknown
Class javax.activation.DataHandler is not found;
  referenced by 4 class files
    javax.mail.internet.MimeBodyPart (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
    javax.mail.internet.MimeMessage (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
    javax.mail.internet.MimeUtility (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
    javax.mail.internet.PreencodedMimeBodyPart (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
  Cause:
    Unknown
Class javax.activation.ActivationDataFlavor is not found;
  referenced by 5 class files
    org.apache.geronimo.mail.handlers.HtmlHandler (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
    org.apache.geronimo.mail.handlers.MessageHandler (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
    org.apache.geronimo.mail.handlers.MultipartHandler (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
    org.apache.geronimo.mail.handlers.TextHandler (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
    org.apache.geronimo.mail.handlers.XMLHandler (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
  Cause:
    Unknown
Class javax.activation.DataContentHandler is not found;
  referenced by 3 class files
    org.apache.geronimo.mail.handlers.MessageHandler (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
    org.apache.geronimo.mail.handlers.MultipartHandler (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
    org.apache.geronimo.mail.handlers.TextHandler (com.google.appengine:appengine-api-1.0-sdk:1.9.71)
  Cause:
    Unknown
Problematic artifacts in the dependency tree:
com.google.appengine:appengine-api-1.0-sdk:1.9.71 is at:
  com.google.http-client:google-http-client-appengine:1.38.0 (compile) / com.google.appengine:appengine-api-1.0-sdk:1.9.71 (provided)
  and 2 other dependency paths.
```

`javax.activation` package has been removed in Java 11 ([JEP 320: Remove the Java EE and CORBA Modules](https://openjdk.java.net/jeps/320))