### PR TITLE
GitHub CI to use local Maven repository cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,14 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
     - run: mkdir -p ~/.m2 && cp settings.xml ~/.m2/
     - run: ./mvnw -B -e install
     - run: cd gradle-plugin && ./gradlew build publishToMavenLocal

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,8 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
-    - uses: actions/cache@v2
+    - name: Cache Gradle files
+      uses: actions/cache@v2
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,13 @@ jobs:
       with:
         java-version: ${{matrix.java}}
     - run: java -version
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - run: mkdir -p ~/.m2 && cp settings.xml ~/.m2/
     - run: ./mvnw -B -e install
     - run: cd gradle-plugin && ./gradlew build publishToMavenLocal


### PR DESCRIPTION
Testing the speed of GitHub Actions CI with "cache" action.


 step | Without Cache (seconds) | With Cache (seconds)
------------ | ------------- | ----------
Setup Maven Cache | N/A | 44
Setup Gradle Cache | N/A | 3
Maven build | 1299 | 553
Gradle build | 98 | 52
Total | 1397 | 652

- Maven cache size: 1,228 MB
- Gradle cache size: 238 MB

This change does not affect the Kokoro build. Still we can know failures, if any, quickly.

# Todo

When to evict unused artifacts from cache? I think the timing when master branch is updated is best because nobody waits for the build.