### PR TITLE
Guava and autovalue versions have been set

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -57,10 +57,10 @@
     <google.cloud.spanner.version>6.0.0</google.cloud.spanner.version>
     <google.cloud.bigtable.version>1.21.2</google.cloud.bigtable.version>
     <google.cloud.bigtable.client.version>1.19.1</google.cloud.bigtable.client.version>
-    <google.autovalue.version>1.7.5</google.autovalue.version>
+    <google.autovalue.version>1.8.0</google.autovalue.version>
     <google.api.client.version>1.31.3</google.api.client.version>
     <!-- JRE for Java 8. Beam's dependency (gcsio) uses JRE flavor -->
-    <guava.version>30.1-jre</guava.version>
+    <guava.version>30.1.1-jre</guava.version>
     <io.grpc.version>1.36.1</io.grpc.version>
     <protobuf.version>3.15.6</protobuf.version>
 


### PR DESCRIPTION
@suztomo LTS versions for autovalue and Guava have been picked. They are 30.1.1 and 1.8.0 respectively.  