### PR TITLE
Adding a test for test scope for the enforcer rule

### DIFF
--- a/enforcer-rules/src/it/test-scope/invoker.properties
+++ b/enforcer-rules/src/it/test-scope/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=verify
+invoker.buildResult=success
+invoker.java.version=1.8

--- a/enforcer-rules/src/it/test-scope/pom.xml
+++ b/enforcer-rules/src/it/test-scope/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright 2020 Google LLC.
+  ~ Copyright 2021 Google LLC.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -34,8 +34,9 @@
 
   <dependencies>
     <!--
-      These two artifacts have reachable linkage errors. However, because one of them has test
-      scope, the conflict does not cause problems at users' runtime
+      These two artifacts have reachable linkage errors. However, the latter has test scope, the
+      conflict does not cause problems at users' runtime. Linkage Checker should not report the
+      linkage errors.
     -->
     <dependency>
       <groupId>com.google.api-client</groupId>

--- a/enforcer-rules/src/it/test-scope/pom.xml
+++ b/enforcer-rules/src/it/test-scope/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2020 Google LLC.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.google.cloud.tools.opensource</groupId>
+  <artifactId>dependency-with-test-scope</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>dependency-with-test-scope</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <!--
+      These two artifacts have reachable linkage errors. However, because one of them has test
+      scope, the conflict does not cause problems at users' runtime
+    -->
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>1.27.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+      <version>1.17.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M3</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.google.cloud.tools</groupId>
+            <artifactId>linkage-checker-enforcer-rules</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>enforce-linkage-checker</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <LinkageCheckerRule
+                  implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
+                  <reportOnlyReachable>true</reportOnlyReachable>
+                </LinkageCheckerRule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/enforcer-rules/src/it/test-scope/verify.groovy
+++ b/enforcer-rules/src/it/test-scope/verify.groovy
@@ -1,0 +1,3 @@
+def buildLog = new File(basedir, "build.log").text.replaceAll("\\r\\n", "\n")
+
+assert buildLog.contains('No reachable error found')


### PR DESCRIPTION
Not a bug. But I found the project lacks a test for test-scope dependencies (the enforcer rule excludes such dependencies in [`entryPoints` method](https://github.com/GoogleCloudPlatform/cloud-opensource-java/blob/master/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java#L402))