### PR TITLE
BOM release doc: git diff command before starting a BOM release

### DIFF
--- a/boms/cloud-oss-bom/RELEASING.md
+++ b/boms/cloud-oss-bom/RELEASING.md
@@ -16,14 +16,20 @@ tool if you not previously done so.
 
 ## Decide the release version
 
-Check the changes since the last release. For example, if the last BOM release was 16.4.0, then run
-`git diff v16.4.0-bom -- boms/cloud-oss-bom/pom.xml`.
+To decide the release version, check the changes since the last release.
 (This step ensures that you do not miss expected libraries upgrades.)
+For example, if the last BOM release was version 16.4.0, then run the following command
+to see the difference.
+
+```
+git diff v16.4.0-bom -- boms/cloud-oss-bom/pom.xml`
+```
+
 If the difference includes the google-cloud-bom version, then check the change in the release note
-at https://github.com/googleapis/java-cloud-bom/releases.
+at https://github.com/googleapis/java-cloud-bom/releases as well.
 
 From these changes in the content of the Libraries BOM,
-determine the version of the Libraries BOM by the following logic:
+determine the release version by the following logic:
 
 - If there are at least one major version bumps among the changes, it's a major version bump.
 - If there are at least one minor version bumps (no major version change), it's a minor version

--- a/boms/cloud-oss-bom/RELEASING.md
+++ b/boms/cloud-oss-bom/RELEASING.md
@@ -31,8 +31,8 @@ at https://github.com/googleapis/java-cloud-bom/releases as well.
 From these changes in the content of the Libraries BOM,
 determine the release version by the following logic:
 
-- If there are at least one major version bumps among the changes, it's a major version bump.
-- If there are at least one minor version bumps (no major version change), it's a minor version
+- If there is at least one major version bump among the changes, it's a major version bump.
+- If there is at least one minor version bump (no major version change), it's a minor version
   bump.
 - If there are only patch version bumps (no major or minor version change), it's a patch version
   bump.

--- a/boms/cloud-oss-bom/RELEASING.md
+++ b/boms/cloud-oss-bom/RELEASING.md
@@ -22,7 +22,7 @@ For example, if the last BOM release was version 16.4.0, then run the following 
 to see the difference.
 
 ```
-git diff v16.4.0-bom -- boms/cloud-oss-bom/pom.xml`
+git diff v16.4.0-bom -- boms/cloud-oss-bom/pom.xml
 ```
 
 If the difference includes the google-cloud-bom version, then check the change in the release note

--- a/boms/cloud-oss-bom/RELEASING.md
+++ b/boms/cloud-oss-bom/RELEASING.md
@@ -14,6 +14,25 @@ tool if you not previously done so.
 
 * Install and configure the [repo tool](https://github.com/googleapis/github-repo-automation).
 
+## Decide the release version
+
+Check the changes since the last release. For example, if the last BOM release was 16.4.0, then run
+`git diff v16.4.0-bom -- boms/cloud-oss-bom/pom.xml`.
+(This step ensures that you do not miss expected libraries upgrades.)
+If the difference includes the google-cloud-bom version, then check the change in the release note
+at https://github.com/googleapis/java-cloud-bom/releases.
+
+From these changes in the content of the Libraries BOM,
+determine the version of the Libraries BOM by the following logic:
+
+- If there are at least one major version bumps among the changes, it's a major version bump.
+- If there are at least one minor version bumps (no major version change), it's a minor version
+  bump.
+- If there are only patch version bumps (no major or minor version change), it's a patch version
+  bump.
+
+We use the release version for `release.sh` in the next steps.
+
 ## Steps
 
 All on your corp desktop: 


### PR DESCRIPTION
I missed the google-cloud-bom bump today and the same thing happened to me before. I think I need to remind future me to confirm the changes before performing the release.