### PR TITLE
The BOM Dashboard to report only reachable linkage errors

### DIFF
--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/dashboard/DashboardMain.java
@@ -181,7 +181,9 @@ public class DashboardMain {
     ClassPathResult classPathResult = classPathBuilder.resolve(managedDependencies, false);
     ImmutableList<ClassPathEntry> classpath = classPathResult.getClassPath();
 
-    LinkageChecker linkageChecker = LinkageChecker.create(classpath, classpath.subList(0, managedDependencies.size()), null);
+    // The managed dependencies in the BOM are the entry points of the reachability analysis.
+    ImmutableList<ClassPathEntry> entryPoints = classpath.subList(0, managedDependencies.size());
+    LinkageChecker linkageChecker = LinkageChecker.create(classpath, entryPoints, null);
 
     ImmutableSet<LinkageProblem> linkageProblems = linkageChecker.findLinkageProblems();
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -118,6 +118,14 @@
       <artifactId>guava-testlib</artifactId>
       <scope>test</scope>
     </dependency>
+
+
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
+      <version>4.1.51.Final</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -118,14 +118,6 @@
       <artifactId>guava-testlib</artifactId>
       <scope>test</scope>
     </dependency>
-
-
-
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-common</artifactId>
-      <version>4.1.51.Final</version>
-    </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
This PR lists the effect of making the dashboard to show only the reachable errors. The entry point classes for the reachability analysis are the classes in the managed dependencies in the BOM.

If you need the report you can checkout logger_linkage_error branch and run the dashboard locally:

```
suztomo-macbookpro44% pwd                                                                                               
/Users/suztomo/cloud-opensource-java/dashboard
suztomo-macbookpro44% mvn exec:java -Dexec.arguments="-f ../boms/cloud-oss-bom/pom.xml" 
...
```

# The number of artifacts with linkage errors

With this change, the number of artifacts that have at least one linkage error becomes 6 (from [85](https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/snapshot/index.html)).

<img width="1220" alt="Screen Shot 2020-12-11 at 14 43 19" src="https://user-images.githubusercontent.com/28604/101947937-3e015880-3bbf-11eb-859d-c15adca3753b.png">

The artifacts showing "3 FAILURES" in the [artifact_details.html](https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/snapshot/artifact_details.html) are the ones that have `commons-logging:commons-logging:1.2` dependency (#1871).

# Remaining 6 artifacts that still showing linkage errors

The following 6 artifacts still show linkage errors even after filtering out unreachable linkage errors

- com.google.cloud:google-cloud-resourcemanager:0.118.4-alpha
- com.google.cloud:google-cloud-core-http:1.94.0
- com.google.http-client:google-http-client-appengine:1.38.0
- io.grpc:grpc-alts:1.34.0
- io.grpc:grpc-netty:1.34.0
- io.grpc:grpc-netty-shaded:1.34.0

## com.google.cloud:google-cloud-resourcemanager:0.118.4-alpha, com.google.cloud:google-cloud-core-http:1.94.0, and com.google.http-client:google-http-client-appengine:1.38.0


```
com.google.appengine:appengine-api-1.0-sdk:1.9.71
5 target classes causing linkage errors referenced from 5 source classes.

Class com.google.api.VisibilityProto is not found, referenced from com.google.appengine.repackaged.com.google.api.HttpProto

Class com.google.api.AuthzProto is not found, referenced from com.google.appengine.repackaged.com.google.api.HttpProto

Class com.google.api.MediaProto is not found, referenced from com.google.appengine.repackaged.com.google.api.HttpProto

Class libcore.io.Memory is not found, referenced from com.google.appengine.repackaged.com.google.protobuf.UnsafeUtil

Class com.google.storage.onestore.v3.OnestoreAction$Action is not found, referenced from com.google.apphosting.api.DatastorePb
```

## io.grpc:grpc-alts:1.34.0 and io.grpc:grpc-netty-shaded:1.34.0

```
io.grpc:grpc-netty-shaded:1.34.0
39 target classes causing linkage errors referenced from 58 source classes.

Class com.jcraft.jzlib.JZlib is not found, referenced from 4 classes ▶

Class com.jcraft.jzlib.Deflater is not found, referenced from 3 classes ▶

Class org.bouncycastle.asn1.x500.X500Name is not found, referenced from io.grpc.netty.shaded.io.netty.handler.ssl.util.BouncyCastleSelfSignedCertGenerator

Class org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder is not found, referenced from io.grpc.netty.shaded.io.netty.handler.ssl.util.BouncyCastleSelfSignedCertGenerator

Class org.bouncycastle.operator.jcajce.JcaContentSignerBuilder is not found, referenced from io.grpc.netty.shaded.io.netty.handler.ssl.util.BouncyCastleSelfSignedCertGenerator

Class org.bouncycastle.cert.X509v3CertificateBuilder is not found, referenced from io.grpc.netty.shaded.io.netty.handler.ssl.util.BouncyCastleSelfSignedCertGenerator

Class org.bouncycastle.cert.jcajce.JcaX509CertificateConverter is not found, referenced from io.grpc.netty.shaded.io.netty.handler.ssl.util.BouncyCastleSelfSignedCertGenerator

Class org.bouncycastle.jce.provider.BouncyCastleProvider is not found, referenced from io.grpc.netty.shaded.io.netty.handler.ssl.util.BouncyCastleSelfSignedCertGenerator

Class org.eclipse.jetty.alpn.ALPN$ClientProvider is not found, referenced from io.grpc.netty.shaded.io.netty.handler.ssl.JettyAlpnSslEngine

Class org.eclipse.jetty.alpn.ALPN is not found, referenced from io.grpc.netty.shaded.io.netty.handler.ssl.JettyAlpnSslEngine

Class org.eclipse.jetty.npn.NextProtoNego$ServerProvider is not found, referenced from io.grpc.netty.shaded.io.netty.handler.ssl.JettyNpnSslEngine

Class org.eclipse.jetty.alpn.ALPN$ServerProvider is not found, referenced from io.grpc.netty.shaded.io.netty.handler.ssl.JettyAlpnSslEngine

Class org.eclipse.jetty.npn.NextProtoNego is not found, referenced from io.grpc.netty.shaded.io.netty.handler.ssl.JettyNpnSslEngine

Class org.eclipse.jetty.npn.NextProtoNego$ClientProvider is not found, referenced from io.grpc.netty.shaded.io.netty.handler.ssl.JettyNpnSslEngine

Class org.jboss.marshalling.Marshaller is not found, referenced from 3 classes ▶

Class org.jboss.marshalling.MarshallerFactory is not found, referenced from 4 classes ▶

Class org.jboss.marshalling.Unmarshaller is not found, referenced from 4 classes ▶

Class com.ning.compress.lzf.util.ChunkDecoderFactory is not found, referenced from io.grpc.netty.shaded.io.netty.handler.codec.compression.LzfDecoder

Class com.ning.compress.lzf.ChunkDecoder is not found, referenced from io.grpc.netty.shaded.io.netty.handler.codec.compression.LzfDecoder

Class com.ning.compress.BufferRecycler is not found, referenced from 2 classes ▶

Class com.google.protobuf.nano.MessageNano is not found, referenced from 2 classes ▶

Class com.jcraft.jzlib.JZlib$WrapperType is not found, referenced from io.grpc.netty.shaded.io.netty.handler.codec.compression.ZlibUtil

Class com.jcraft.jzlib.Inflater is not found, referenced from 2 classes ▶

Class net.jpountz.lz4.LZ4Factory is not found, referenced from 2 classes ▶

Class net.jpountz.lz4.LZ4Exception is not found, referenced from 2 classes ▶

Class net.jpountz.lz4.LZ4FastDecompressor is not found, referenced from io.grpc.netty.shaded.io.netty.handler.codec.compression.Lz4FrameDecoder

Class lzma.sdk.lzma.Encoder is not found, referenced from io.grpc.netty.shaded.io.netty.handler.codec.compression.LzmaFrameEncoder

Class net.jpountz.lz4.LZ4Compressor is not found, referenced from io.grpc.netty.shaded.io.netty.handler.codec.compression.Lz4FrameEncoder

Class com.google.protobuf.nano.CodedOutputByteBufferNano is not found, referenced from io.grpc.netty.shaded.io.netty.handler.codec.protobuf.ProtobufEncoderNano

Class org.jboss.marshalling.ByteInput is not found, referenced from 2 classes ▶

Class org.jboss.marshalling.ByteOutput is not found, referenced from io.grpc.netty.shaded.io.netty.handler.codec.marshalling.ChannelBufferByteOutput

Class com.ning.compress.lzf.util.ChunkEncoderFactory is not found, referenced from io.grpc.netty.shaded.io.netty.handler.codec.compression.LzfEncoder

Class com.ning.compress.lzf.ChunkEncoder is not found, referenced from io.grpc.netty.shaded.io.netty.handler.codec.compression.LzfEncoder

Class com.ning.compress.lzf.LZFEncoder is not found, referenced from io.grpc.netty.shaded.io.netty.handler.codec.compression.LzfEncoder

Class com.ning.compress.lzf.LZFChunk is not found, referenced from io.grpc.netty.shaded.io.netty.handler.codec.compression.LzfEncoder

Class net.jpountz.xxhash.XXHash32 is not found, referenced from io.grpc.netty.shaded.io.netty.handler.codec.compression.Lz4XXHash32

Class net.jpountz.xxhash.XXHashFactory is not found, referenced from io.grpc.netty.shaded.io.netty.handler.codec.compression.Lz4XXHash32

Class reactor.blockhound.integration.BlockHoundIntegration is not found, referenced from io.grpc.netty.shaded.io.netty.util.internal.Hidden

Class reactor.blockhound.BlockHound$Builder is not found, referenced from io.grpc.netty.shaded.io.netty.util.internal.Hidden

The following paths contain io.grpc:grpc-netty-shaded:1.34.0:

io.grpc:grpc-netty-shaded:1.34.0 (compile)
io.grpc:grpc-alts:1.34.0 (compile) / io.grpc:grpc-netty-shaded:1.34.0 (compile)
```

## io.grpc:grpc-netty:1.34.0

```
io.netty:netty-handler:4.1.51.Final
14 target classes causing linkage errors referenced from 30 source classes.

Class io.netty.internal.tcnative.SSL is not found, referenced from 8 classes ▶

Class io.netty.internal.tcnative.SSLContext is not found, referenced from 6 classes ▶

Class io.netty.internal.tcnative.SessionTicketKey is not found, referenced from 2 classes ▶

Class org.eclipse.jetty.alpn.ALPN$ClientProvider is not found, referenced from io.netty.handler.ssl.JettyAlpnSslEngine

Class io.netty.internal.tcnative.CertificateCallback is not found, referenced from 2 classes ▶

Class org.eclipse.jetty.alpn.ALPN is not found, referenced from io.netty.handler.ssl.JettyAlpnSslEngine

Class io.netty.internal.tcnative.CertificateVerifier is not found, referenced from 2 classes ▶

Class org.eclipse.jetty.npn.NextProtoNego$ServerProvider is not found, referenced from io.netty.handler.ssl.JettyNpnSslEngine

Class org.eclipse.jetty.alpn.ALPN$ServerProvider is not found, referenced from io.netty.handler.ssl.JettyAlpnSslEngine

Class io.netty.internal.tcnative.SniHostNameMatcher is not found, referenced from io.netty.handler.ssl.ReferenceCountedOpenSslServerContext

Class io.netty.internal.tcnative.SSLPrivateKeyMethod is not found, referenced from 2 classes ▶

Class org.eclipse.jetty.npn.NextProtoNego is not found, referenced from io.netty.handler.ssl.JettyNpnSslEngine

Class org.eclipse.jetty.npn.NextProtoNego$ClientProvider is not found, referenced from io.netty.handler.ssl.JettyNpnSslEngine

Class io.netty.internal.tcnative.Buffer is not found, referenced from io.netty.handler.ssl.ReferenceCountedOpenSslEngine

The following paths contain io.netty:netty-handler:4.1.51.Final:

io.grpc:grpc-netty:1.34.0 (compile) / io.netty:netty-codec-http2:4.1.51.Final (compile) / io.netty:netty-handler:4.1.51.Final (compile)
io.grpc:grpc-netty:1.34.0 (compile) / io.netty:netty-codec-http2:4.1.51.Final (compile) / io.netty:netty-codec-http:4.1.51.Final (compile) / io.netty:netty-handler:4.1.51.Final (compile)
io.grpc:grpc-netty:1.34.0 (compile) / io.netty:netty-handler-proxy:4.1.51.Final (runtime) / io.netty:netty-codec-http:4.1.51.Final (compile) / io.netty:netty-handler:4.1.51.Final (compile)
```
