### PR TITLE
Libraries BOM: gRPC and google-auth-library version upgrade

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -46,7 +46,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>30.0-android</guava.version>
     <google.cloud.java.version>0.145.0</google.cloud.java.version>
-    <io.grpc.version>1.33.1</io.grpc.version>
+    <io.grpc.version>1.34.0</io.grpc.version>
     <protobuf.version>3.14.0</protobuf.version>
     <http.version>1.38.0</http.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
@@ -235,7 +235,7 @@
        <dependency>
          <groupId>com.google.auth</groupId>
          <artifactId>google-auth-library-bom</artifactId>
-         <version>0.22.0</version>
+         <version>0.22.1</version>
          <type>pom</type>
          <scope>import</scope>
        </dependency>


### PR DESCRIPTION
update dependency com.google.auth:google-auth-library-bom to v0.22.1
update io.grpc.version to v1.34.0

The build succeeded in my local without showing the error in https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1779. Does this work?