### PR TITLE
Linkage Monitor not to read dependencyManagement section of parent poms

### DIFF
--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
@@ -194,8 +194,17 @@ public class LinkageMonitor {
         artifactToVersion.put(versionlessCoordinates, model.getVersion());
         logger.fine("Found local artifact: " + model);
         DependencyManagement dependencyManagement = model.getDependencyManagement();
-        if ("pom".equals(model.getPackaging()) && dependencyManagement != null) {
-          // Read the content of a BOM.
+
+        // For gax-java repository (Gradle), the dependencyManagement section of the gax-bom/pom.xml
+        // tells what artifacts the repository produces. However, we have to distinguish BOMs from
+        // normal parent poms
+        // (https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1958).
+        // Unfortunately the difference between a BOM and a parent POM is how we name it. Therefore
+        // this logic checks whether the artifactId of the pom.xml files has "-bom" or not.
+        if (model.getArtifactId().endsWith("-bom")
+            && "pom".equals(model.getPackaging())
+            && dependencyManagement != null) {
+          // Read the dependencyManagement section of a BOM.
           for (org.apache.maven.model.Dependency dependency :
               dependencyManagement.getDependencies()) {
             String managedDependencyVersionlessCoordinates =

--- a/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
+++ b/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
@@ -279,6 +279,7 @@ public class LinkageMonitorTest {
 
     // This should not include project under "build" directory, but should include the entries
     // in the dependencyManagement section of the gax-bom/pom.xml.
+    // This should not include the grpc-google-cloud-pubsub-v1 in the root testproject pom.xml
     Truth.assertThat(localArtifacts).hasSize(6);
     assertEquals("0.0.1-SNAPSHOT", localArtifacts.get("com.google.cloud.tools:test-project"));
     assertEquals("0.0.2-SNAPSHOT", localArtifacts.get("com.google.cloud.tools:test-subproject"));
@@ -287,6 +288,10 @@ public class LinkageMonitorTest {
         "localArtifacts should contain the dependency management section in the BOM",
         "1.60.2-SNAPSHOT",
         localArtifacts.get("com.google.api:gax"));
+
+    // localArtifacts should not include the dependencyManagement section of a non-BOM pom.xml
+    Truth.assertThat(localArtifacts)
+        .doesNotContainKey("com.google.api.grpc:grpc-google-cloud-pubsub-v1");
   }
 
   @Test

--- a/linkage-monitor/src/test/resources/testproject/pom.xml
+++ b/linkage-monitor/src/test/resources/testproject/pom.xml
@@ -11,4 +11,13 @@
 
   <name>Test Project for LinkageMonitorTest</name>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>grpc-google-cloud-pubsub-v1</artifactId>
+        <version>1.93.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>


### PR DESCRIPTION
Fixes #1958.

@elharo Do you think of a better way than checking "-bom" to distinguish a BOM from a non-BOM?

- On one hand, I want Linkage Monitor to read the dependencyManagement section of the gax-bom.
  The gax-java repository is a Gradle project and the repository does not have pom.xml files for its artifacts (gax, gax-httpjson, gax-grpc). This is the background of https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/1920.
- On the other hand, I don't want Linkage Monitor to read the dependencyManagement section of the [google-cloud-asset-parent pom.xml](https://github.com/googleapis/java-asset/blob/master/pom.xml#L68). This behavior caused  #1958.


