### PR TITLE
Release 1.5.6-dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-# Linkage Checker Enforcer Rule Change Log
+# Linkage Checker Enforcer Rule and Linkage Monitor Change Log
+
+## 1.5.6
+* Fixed false negative problem in Linkage Monitor where it did not find local
+  artifacts listed in a BOM ([#1919](
+  https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1919)).
+
+## 1.5.5
+* Linkage Monitor is part of the release process.
 
 ## 1.5.4
 * Fixed false positive linkage errors on unused private inner classes ([#1608](

--- a/boms/integration-tests/pom.xml
+++ b/boms/integration-tests/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>dependencies</artifactId>
-      <version>1.5.6-SNAPSHOT</version>
+      <version>1.5.6</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/boms/integration-tests/pom.xml
+++ b/boms/integration-tests/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>dependencies</artifactId>
-      <version>1.5.6</version>
+      <version>1.5.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.5.6</version>
+    <version>1.5.7-SNAPSHOT</version>
   </parent>
   <artifactId>dashboard</artifactId>
 

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.5.6-SNAPSHOT</version>
+    <version>1.5.6</version>
   </parent>
   <artifactId>dashboard</artifactId>
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.5.6-SNAPSHOT</version>
+    <version>1.5.6</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.5.6</version>
+    <version>1.5.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.5.6-SNAPSHOT</version>
+    <version>1.5.6</version>
   </parent>
 
   <artifactId>linkage-checker-enforcer-rules</artifactId>

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.5.6</version>
+    <version>1.5.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>linkage-checker-enforcer-rules</artifactId>

--- a/gradle-plugin/gradle.properties
+++ b/gradle-plugin/gradle.properties
@@ -1,2 +1,2 @@
 # scripts/prepare_release.sh maintains this value.
-version = 1.5.6-SNAPSHOT
+version = 1.5.6

--- a/gradle-plugin/gradle.properties
+++ b/gradle-plugin/gradle.properties
@@ -1,2 +1,2 @@
 # scripts/prepare_release.sh maintains this value.
-version = 1.5.6
+version = 1.5.7-SNAPSHOT

--- a/linkage-monitor/action.yml
+++ b/linkage-monitor/action.yml
@@ -7,7 +7,7 @@ runs:
       # scripts/release.sh updates the version part in the URL
       run: |
         curl --output /tmp/linkage-monitor.jar \
-        "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor/linkage-monitor-1.5.6-SNAPSHOT-all-deps.jar"
+        "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor/linkage-monitor-1.5.6-all-deps.jar"
       shell: bash
     - run: java -jar /tmp/linkage-monitor.jar com.google.cloud:libraries-bom
       shell: bash

--- a/linkage-monitor/action.yml
+++ b/linkage-monitor/action.yml
@@ -7,7 +7,7 @@ runs:
       # scripts/release.sh updates the version part in the URL
       run: |
         curl --output /tmp/linkage-monitor.jar \
-        "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor/linkage-monitor-1.5.6-all-deps.jar"
+        "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor/linkage-monitor-1.5.7-SNAPSHOT-all-deps.jar"
       shell: bash
     - run: java -jar /tmp/linkage-monitor.jar com.google.cloud:libraries-bom
       shell: bash

--- a/linkage-monitor/pom.xml
+++ b/linkage-monitor/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.5.6</version>
+    <version>1.5.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>linkage-monitor</artifactId>

--- a/linkage-monitor/pom.xml
+++ b/linkage-monitor/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.5.6-SNAPSHOT</version>
+    <version>1.5.6</version>
   </parent>
 
   <artifactId>linkage-monitor</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>dependencies-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.5.6</version>
+  <version>1.5.7-SNAPSHOT</version>
 
   <name>Cloud Tools Open Source Code Hygiene Tooling</name>
   <url>https://github.com/GoogleCloudPlatform/cloud-opensource-java/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>dependencies-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.5.6-SNAPSHOT</version>
+  <version>1.5.6</version>
 
   <name>Cloud Tools Open Source Code Hygiene Tooling</name>
   <url>https://github.com/GoogleCloudPlatform/cloud-opensource-java/</url>


### PR DESCRIPTION
A patch release to fix the Linkage Monitor bug https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1919