### PR TITLE
The enforcer rule to entry point JARs for BOMs correctly

### DIFF
--- a/enforcer-rules/src/it/bom-project-no-error/pom.xml
+++ b/enforcer-rules/src/it/bom-project-no-error/pom.xml
@@ -35,16 +35,12 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- These two artifacts have linkage errors that are not reachable -->
+      <!-- The transitive dependency of this artifact has linkage errors on AvalonLogger. They are
+      unreachable. https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1871 -->
       <dependency>
-        <groupId>com.google.api-client</groupId>
-        <artifactId>google-api-client</artifactId>
-        <version>1.27.0</version>
-      </dependency>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-core</artifactId>
-        <version>1.17.1</version>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client</artifactId>
+        <version>1.38.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/enforcer-rules/src/it/report-only-reachable-bom/invoker.properties
+++ b/enforcer-rules/src/it/report-only-reachable-bom/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=verify
+invoker.buildResult=failure

--- a/enforcer-rules/src/it/report-only-reachable-bom/pom.xml
+++ b/enforcer-rules/src/it/report-only-reachable-bom/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2020 Google LLC.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.google.cloud.tools.opensource</groupId>
+  <artifactId>bom-having-linkage-conflicts</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>bom-having-linkage-conflicts</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- These two artifacts have linkage errors that are reachable
+           https://github.com/googleapis/java-shared-dependencies/pull/248#pullrequestreview-578503417
+      -->
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-census</artifactId>
+        <version>1.35.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opencensus</groupId>
+        <artifactId>opencensus-api</artifactId>
+        <version>0.28.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M3</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.google.cloud.tools</groupId>
+            <artifactId>linkage-checker-enforcer-rules</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>enforce-linkage-checker</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <LinkageCheckerRule
+                  implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
+                  <dependencySection>DEPENDENCY_MANAGEMENT</dependencySection>
+                  <reportOnlyReachable>true</reportOnlyReachable>
+                </LinkageCheckerRule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/enforcer-rules/src/it/report-only-reachable-bom/pom.xml
+++ b/enforcer-rules/src/it/report-only-reachable-bom/pom.xml
@@ -35,8 +35,9 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- These two artifacts have linkage errors that are reachable
-           https://github.com/googleapis/java-shared-dependencies/pull/248#pullrequestreview-578503417
+      <!--
+        grpc-census:1.35.0 and opencensus-api:0.28.1 have reachable linkage errors.
+        https://github.com/googleapis/java-shared-dependencies/pull/248#pullrequestreview-578503417
       -->
       <dependency>
         <groupId>io.grpc</groupId>
@@ -52,7 +53,6 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
 
   <build>
     <plugins>

--- a/enforcer-rules/src/it/report-only-reachable-bom/pom.xml
+++ b/enforcer-rules/src/it/report-only-reachable-bom/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright 2020 Google LLC.
+  ~ Copyright 2021 Google LLC.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/enforcer-rules/src/it/report-only-reachable-bom/pom.xml
+++ b/enforcer-rules/src/it/report-only-reachable-bom/pom.xml
@@ -40,8 +40,10 @@
       -->
       <dependency>
         <groupId>io.grpc</groupId>
-        <artifactId>grpc-census</artifactId>
+        <artifactId>grpc-bom</artifactId>
         <version>1.35.0</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.opencensus</groupId>

--- a/enforcer-rules/src/it/report-only-reachable-bom/pom.xml
+++ b/enforcer-rules/src/it/report-only-reachable-bom/pom.xml
@@ -21,11 +21,11 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.google.cloud.tools.opensource</groupId>
-  <artifactId>bom-having-linkage-conflicts</artifactId>
+  <artifactId>bom-having-linkage-errors</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <name>bom-having-linkage-conflicts</name>
+  <name>bom-having-linkage-errors</name>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/enforcer-rules/src/it/report-only-reachable-bom/verify.groovy
+++ b/enforcer-rules/src/it/report-only-reachable-bom/verify.groovy
@@ -1,0 +1,7 @@
+def buildLog = new File(basedir, "build.log").text.replaceAll("\\r\\n", "\n")
+
+assert buildLog.contains('''\
+(io.opencensus:opencensus-api:0.28.1) Class io.opencensus.trace.unsafe.ContextUtils has default access;
+  referenced by 1 class file in a different package
+    io.grpc.census.CensusTracingModule (io.grpc:grpc-census:1.35.0)
+''')

--- a/enforcer-rules/src/it/report-only-reachable-bom/verify.groovy
+++ b/enforcer-rules/src/it/report-only-reachable-bom/verify.groovy
@@ -2,6 +2,7 @@ def buildLog = new File(basedir, "build.log").text.replaceAll("\\r\\n", "\n")
 
 assert buildLog.contains('''\
 (io.opencensus:opencensus-api:0.28.1) Class io.opencensus.trace.unsafe.ContextUtils has default access;
-  referenced by 1 class file in a different package
+  referenced by 2 class files in a different package
     io.grpc.census.CensusTracingModule (io.grpc:grpc-census:1.35.0)
+    io.grpc.testing.integration.AbstractInteropTest (io.grpc:grpc-interop-testing:1.35.0)
 ''')

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -380,7 +380,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
   }
 
   /**
-   * Returns the class path entries that contains entry point classes.
+   * Returns the class path entries that contain entry point classes.
    *
    * <p>For BOM projects, they are the dependencies listed in the {@code dependencyManagement}
    * section.

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -380,7 +380,7 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
   }
 
   /**
-   * Returns class path entries that contains entry point classes.
+   * Returns the class path entries that contains entry point classes.
    *
    * <p>For BOM projects, they are the dependencies listed in the {@code dependencyManagement}
    * section.

--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -243,6 +244,8 @@ public class LinkageMonitor {
     ImmutableList<Artifact> snapshotManagedDependencies = snapshot.getManagedDependencies();
     ClassPathResult classPathResult = (new ClassPathBuilder()).resolve(snapshotManagedDependencies, true);
     ImmutableList<ClassPathEntry> classpath = classPathResult.getClassPath();
+    logger.info("Class path for the snapshot BOM" +
+        classpath.stream().map(ClassPathEntry::toString).collect(Collectors.joining("\n")));
     List<ClassPathEntry> entryPointJars = classpath.subList(0, snapshotManagedDependencies.size());
 
     ImmutableSet<LinkageProblem> problemsInSnapshot =

--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
@@ -244,8 +244,9 @@ public class LinkageMonitor {
     ImmutableList<Artifact> snapshotManagedDependencies = snapshot.getManagedDependencies();
     ClassPathResult classPathResult = (new ClassPathBuilder()).resolve(snapshotManagedDependencies, true);
     ImmutableList<ClassPathEntry> classpath = classPathResult.getClassPath();
-    logger.info("Class path for the snapshot BOM" +
-        classpath.stream().map(ClassPathEntry::toString).collect(Collectors.joining("\n")));
+    logger.info(
+        "Class path for the snapshot BOM"
+            + classpath.stream().map(ClassPathEntry::toString).collect(Collectors.joining("\n")));
     List<ClassPathEntry> entryPointJars = classpath.subList(0, snapshotManagedDependencies.size());
 
     ImmutableSet<LinkageProblem> problemsInSnapshot =

--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
@@ -48,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -244,9 +243,6 @@ public class LinkageMonitor {
     ImmutableList<Artifact> snapshotManagedDependencies = snapshot.getManagedDependencies();
     ClassPathResult classPathResult = (new ClassPathBuilder()).resolve(snapshotManagedDependencies, true);
     ImmutableList<ClassPathEntry> classpath = classPathResult.getClassPath();
-    logger.info(
-        "Class path for the snapshot BOM"
-            + classpath.stream().map(ClassPathEntry::toString).collect(Collectors.joining("\n")));
     List<ClassPathEntry> entryPointJars = classpath.subList(0, snapshotManagedDependencies.size());
 
     ImmutableSet<LinkageProblem> problemsInSnapshot =


### PR DESCRIPTION
Fixes #1932 , where the enforcer rule was not detecting problems when reportOnlyReachable is true.