### PR TITLE
deps: remove maps

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -266,11 +266,6 @@
         <artifactId>google-cloud-spanner</artifactId>
         <version>${google.cloud.spanner.version}</version>
       </dependency>
-      <dependency>
-        <groupId>com.google.maps</groupId>
-        <artifactId>google-maps-services</artifactId>
-        <version>0.17.0</version>
-      </dependency>
 
       <!-- API Infrastructure section -->
       <dependency>


### PR DESCRIPTION
@suztomo Based on discussion with the client, they think we can leave this one out for now. If it ends up causing problems for them, we may have to put it back in but for now I hope the maps API is separable from all the cloud APIs.