### PR TITLE
Trying Guava JRE flavor without using Guava BOM

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -69,10 +69,13 @@
     <dependencies>
       <dependency>
         <groupId>com.google.guava</groupId>
-        <artifactId>guava-bom</artifactId>
+        <artifactId>guava</artifactId>
         <version>${guava.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava-testlib</artifactId>
+        <version>${guava.version}</version>
       </dependency>
 
       <!-- protobufs from https://github.com/protocolbuffers/protobuf/tree/master/java -->

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -44,7 +44,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <guava.version>30.1-android</guava.version>
+    <guava.version>30.1-jre</guava.version>
     <google.cloud.java.version>0.146.0</google.cloud.java.version>
     <io.grpc.version>1.34.1</io.grpc.version>
     <protobuf.version>3.14.0</protobuf.version>

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -72,11 +72,6 @@
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
       </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava-testlib</artifactId>
-        <version>${guava.version}</version>
-      </dependency>
 
       <!-- protobufs from https://github.com/protocolbuffers/protobuf/tree/master/java -->
       <dependency>


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/1888#issuecomment-749044402

- Guava Android BOM has "guava" and "guava-testlib" artifacts.
- Guava JRE BOM has "guava", "guava-gwt", and "guava-testlib".

This PR uses "guava" and "guava-testlib" so that the Libraries BOM does not include the "guava-gwt".