### PR TITLE
Fixing sed parameter for the release script in gLinux

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -83,7 +83,7 @@ fi
 mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion=${VERSION} -DgenerateBackupPoms=false
 
 if [[ "${SUFFIX}" = "dependencies" ]]; then
-  sed -i "" "s/version = .*/version = ${VERSION}/" gradle-plugin/gradle.properties
+  sed -i -e "s/version = .*/version = ${VERSION}/" gradle-plugin/gradle.properties
 fi
 
 # Tags a new commit for this release.
@@ -93,7 +93,7 @@ git tag "${RELEASE_TAG}"
 mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion=${NEXT_SNAPSHOT} -DgenerateBackupPoms=false
 
 if [[ "${SUFFIX}" = "dependencies" ]]; then
-  sed -i "" "s/version = .*/version = ${NEXT_SNAPSHOT}/" gradle-plugin/gradle.properties
+  sed -i -e "s/version = .*/version = ${NEXT_SNAPSHOT}/" gradle-plugin/gradle.properties
 fi
 
 # Commits this next snapshot version.


### PR DESCRIPTION
The `sed` command's options have slightly different between Mac and gLinux:

In Mac, in-place update without a backup is `-i ""`, while Linux it tries to open a filename with an empty string. In gLinux we do not need to specify the empty string for `-i` option:

```
suztomo@suztomo:~/cloud-opensource-java$ sed -i "" -e "s/version = .*/version = ${VERSION}/" gradle-plugin/gradle.properties
sed: can't read : No such file or directory
```

In gLinux, `-i "s/version = .*/version = ${NEXT_SNAPSHOT}/"` means opening file `"s/version = .*/version = ${NEXT_SNAPSHOT}/"` as a backup. We need to specify `-e` explicitly for the sed expression.
