### PR TITLE
BOM release document: replace_string to use variables

### DIFF
--- a/boms/cloud-oss-bom/RELEASING.md
+++ b/boms/cloud-oss-bom/RELEASING.md
@@ -100,6 +100,7 @@ new release is available on Maven Central.
       (Adjust the old and new versions)
     * `/google/src/head/depot/google3/devtools/scripts/replace_string "&lt;version>${OLD}&lt;/version>" "&lt;version>${NEW}&lt;/version>"`
     * `/google/src/head/depot/google3/devtools/scripts/replace_string "&lt;version&gt;${OLD}&lt;/version&gt;" "&lt;version>${NEW}&lt;/version>"`
+    * `/google/src/head/depot/google3/devtools/scripts/replace_string "&lt;version&gt;${OLD}&lt;/version>" "&lt;version>${NEW}&lt;/version>"`
     * Sanity check the cl and send it for review.
     * Submit on approval
 * Search for libraries-bom in google3 to find any internal references (typically cloudsite and devsite) that still need to be updated.

--- a/boms/cloud-oss-bom/RELEASING.md
+++ b/boms/cloud-oss-bom/RELEASING.md
@@ -96,8 +96,10 @@ new release is available on Maven Central.
 * Manually edit and update any pom.xml files in https://github.com/GoogleCloudPlatform/java-docs-samples that dependabot missed
 * In google3 run:
     * `$ g4d -f bom`
-    * `/google/src/head/depot/google3/devtools/scripts/replace_string "&lt;version>oldVersion&lt;/version>" "&lt;version>newVersion&lt;/version>"`
-    * `/google/src/head/depot/google3/devtools/scripts/replace_string "&lt;version&gt;oldVersion&lt;/version&gt;" "&lt;version>newVersion&lt;/version>"`
+    * `$ OLD=19.0.0; NEW=19.1.0`
+      (Adjust the old and new versions)
+    * `/google/src/head/depot/google3/devtools/scripts/replace_string "&lt;version>${OLD}&lt;/version>" "&lt;version>${NEW}&lt;/version>"`
+    * `/google/src/head/depot/google3/devtools/scripts/replace_string "&lt;version&gt;${OLD}&lt;/version&gt;" "&lt;version>${NEW}&lt;/version>"`
     * Sanity check the cl and send it for review.
     * Submit on approval
 * Search for libraries-bom in google3 to find any internal references (typically cloudsite and devsite) that still need to be updated.


### PR DESCRIPTION
@elharo I tried this today and I felt it's more convenient (for copy-pasting the long commands) and less error-prone to use variables when running the `replace_string` command. What do you think?