### PR TITLE
Release 18.0.0-bom

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>18.0.0</version>
+  <version>18.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>17.0.1-SNAPSHOT</version>
+  <version>18.0.0</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>18.0.0</version>
+        <version>18.0.1-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>17.0.1-SNAPSHOT</version>
+        <version>18.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Release 18.0.0-bom

```
suztomo@suztomo:~/cloud-opensource-java$ git diff v17.0.0-bom -- boms/cloud-oss-bom/pom.xml
diff --git a/boms/cloud-oss-bom/pom.xml b/boms/cloud-oss-bom/pom.xml
index a2d650c8..b183d1eb 100644
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>17.0.0</version>
+  <version>17.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>
@@ -45,8 +45,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>30.1-android</guava.version>
-    <google.cloud.java.version>0.147.0</google.cloud.java.version>
-    <io.grpc.version>1.35.0</io.grpc.version>
+    <google.cloud.java.version>0.148.0</google.cloud.java.version>
+    <io.grpc.version>1.36.0</io.grpc.version>
     <protobuf.version>3.15.1</protobuf.version>
     <http.version>1.38.1</http.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
```

google-cloud-bom 0.148.0 includes google-cloud-spanner-bom 4.0.1 (a major version bump from previously included 3.2.1)