### PR TITLE
Update the periodic job to create dashboard for the new BOM

### DIFF
--- a/kokoro/ubuntu/periodic.sh
+++ b/kokoro/ubuntu/periodic.sh
@@ -17,3 +17,6 @@ cd dashboard
 # For all versions available in Maven Central and local repository
 mvn -V -B exec:java -Dexec.mainClass="com.google.cloud.tools.opensource.dashboard.DashboardMain" \
   -Dexec.arguments="-a com.google.cloud:libraries-bom"
+
+mvn -V -B exec:java -Dexec.mainClass="com.google.cloud.tools.opensource.dashboard.DashboardMain" \
+  -Dexec.arguments="-a com.google.cloud:gcp-lts-bom"


### PR DESCRIPTION
Most of the errors in the dashboard for the BOM are already known (optional compression algorithms, etc.) But there are new items we'll need to investigate. For example:

<img width="1423" alt="Screen Shot 2021-03-30 at 15 42 58" src="https://user-images.githubusercontent.com/28604/113047309-269aab00-916f-11eb-8c37-5399bbd3d52e.png">
