### PR TITLE
Linkage monitor to read file to get list of artifacts for a repository (when necessary)

### DIFF
--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
@@ -482,6 +482,4 @@ public class LinkageMonitor {
     // "-SNAPSHOT" suffix for coordinate to distinguish easily.
     return new Bom(bom.getCoordinates() + "-SNAPSHOT", managedDependencies.build());
   }
-
-
 }

--- a/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
+++ b/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
@@ -272,7 +272,7 @@ public class LinkageMonitorTest {
   }
 
   @Test
-  public void testFindLocalArtifacts() {
+  public void testFindLocalArtifacts() throws IOException, MavenRepositoryException {
     ImmutableMap<String, String> localArtifacts =
         LinkageMonitor.findLocalArtifacts(
             system, session, Paths.get("src/test/resources/testproject"));
@@ -280,17 +280,21 @@ public class LinkageMonitorTest {
     // This should not include project under "build" directory, but should include the entries
     // in the dependencyManagement section of the gax-bom/pom.xml.
     Truth.assertThat(localArtifacts).hasSize(6);
+    Truth.assertThat(localArtifacts)
+        .doesNotContainKey("com.google.cloud.tools:copy-of-test-subproject-in-build");
     assertEquals("0.0.1-SNAPSHOT", localArtifacts.get("com.google.cloud.tools:test-project"));
     assertEquals("0.0.2-SNAPSHOT", localArtifacts.get("com.google.cloud.tools:test-subproject"));
     assertEquals("1.60.2-SNAPSHOT", localArtifacts.get("com.google.api:gax-bom"));
-    assertEquals(
-        "localArtifacts should contain the dependency management section in the BOM",
-        "1.60.2-SNAPSHOT",
-        localArtifacts.get("com.google.api:gax"));
+
+    // Linkage Monitor should read linkage-monitor-artifacts.txt. The file tells versionless
+    // coordinates
+    Truth.assertThat(localArtifacts).containsKey("com.google.api:gax");
+    Truth.assertThat(localArtifacts).containsKey("com.google.api:gax-grpc");
+    Truth.assertThat(localArtifacts).containsKey("com.google.api:gax-httpjson");
   }
 
   @Test
-  public void testFindLocalArtifacts_absolutePath() {
+  public void testFindLocalArtifacts_absolutePath() throws IOException, MavenRepositoryException {
     Path relativePath = Paths.get("src/test/resources/testproject");
     Path absolutePath = relativePath.toAbsolutePath();
     ImmutableMap<String, String> localArtifactsFromAbsolutePath =
@@ -303,5 +307,58 @@ public class LinkageMonitorTest {
         "findLocalArtifacts should behave the same for relative and absolute paths",
         localArtifactsFromRelativePath,
         localArtifactsFromAbsolutePath);
+  }
+
+  @Test
+  public void testFindLocalArtifactsFromFile() throws IOException, MavenRepositoryException {
+    Path artifactFile = Paths.get("src/test/resources/testproject/linkage-monitor-artifacts.txt");
+    ImmutableMap<String, String> localArtifacts =
+        LinkageMonitor.findLocalArtifactsFromFile(artifactFile);
+
+    Truth.assertThat(localArtifacts.keySet())
+        .containsExactly(
+            "com.google.api:gax", "com.google.api:gax-grpc", "com.google.api:gax-httpjson");
+  }
+
+  @Test
+  public void testFindLocalArtifactsFromFile_invalidLines()
+      throws IOException, MavenRepositoryException {
+    // This file has coordinates with versions
+    Path artifactFile =
+        Paths.get("src/test/resources/testproject/linkage-monitor-artifacts-invalid-format.txt");
+
+    try {
+      LinkageMonitor.findLocalArtifactsFromFile(artifactFile);
+      fail();
+    } catch (IOException ex) {
+      // pass
+    }
+  }
+
+  @Test
+  public void testFindLocalArtifactsFromFile_nonexistentCoordinates()
+      throws IOException, MavenRepositoryException {
+    // There's no such artifact with "com.google.api:gax-nonexistent-coordinates"
+    Path artifactFile =
+        Paths.get(
+            "src/test/resources/testproject/linkage-monitor-artifacts-nonexistent-coordinates.txt");
+
+    try {
+      LinkageMonitor.findLocalArtifactsFromFile(artifactFile);
+      fail();
+    } catch (IOException ex) {
+      // pass
+    }
+  }
+
+  @Test
+  public void testFindLocalArtifactsFromFile_nonexistentFile()
+      throws IOException, MavenRepositoryException {
+    // Most of the repositories do not have the file. Linkage Monitor should not throw an exception.
+    Path artifactFile = Paths.get("src/test/resources/testproject/nonexistent-file");
+
+    ImmutableMap<String, String> localArtifactsFromFile =
+        LinkageMonitor.findLocalArtifactsFromFile(artifactFile);
+    Truth.assertThat(localArtifactsFromFile).isEmpty();
   }
 }

--- a/linkage-monitor/src/test/resources/testproject/gax-bom/pom.xml
+++ b/linkage-monitor/src/test/resources/testproject/gax-bom/pom.xml
@@ -14,34 +14,6 @@
         <artifactId>gax</artifactId>
         <version>1.60.2-SNAPSHOT</version>
       </dependency>
-      <dependency>
-        <groupId>com.google.api</groupId>
-        <artifactId>gax</artifactId>
-        <version>1.60.2-SNAPSHOT</version>
-        <classifier>testlib</classifier>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api</groupId>
-        <artifactId>gax-grpc</artifactId>
-        <version>1.60.2-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api</groupId>
-        <artifactId>gax-grpc</artifactId>
-        <version>1.60.2-SNAPSHOT</version>
-        <classifier>testlib</classifier>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api</groupId>
-        <artifactId>gax-httpjson</artifactId>
-        <version>0.77.2-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api</groupId>
-        <artifactId>gax-httpjson</artifactId>
-        <version>0.77.2-SNAPSHOT</version>
-        <classifier>testlib</classifier>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts-invalid-format.txt
+++ b/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts-invalid-format.txt
@@ -1,0 +1,3 @@
+com.google.api:gax:1.0.0
+com.google.api:gax-grpc:1.0.0
+com.google.api:gax-httpjson:1.0.0

--- a/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts-nonexistent-coordinates.txt
+++ b/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts-nonexistent-coordinates.txt
@@ -1,0 +1,2 @@
+com.google.api:gax-nonexistent-coordinates
+com.google.api:gax-grpc

--- a/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts.txt
+++ b/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts.txt
@@ -1,0 +1,3 @@
+com.google.api:gax
+com.google.api:gax-grpc
+com.google.api:gax-httpjson


### PR DESCRIPTION
@elharo As discussed, this replaces the last month's https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/1920/files.

# What is the file will look like?

gax-java repository to have linkage-monitor-artifacts.txt in the root directory.

```
com.google.api:gax
com.google.api:gax-grpc
com.google.api:gax-httpjson
```

CC: @chingor13 who owns gax-java

# Why versionless coordinates?

One thing I didn't know during the discussion was that the versions of generated artifacts are not static. This PR uses `RepositoryUtility.findVersions()` to find the latest version for the versionless coordinates listed in `linkage-monitor-artifacts.txt`. (Alternatively we could modify gax-java's build.gradle to generate linkage-monitor-artifacts.txt with concrete coordinates. This seemed complex compared to `RepositoryUtility.findVersions()`).

Fixes #1958 