### PR TITLE
Removing httpclient dependencies throws exception

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -74,11 +74,12 @@
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-connector-basic</artifactId>
     </dependency>
+    <!--
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.12</version>
-    </dependency>
+    </dependency> -->
     <dependency>
       <groupId>org.relaxng</groupId>
       <artifactId>jing</artifactId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -74,12 +74,17 @@
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-connector-basic</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.2</version>
+    </dependency>
     <!--
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.12</version>
-    </dependency> -->
+    </dependency>-->
     <dependency>
       <groupId>org.relaxng</groupId>
       <artifactId>jing</artifactId>


### PR DESCRIPTION
```
Exception in thread "DefaultMetadataResolver-0-1" Exception in thread "DefaultMetadataResolver-0-0" java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.aether.transport.http.SslSocketFactory
	at org.eclipse.aether.transport.http.GlobalState.newConnectionManager(GlobalState.java:177)
	at org.eclipse.aether.transport.http.LocalState.<init>(LocalState.java:63)
	at org.eclipse.aether.transport.http.HttpTransporter.<init>(HttpTransporter.java:137)
	at org.eclipse.aether.transport.http.HttpTransporterFactory.newInstance(HttpTransporterFactory.java:71)
	at org.eclipse.aether.internal.impl.DefaultTransporterProvider.newTransporter(DefaultTransporterProvider.java:104)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector.<init>(BasicRepositoryConnector.java:129)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory.newInstance(BasicRepositoryConnectorFactory.java:155)
	at org.eclipse.aether.internal.impl.DefaultRepositoryConnectorProvider.newRepositoryConnector(DefaultRepositoryConnectorProvider.java:107)
	at org.eclipse.aether.internal.impl.DefaultMetadataResolver$ResolveTask.run(DefaultMetadataResolver.java:570)
	at org.eclipse.aether.util.concurrency.RunnableErrorForwarder$1.run(RunnableErrorForwarder.java:75)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.aether.transport.http.SslSocketFactory
	at org.eclipse.aether.transport.http.GlobalState.newConnectionManager(GlobalState.java:177)
	at org.eclipse.aether.transport.http.LocalState.<init>(LocalState.java:63)
	at org.eclipse.aether.transport.http.HttpTransporter.<init>(HttpTransporter.java:137)
	at org.eclipse.aether.transport.http.HttpTransporterFactory.newInstance(HttpTransporterFactory.java:71)
	at org.eclipse.aether.internal.impl.DefaultTransporterProvider.newTransporter(DefaultTransporterProvider.java:104)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector.<init>(BasicRepositoryConnector.java:129)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory.newInstance(BasicRepositoryConnectorFactory.java:155)
	at org.eclipse.aether.internal.impl.DefaultRepositoryConnectorProvider.newRepositoryConnector(DefaultRepositoryConnectorProvider.java:107)
	at org.eclipse.aether.internal.impl.DefaultMetadataResolver$ResolveTask.run(DefaultMetadataResolver.java:570)
	at org.eclipse.aether.util.concurrency.RunnableErrorForwarder$1.run(RunnableErrorForwarder.java:75)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```