### PR TITLE
Upgrade google-auth-library-bom to 0.25.0

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -235,7 +235,7 @@
        <dependency>
          <groupId>com.google.auth</groupId>
          <artifactId>google-auth-library-bom</artifactId>
-         <version>0.24.1</version>
+         <version>0.25.0</version>
          <type>pom</type>
          <scope>import</scope>
        </dependency>


### PR DESCRIPTION
For https://github.com/googleapis/gax-java/pull/1302, which fails Linkage Monitor.

CC: @arithmetic1728 