### PR TITLE
Exclude boms/cloud-lts-bom from RenovateBot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     "example-problems/**",
     "enforcer-rules/src/it/**",
     "boms/convergence-check",
+    "boms/cloud-lts-bom",
     "verboseTree-maven-plugin/src/it/**"
   ],
   "separateMajorMinor": false,


### PR DESCRIPTION
Without this exclusion, RenovateBot's Dependency Dashboard is messed up. We know that the file is not tracking to the latest versions.

https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1674