### PR TITLE
Libraries BOM: gRPC 1.34.1

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -46,7 +46,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>30.1-android</guava.version>
     <google.cloud.java.version>0.145.0</google.cloud.java.version>
-    <io.grpc.version>1.33.1</io.grpc.version>
+    <io.grpc.version>1.34.1</io.grpc.version>
     <protobuf.version>3.14.0</protobuf.version>
     <http.version>1.38.0</http.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.


### PR DESCRIPTION
gRPC 1.34.1 has been released https://github.com/grpc/grpc-java/releases/tag/v1.34.1 (no release note yet?)