### PR TITLE
Add default exclusion rules for grpc-netty-shaded

### DIFF
--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -213,7 +213,7 @@ public class DashboardTest {
     // appengine-api-sdk, shown as first item in linkage errors, has these errors
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
         .isEqualTo(
-            "40 target classes causing linkage errors referenced from 61 source classes.");
+            "4 target classes causing linkage errors referenced from 4 source classes.");
 
     Nodes dependencyPaths = details.query("//p[@class='linkage-check-dependency-paths']");
     Node dependencyPathMessageOnProblem = dependencyPaths.get(dependencyPaths.size() - 1);

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -274,7 +274,7 @@
       <Class name="io.grpc.netty.shaded.io.netty.handler.codec.spdy.SpdyHeaderBlockJZlibEncoder" />
     </Source>
     <Reason>
-      (For grpc-netty-shaded source)
+      (For grpc-netty-shaded source)LinkageCheckerMainIntegrationTest
       io.netty.handler.codec.spdy.SpdyHeaderBlockEncoder chooses the compression encoder based on
       the Java platform. For Java 7 or later, it does not use SpdyHeaderBlockJZlibEncoder, as the
       Zlib compression is available in JVM.

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -147,6 +147,21 @@
     </Reason>
   </LinkageError>
   <LinkageError>
+    <Target>
+      <Package name="reactor.blockhound" />
+    </Target>
+    <Source>
+      <Class name="io.grpc.netty.shaded.io.netty.util.internal.Hidden" />
+    </Source>
+    <Reason>
+      (For grpc-netty-shaded source)
+      If BlockHound library is present in the class path, it loads the Hidden class to enable
+      Netty-BlockHound integration. In this case, the target classes are on the class path.
+      If BlockHound is not on the class path, nothing loads this source class.
+      https://github.com/reactor/BlockHound/blob/master/docs/custom_integrations.md
+    </Reason>
+  </LinkageError>
+  <LinkageError>
     <Source>
       <Package name="io.netty.util.internal.logging" />
     </Source>
@@ -176,6 +191,17 @@
   </LinkageError>
   <LinkageError>
     <Source>
+      <Package name="io.grpc.netty.shaded.io.netty.handler.codec.marshalling" />
+    </Source>
+    <Reason>
+      (For grpc-netty-shaded source)
+      Netty users can optionally add JBoss Marshalling dependency to use
+      io.netty.handler.codec.marshalling package when they need the serialization algorithm.
+      By default, the classes in the package have references to missing classes.
+    </Reason>
+  </LinkageError>
+  <LinkageError>
+    <Source>
       <Package name="io.netty.handler.codec.protobuf" />
     </Source>
     <Reason>
@@ -186,9 +212,30 @@
   </LinkageError>
   <LinkageError>
     <Source>
+      <Package name="io.grpc.netty.shaded.io.netty.handler.codec.protobuf" />
+    </Source>
+    <Reason>
+      (For grpc-netty-shaded source)
+      Netty users can optionally add protobuf dependency to use io.netty.handler.codec.protobuf
+      package when they need the serialization algorithm. By default, the classes in the package
+      have references to missing classes.
+    </Reason>
+  </LinkageError>
+  <LinkageError>
+    <Source>
       <Package name="io.netty.handler.codec.compression" />
     </Source>
     <Reason>
+      Netty users can optionally add corresponding dependencies to use compression algorithms (LZMA,
+      LZF, zlib). By default, the classes in the package have references to missing classes.
+    </Reason>
+  </LinkageError>
+  <LinkageError>
+    <Source>
+      <Package name="io.grpc.netty.shaded.io.netty.handler.codec.compression" />
+    </Source>
+    <Reason>
+      (For grpc-netty-shaded source)
       Netty users can optionally add corresponding dependencies to use compression algorithms (LZMA,
       LZF, zlib). By default, the classes in the package have references to missing classes.
     </Reason>
@@ -221,6 +268,20 @@
   </LinkageError>
   <LinkageError>
     <Target>
+      <Package name="com.jcraft.jzlib" />
+    </Target>
+    <Source>
+      <Class name="io.grpc.netty.shaded.io.netty.handler.codec.spdy.SpdyHeaderBlockJZlibEncoder" />
+    </Source>
+    <Reason>
+      (For grpc-netty-shaded source)
+      io.netty.handler.codec.spdy.SpdyHeaderBlockEncoder chooses the compression encoder based on
+      the Java platform. For Java 7 or later, it does not use SpdyHeaderBlockJZlibEncoder, as the
+      Zlib compression is available in JVM.
+    </Reason>
+  </LinkageError>
+  <LinkageError>
+    <Target>
       <Package name="org.bouncycastle" />
     </Target>
     <Source>
@@ -234,12 +295,40 @@
   </LinkageError>
   <LinkageError>
     <Target>
+      <Package name="org.bouncycastle" />
+    </Target>
+    <Source>
+      <Class name="io.grpc.netty.shaded.io.netty.handler.ssl.util.BouncyCastleSelfSignedCertGenerator" />
+    </Source>
+    <Reason>
+      (For grpc-netty-shaded source)
+      io.netty.handler.ssl.util.SelfSignedCertificate checks the availability of Bouncy Castle
+      library (http://www.bouncycastle.org/). If it's unavailable, then Netty does not use the
+      BouncyCastleSelfSignedCertGenerator.
+    </Reason>
+  </LinkageError>  <LinkageError>
+    <Target>
       <Package name="org.eclipse.jetty.npn" />
     </Target>
     <Source>
       <Class name="io.netty.handler.ssl.JettyNpnSslEngine" />
     </Source>
     <Reason>
+      The Jetty-ALPN and Jetty-NPN are the optional fallback method when Netty users cannot use
+      OpenSSL with netty-tcnative. Therefore, the JettyNpnSslEngine class has linkage errors by
+      default.
+      https://netty.io/wiki/requirements-for-4.x.html#tls-with-jdk-jetty-alpnnpn
+    </Reason>
+  </LinkageError>
+  <LinkageError>
+    <Target>
+      <Package name="org.eclipse.jetty.npn" />
+    </Target>
+    <Source>
+      <Class name="io.grpc.netty.shaded.io.netty.handler.ssl.JettyNpnSslEngine" />
+    </Source>
+    <Reason>
+      (For grpc-netty-shaded source)
       The Jetty-ALPN and Jetty-NPN are the optional fallback method when Netty users cannot use
       OpenSSL with netty-tcnative. Therefore, the JettyNpnSslEngine class has linkage errors by
       default.
@@ -260,5 +349,18 @@
       https://netty.io/wiki/requirements-for-4.x.html#tls-with-jdk-jetty-alpnnpn
     </Reason>
   </LinkageError>
-
+  <LinkageError>
+    <Target>
+      <Package name="org.eclipse.jetty.alpn" />
+    </Target>
+    <Source>
+      <Class name="io.grpc.netty.shaded.io.netty.handler.ssl.JettyAlpnSslEngine" />
+    </Source>
+    <Reason>
+      The Jetty-ALPN and Jetty-NPN are the optional fallback method when Netty users cannot use
+      OpenSSL with netty-tcnative. Therefore, the JettyAlpnSslEngine class has linkage errors by
+      default.
+      https://netty.io/wiki/requirements-for-4.x.html#tls-with-jdk-jetty-alpnnpn
+    </Reason>
+  </LinkageError>
 </LinkageCheckerFilter>

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -102,17 +102,17 @@ public class LinkageCheckerMainIntegrationTest {
     String output = readCapturedStdout();
     Truth.assertThat(output)
         .contains(
-            "Class com.jcraft.jzlib.JZlib is not found;\n"
-                + "  referenced by 4 class files\n"
-                + "    io.grpc.netty.shaded.io.netty.handler.codec.spdy.SpdyHeaderBlockJZlibEncoder"
-                + " (io.grpc:grpc-netty-shaded:1.30.2)");
+            "Class org.apache.avalon.framework.logger.Logger is not found;\n"
+                + "  referenced by 1 class file\n"
+                + "    org.apache.commons.logging.impl.AvalonLogger"
+                + " (commons-logging:commons-logging:1.2)");
 
     // Show the dependency path to the problematic artifact
     Truth.assertThat(output)
         .contains(
-            "io.grpc:grpc-netty-shaded:1.30.2 is at:\n"
+            "commons-logging:commons-logging:1.2 is at:\n"
                 + "  com.google.cloud:google-cloud-firestore:jar:1.35.2 /"
-                + " io.grpc:grpc-netty-shaded:1.30.2 (compile)\n");
+                + " commons-logging:commons-logging:1.2 (compile)\n");
   }
 
   @Test
@@ -136,7 +136,7 @@ public class LinkageCheckerMainIntegrationTest {
       LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 691 linkage errors", expected.getMessage());
+      assertEquals("Found 634 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -96,7 +96,7 @@ public class LinkageCheckerMainIntegrationTest {
           new String[] {"-a", "com.google.cloud:google-cloud-firestore:1.35.2"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 61 linkage errors", expected.getMessage());
+      assertEquals("Found 3 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();
@@ -170,7 +170,7 @@ public class LinkageCheckerMainIntegrationTest {
       LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 713 linkage errors", expected.getMessage());
+      assertEquals("Found 656 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();

--- a/gradle-plugin/src/functionalTest/groovy/com/google/cloud/tools/dependencies/gradle/ExclusionFileFunctionalTest.groovy
+++ b/gradle-plugin/src/functionalTest/groovy/com/google/cloud/tools/dependencies/gradle/ExclusionFileFunctionalTest.groovy
@@ -84,7 +84,7 @@ class ExclusionFileFunctionalTest extends Specification {
     result.output.contains("Task :linkageCheck")
     result.output.contains("BUILD FAILED")
     // Ensure it outputs the linkage errors
-    result.output.contains("Class com.jcraft.jzlib.JZlib is not found")
+    result.output.contains("Class org.apache.avalon.framework.logger.Logger is not found")
 
     // BaseDnsNameResolverProvider is referenced by SecretGrpclbNameResolverProvider, which we
     // suppress via the exclusion file.
@@ -141,7 +141,7 @@ class ExclusionFileFunctionalTest extends Specification {
     result.output.contains("Task :linkageCheck")
     result.output.contains("BUILD FAILED")
     // Ensure it outputs the linkage errors
-    result.output.contains("Class com.jcraft.jzlib.JZlib is not found")
+    result.output.contains("Class org.apache.avalon.framework.logger.Logger is not found")
 
     // BaseDnsNameResolverProvider is referenced by SecretGrpclbNameResolverProvider, which we
     // suppress via the exclusion file.


### PR DESCRIPTION
Adding the gRPC's shaded package ("io.grpc.shaded.io.netty") to the defalut exclusion rule (previously done for io.netty package in #1979).

This PR clears the linkage errors shown in grpc-netty-shaded in the Libraries BOM dashboard.

<img width="798" alt="Screen Shot 2021-04-02 at 18 12 19" src="https://user-images.githubusercontent.com/28604/113458036-77183f80-93df-11eb-80ac-9397214ba9df.png">

These false positive errors also appear in spring-cloud-gcp's Linkage Checker result: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/429