### PR TITLE
Linkage Monitor to read artifact list file that contains Maven coordinates with versions

### DIFF
--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
@@ -482,6 +482,4 @@ public class LinkageMonitor {
     // "-SNAPSHOT" suffix for coordinate to distinguish easily.
     return new Bom(bom.getCoordinates() + "-SNAPSHOT", managedDependencies.build());
   }
-
-
 }

--- a/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
+++ b/linkage-monitor/src/main/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitor.java
@@ -223,10 +223,12 @@ public class LinkageMonitor {
    * Returns a map from versionless coordinates to the versions for the Maven coordinates listed in
    * {@code artifactListFile}. If the file does not exists, it returns an empty map.
    *
-   * @throws IOException if the artifactListFile contains line in an invalid format for versionless coordinates
+   * @throws IOException if the artifactListFile contains line in an invalid format for versionless
+   *     coordinates
    */
   @VisibleForTesting
-  static ImmutableMap<String, String> findLocalArtifactsFromFile(Path artifactListFile) throws IOException {
+  static ImmutableMap<String, String> findLocalArtifactsFromFile(Path artifactListFile)
+      throws IOException {
     if (!Files.exists(artifactListFile)) {
       return ImmutableMap.of();
     }

--- a/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
+++ b/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
@@ -272,7 +272,7 @@ public class LinkageMonitorTest {
   }
 
   @Test
-  public void testFindLocalArtifacts() {
+  public void testFindLocalArtifacts() throws IOException, MavenRepositoryException {
     ImmutableMap<String, String> localArtifacts =
         LinkageMonitor.findLocalArtifacts(
             system, session, Paths.get("src/test/resources/testproject"));
@@ -280,17 +280,21 @@ public class LinkageMonitorTest {
     // This should not include project under "build" directory, but should include the entries
     // in the dependencyManagement section of the gax-bom/pom.xml.
     Truth.assertThat(localArtifacts).hasSize(6);
+    Truth.assertThat(localArtifacts)
+        .doesNotContainKey("com.google.cloud.tools:copy-of-test-subproject-in-build");
     assertEquals("0.0.1-SNAPSHOT", localArtifacts.get("com.google.cloud.tools:test-project"));
     assertEquals("0.0.2-SNAPSHOT", localArtifacts.get("com.google.cloud.tools:test-subproject"));
     assertEquals("1.60.2-SNAPSHOT", localArtifacts.get("com.google.api:gax-bom"));
-    assertEquals(
-        "localArtifacts should contain the dependency management section in the BOM",
-        "1.60.2-SNAPSHOT",
-        localArtifacts.get("com.google.api:gax"));
+
+    // Linkage Monitor should read linkage-monitor-artifacts.txt. The file tells versionless
+    // coordinates
+    Truth.assertThat(localArtifacts).containsKey("com.google.api:gax");
+    Truth.assertThat(localArtifacts).containsKey("com.google.api:gax-grpc");
+    Truth.assertThat(localArtifacts).containsKey("com.google.api:gax-httpjson");
   }
 
   @Test
-  public void testFindLocalArtifacts_absolutePath() {
+  public void testFindLocalArtifacts_absolutePath() throws IOException, MavenRepositoryException {
     Path relativePath = Paths.get("src/test/resources/testproject");
     Path absolutePath = relativePath.toAbsolutePath();
     ImmutableMap<String, String> localArtifactsFromAbsolutePath =
@@ -303,5 +307,58 @@ public class LinkageMonitorTest {
         "findLocalArtifacts should behave the same for relative and absolute paths",
         localArtifactsFromRelativePath,
         localArtifactsFromAbsolutePath);
+  }
+
+  @Test
+  public void testFindLocalArtifactsFromFile() throws IOException, MavenRepositoryException {
+    Path artifactFile = Paths.get("src/test/resources/testproject/linkage-monitor-artifacts.txt");
+    ImmutableMap<String, String> localArtifacts =
+        LinkageMonitor.findLocalArtifactsFromFile(artifactFile);
+
+    Truth.assertThat(localArtifacts.keySet())
+        .containsExactly(
+            "com.google.api:gax", "com.google.api:gax-grpc", "com.google.api:gax-httpjson");
+  }
+
+  @Test
+  public void testFindLocalArtifactsFromFile_invalidLines()
+      throws IOException, MavenRepositoryException {
+    // This file has coordinates with versions
+    Path artifactFile =
+        Paths.get("src/test/resources/testproject/linkage-monitor-artifacts-invalid-format.txt");
+
+    try {
+      LinkageMonitor.findLocalArtifactsFromFile(artifactFile);
+      fail();
+    } catch (IOException ex) {
+      // pass
+    }
+  }
+
+  @Test
+  public void testFindLocalArtifactsFromFile_nonexistentCoordinates()
+      throws IOException, MavenRepositoryException {
+    // There's no such artifact with "com.google.api:gax-nonexistent-coordinates"
+    Path artifactFile =
+        Paths.get(
+            "src/test/resources/testproject/linkage-monitor-artifacts-nonexistent-coordinates.txt");
+
+    try {
+      LinkageMonitor.findLocalArtifactsFromFile(artifactFile);
+      fail();
+    } catch (IOException ex) {
+      // pass
+    }
+  }
+
+  @Test
+  public void testFindLocalArtifactsFromFile_nonexistentFile()
+      throws IOException, MavenRepositoryException {
+    // Most of the repositories do not have the file. Linkage Monitor should not throw an exception.
+    Path artifactFile = Paths.get("src/test/resources/testproject/nonexistent-file");
+
+    ImmutableMap<String, String> localArtifactsFromFile =
+        LinkageMonitor.findLocalArtifactsFromFile(artifactFile);
+    Truth.assertThat(localArtifactsFromFile).isEmpty();
   }
 }

--- a/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
+++ b/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
@@ -277,20 +277,21 @@ public class LinkageMonitorTest {
         LinkageMonitor.findLocalArtifacts(
             system, session, Paths.get("src/test/resources/testproject"));
 
-    // This should not include project under "build" directory, but should include the entries
-    // in the dependencyManagement section of the gax-bom/pom.xml.
-    Truth.assertThat(localArtifacts).hasSize(6);
+    // This should not include project under "build" directory
     Truth.assertThat(localArtifacts)
         .doesNotContainKey("com.google.cloud.tools:copy-of-test-subproject-in-build");
-    assertEquals("0.0.1-SNAPSHOT", localArtifacts.get("com.google.cloud.tools:test-project"));
-    assertEquals("0.0.2-SNAPSHOT", localArtifacts.get("com.google.cloud.tools:test-subproject"));
-    assertEquals("1.60.2-SNAPSHOT", localArtifacts.get("com.google.api:gax-bom"));
 
-    // Linkage Monitor should read linkage-monitor-artifacts.txt. The file tells versionless
-    // coordinates
-    Truth.assertThat(localArtifacts).containsKey("com.google.api:gax");
-    Truth.assertThat(localArtifacts).containsKey("com.google.api:gax-grpc");
-    Truth.assertThat(localArtifacts).containsKey("com.google.api:gax-httpjson");
+    // Linkage Monitor should read linkage-monitor-artifacts.txt.
+    Truth.assertThat(localArtifacts)
+        .containsExactlyEntriesIn(
+            ImmutableMap.builder()
+                .put("com.google.cloud.tools:test-project", "0.0.1-SNAPSHOT")
+                .put("com.google.cloud.tools:test-subproject", "0.0.2-SNAPSHOT")
+                .put("com.google.api:gax-bom", "1.60.2-SNAPSHOT")
+                .put("com.google.api:gax", "1.60.0-SNAPSHOT")
+                .put("com.google.api:gax-grpc", "1.60.0-SNAPSHOT")
+                .put("com.google.api:gax-httpjson", "0.77.0-SNAPSHOT")
+                .build());
   }
 
   @Test
@@ -315,9 +316,12 @@ public class LinkageMonitorTest {
     ImmutableMap<String, String> localArtifacts =
         LinkageMonitor.findLocalArtifactsFromFile(artifactFile);
 
-    Truth.assertThat(localArtifacts.keySet())
-        .containsExactly(
-            "com.google.api:gax", "com.google.api:gax-grpc", "com.google.api:gax-httpjson");
+    Truth.assertThat(localArtifacts)
+        .containsExactlyEntriesIn(
+            ImmutableMap.of(
+                "com.google.api:gax", "1.60.0-SNAPSHOT",
+                "com.google.api:gax-grpc", "1.60.0-SNAPSHOT",
+                "com.google.api:gax-httpjson", "0.77.0-SNAPSHOT"));
   }
 
   @Test

--- a/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
+++ b/linkage-monitor/src/test/java/com/google/cloud/tools/dependencies/linkagemonitor/LinkageMonitorTest.java
@@ -149,7 +149,7 @@ public class LinkageMonitorTest {
   }
 
   @Test
-  public void generateMessageForNewError() throws IOException {
+  public void generateMessageForNewError() {
     Set<LinkageProblem> baselineProblems = ImmutableSet.of(classNotFoundProblem);
 
     ImmutableSet<LinkageProblem> snapshotProblems =
@@ -272,7 +272,7 @@ public class LinkageMonitorTest {
   }
 
   @Test
-  public void testFindLocalArtifacts() throws IOException, MavenRepositoryException {
+  public void testFindLocalArtifacts() throws IOException {
     ImmutableMap<String, String> localArtifacts =
         LinkageMonitor.findLocalArtifacts(
             system, session, Paths.get("src/test/resources/testproject"));
@@ -294,7 +294,7 @@ public class LinkageMonitorTest {
   }
 
   @Test
-  public void testFindLocalArtifacts_absolutePath() throws IOException, MavenRepositoryException {
+  public void testFindLocalArtifacts_absolutePath() throws IOException {
     Path relativePath = Paths.get("src/test/resources/testproject");
     Path absolutePath = relativePath.toAbsolutePath();
     ImmutableMap<String, String> localArtifactsFromAbsolutePath =
@@ -310,7 +310,7 @@ public class LinkageMonitorTest {
   }
 
   @Test
-  public void testFindLocalArtifactsFromFile() throws IOException, MavenRepositoryException {
+  public void testFindLocalArtifactsFromFile() throws IOException {
     Path artifactFile = Paths.get("src/test/resources/testproject/linkage-monitor-artifacts.txt");
     ImmutableMap<String, String> localArtifacts =
         LinkageMonitor.findLocalArtifactsFromFile(artifactFile);
@@ -321,9 +321,23 @@ public class LinkageMonitorTest {
   }
 
   @Test
-  public void testFindLocalArtifactsFromFile_invalidLines()
-      throws IOException, MavenRepositoryException {
-    // This file has coordinates with versions
+  public void testFindLocalArtifactsFromFile_emptyLines() throws IOException {
+    Path artifactFile =
+        Paths.get("src/test/resources/testproject/linkage-monitor-artifacts-with-empty-line.txt");
+    ImmutableMap<String, String> localArtifacts =
+        LinkageMonitor.findLocalArtifactsFromFile(artifactFile);
+
+    Truth.assertThat(localArtifacts)
+        .containsExactlyEntriesIn(
+            ImmutableMap.of(
+                "com.google.api:gax", "1.60.0-SNAPSHOT",
+                "com.google.api:gax-grpc", "1.60.0-SNAPSHOT",
+                "com.google.api:gax-httpjson", "0.77.0-SNAPSHOT"));
+  }
+
+  @Test
+  public void testFindLocalArtifactsFromFile_invalidLines() {
+    // This file has a line without version
     Path artifactFile =
         Paths.get("src/test/resources/testproject/linkage-monitor-artifacts-invalid-format.txt");
 
@@ -336,8 +350,7 @@ public class LinkageMonitorTest {
   }
 
   @Test
-  public void testFindLocalArtifactsFromFile_nonexistentCoordinates()
-      throws IOException, MavenRepositoryException {
+  public void testFindLocalArtifactsFromFile_nonexistentCoordinates() {
     // There's no such artifact with "com.google.api:gax-nonexistent-coordinates"
     Path artifactFile =
         Paths.get(
@@ -352,8 +365,7 @@ public class LinkageMonitorTest {
   }
 
   @Test
-  public void testFindLocalArtifactsFromFile_nonexistentFile()
-      throws IOException, MavenRepositoryException {
+  public void testFindLocalArtifactsFromFile_nonexistentFile() throws IOException {
     // Most of the repositories do not have the file. Linkage Monitor should not throw an exception.
     Path artifactFile = Paths.get("src/test/resources/testproject/nonexistent-file");
 

--- a/linkage-monitor/src/test/resources/testproject/gax-bom/pom.xml
+++ b/linkage-monitor/src/test/resources/testproject/gax-bom/pom.xml
@@ -14,34 +14,6 @@
         <artifactId>gax</artifactId>
         <version>1.60.2-SNAPSHOT</version>
       </dependency>
-      <dependency>
-        <groupId>com.google.api</groupId>
-        <artifactId>gax</artifactId>
-        <version>1.60.2-SNAPSHOT</version>
-        <classifier>testlib</classifier>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api</groupId>
-        <artifactId>gax-grpc</artifactId>
-        <version>1.60.2-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api</groupId>
-        <artifactId>gax-grpc</artifactId>
-        <version>1.60.2-SNAPSHOT</version>
-        <classifier>testlib</classifier>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api</groupId>
-        <artifactId>gax-httpjson</artifactId>
-        <version>0.77.2-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api</groupId>
-        <artifactId>gax-httpjson</artifactId>
-        <version>0.77.2-SNAPSHOT</version>
-        <classifier>testlib</classifier>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts-invalid-format.txt
+++ b/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts-invalid-format.txt
@@ -1,3 +1,3 @@
 com.google.api:gax:1.0.0
-com.google.api:gax-grpc:1.0.0
+com.google.api:gax-grpc
 com.google.api:gax-httpjson:1.0.0

--- a/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts-invalid-format.txt
+++ b/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts-invalid-format.txt
@@ -1,0 +1,3 @@
+com.google.api:gax:1.0.0
+com.google.api:gax-grpc:1.0.0
+com.google.api:gax-httpjson:1.0.0

--- a/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts-nonexistent-coordinates.txt
+++ b/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts-nonexistent-coordinates.txt
@@ -1,0 +1,2 @@
+com.google.api:gax-nonexistent-coordinates
+com.google.api:gax-grpc

--- a/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts-with-empty-line.txt
+++ b/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts-with-empty-line.txt
@@ -1,3 +1,6 @@
+
 com.google.api:gax:1.60.0-SNAPSHOT
+
 com.google.api:gax-grpc:1.60.0-SNAPSHOT
-com.google.api:gax-httpjson:1.60.0-SNAPSHOT
+
+com.google.api:gax-httpjson:0.77.0-SNAPSHOT

--- a/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts.txt
+++ b/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts.txt
@@ -1,0 +1,3 @@
+com.google.api:gax
+com.google.api:gax-grpc
+com.google.api:gax-httpjson

--- a/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts.txt
+++ b/linkage-monitor/src/test/resources/testproject/linkage-monitor-artifacts.txt
@@ -1,3 +1,3 @@
 com.google.api:gax:1.60.0-SNAPSHOT
 com.google.api:gax-grpc:1.60.0-SNAPSHOT
-com.google.api:gax-httpjson:1.60.0-SNAPSHOT
+com.google.api:gax-httpjson:0.77.0-SNAPSHOT


### PR DESCRIPTION
Fixes #1958 

Another approach for the problem. Compared with https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/1961, this PR expects the artifact list file to have Maven coordinates with versions. In gax-java repository, Gradle's build.gradle will create such file.

# What is the file will look like?

```

com.google.api:gax:1.60.0-SNAPSHOT
com.google.api:gax-grpc:1.60.0-SNAPSHOT
com.google.api:gax-httpjson:1.60.0-SNAPSHOT
```

A simple Gradle task can generate this file using `$version`. In gax-java's build.gradle. I'll add

```
task createLinkageMonitorArtifactList {
  doLast {
    new File(projectDir, "linkage-monitor-artifacts.txt").text = """
com.google.api:gax:$version
com.google.api:gax-grpc:$version
com.google.api:gax-httpjson:$version
"""
  }
}
```


CC: @chingor13 who owns gax-java
