### PR TITLE
Excluding linkage errors from netty's internal logging

### DIFF
--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -213,7 +213,7 @@ public class DashboardTest {
     // appengine-api-sdk, shown as first item in linkage errors, has these errors
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
         .isEqualTo(
-            "53 target classes causing linkage errors referenced from 76 source classes.");
+            "40 target classes causing linkage errors referenced from 61 source classes.");
 
     Nodes dependencyPaths = details.query("//p[@class='linkage-check-dependency-paths']");
     Node dependencyPathMessageOnProblem = dependencyPaths.get(dependencyPaths.size() - 1);

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -137,7 +137,6 @@
       <Package name="io.netty.util.internal.logging" />
     </Source>
     <Reason>
-      Netty supports different logging implementation and declares the dependencies as optional.
       As io.netty.util.internal.logging.InternalLoggerFactory finds the available logging
       implementations in the class path, the missing class references from the logging package
       do not cause runtime errors.

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -132,4 +132,25 @@
       https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1296
     </Reason>
   </LinkageError>
+  <LinkageError>
+    <Source>
+      <Package name="io.netty.util.internal.logging" />
+    </Source>
+    <Reason>
+      Netty supports different logging implementation and declares the dependencies as optional.
+      As io.netty.util.internal.logging.InternalLoggerFactory finds the available logging
+      implementations in the class path, the missing class references from the logging package
+      do not cause runtime errors.
+    </Reason>
+  </LinkageError>
+  <LinkageError>
+    <Source>
+      <Package name="io.grpc.netty.shaded.io.netty.util.internal.logging" />
+    </Source>
+    <Reason>
+      grpc-netty-shaded has copy of the netty's internal logging classes, which detects available
+      logging implementation in the class path. The missing class references do not cause runtime
+      errors.
+    </Reason>
+  </LinkageError>
 </LinkageCheckerFilter>

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -137,8 +137,7 @@
       <Package name="io.netty.util.internal.logging" />
     </Source>
     <Reason>
-      io.netty.util.internal.logging.InternalLoggerFactory catches and handles errors caused by the
-      missing classes.
+      InternalLoggerFactory catches and handles errors caused by the missing classes.
       More details in https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1872
     </Reason>
   </LinkageError>

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -141,6 +141,7 @@
       As io.netty.util.internal.logging.InternalLoggerFactory finds the available logging
       implementations in the class path, the missing class references from the logging package
       do not cause runtime errors.
+      More details in https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1872
     </Reason>
   </LinkageError>
   <LinkageError>

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -137,9 +137,8 @@
       <Package name="io.netty.util.internal.logging" />
     </Source>
     <Reason>
-      As io.netty.util.internal.logging.InternalLoggerFactory finds the available logging
-      implementations in the class path, the missing class references from the logging package
-      do not cause runtime errors.
+      io.netty.util.internal.logging.InternalLoggerFactory catches and handles errors caused by the
+      missing classes.
       More details in https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1872
     </Reason>
   </LinkageError>
@@ -148,9 +147,8 @@
       <Package name="io.grpc.netty.shaded.io.netty.util.internal.logging" />
     </Source>
     <Reason>
-      grpc-netty-shaded has copy of the netty's internal logging classes, which detects available
-      logging implementation in the class path. The missing class references do not cause runtime
-      errors.
+      grpc-netty-shaded has copies of the netty's internal logging classes. which catches and
+      handles errors caused by the missing classes.
     </Reason>
   </LinkageError>
 </LinkageCheckerFilter>

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -96,7 +96,7 @@ public class LinkageCheckerMainIntegrationTest {
           new String[] {"-a", "com.google.cloud:google-cloud-firestore:1.35.2"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 76 linkage errors", expected.getMessage());
+      assertEquals("Found 61 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();
@@ -136,7 +136,7 @@ public class LinkageCheckerMainIntegrationTest {
       LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 801 linkage errors", expected.getMessage());
+      assertEquals("Found 771 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();
@@ -170,7 +170,7 @@ public class LinkageCheckerMainIntegrationTest {
       LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 823 linkage errors", expected.getMessage());
+      assertEquals("Found 793 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();

--- a/enforcer-rules/src/it/bom-project-using-spring-repository/verify.groovy
+++ b/enforcer-rules/src/it/bom-project-using-spring-repository/verify.groovy
@@ -14,6 +14,6 @@ assert !buildLog.text.contains("NullPointerException")
 
 // 4 linkage errors are references to java.util.concurrent.Flow class, which does not exist in
 // Java 8 runtime yet.
-def expectedErrorCount = System.getProperty("java.version").startsWith("1.8.") ? 841 : 847
+def expectedErrorCount = System.getProperty("java.version").startsWith("1.8.") ? 841 : 837
 
 assert buildLog.text.contains("Linkage Checker rule found $expectedErrorCount errors:")

--- a/enforcer-rules/src/it/bom-project-using-spring-repository/verify.groovy
+++ b/enforcer-rules/src/it/bom-project-using-spring-repository/verify.groovy
@@ -14,6 +14,6 @@ assert !buildLog.text.contains("NullPointerException")
 
 // 4 linkage errors are references to java.util.concurrent.Flow class, which does not exist in
 // Java 8 runtime yet.
-def expectedErrorCount = System.getProperty("java.version").startsWith("1.8.") ? 850 : 846
+def expectedErrorCount = System.getProperty("java.version").startsWith("1.8.") ? 841 : 847
 
 assert buildLog.text.contains("Linkage Checker rule found $expectedErrorCount errors:")


### PR DESCRIPTION
Fixes #1872 

It's easy to maintain the file with package-level (compared to class-level), as the number of referencing class are not small. They all share the same reason why they do not cause runtime errors.