### PR TITLE
Release 19.1.0-bom

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>19.1.0</version>
+  <version>19.1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>19.0.1-SNAPSHOT</version>
+  <version>19.1.0</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>19.0.1-SNAPSHOT</version>
+        <version>19.1.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>19.1.0</version>
+        <version>19.1.1-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Release 19.1.0-bom

```
$ git diff v19.0.0-bom v19.1.0-bom -- boms/cloud-oss-bom/pom.xml 
diff --git a/boms/cloud-oss-bom/pom.xml b/boms/cloud-oss-bom/pom.xml
index 4b854db8..27443cbb 100644
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>19.0.0</version>
+  <version>19.1.0</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>
@@ -45,16 +45,16 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>30.1-android</guava.version>
-    <google.cloud.java.version>0.149.0</google.cloud.java.version>
+    <google.cloud.java.version>0.150.0</google.cloud.java.version>
     <io.grpc.version>1.36.0</io.grpc.version>
-    <http.version>1.39.0</http.version>
-    <protobuf.version>3.15.3</protobuf.version>
+    <http.version>1.39.1</http.version>
+    <protobuf.version>3.15.6</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
     <gax.version>1.62.0</gax.version>
     <gax.httpjson.version>0.79.0</gax.httpjson.version>
     <common.protos.version>2.1.0</common.protos.version>
-    <iam.protos.version>1.0.10</iam.protos.version>
+    <iam.protos.version>1.0.11</iam.protos.version>
   </properties>
 
   <distributionManagement>
@@ -242,7 +242,7 @@
        <dependency>
          <groupId>com.google.cloud</groupId>
          <artifactId>google-cloud-core-bom</artifactId>
-         <version>1.94.3</version>
+         <version>1.94.4</version>
          <type>pom</type>
          <scope>import</scope>
        </dependency>

```