### PR TITLE
Upgrading google-cloud-core with a temporary fix in upper-bound check

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -243,7 +243,7 @@
        <dependency>
          <groupId>com.google.cloud</groupId>
          <artifactId>google-cloud-core-bom</artifactId>
-         <version>${google.cloud.java.version}</version>
+         <version>${google.cloud.core.version}</version>
          <type>pom</type>
          <scope>import</scope>
        </dependency>

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -46,6 +46,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>30.1.1-android</guava.version>
     <google.cloud.java.version>0.152.0</google.cloud.java.version>
+    <google.cloud.core.version>1.94.8</google.cloud.core.version>
     <io.grpc.version>1.37.0</io.grpc.version>
     <http.version>1.39.2</http.version>
     <protobuf.version>3.15.8</protobuf.version>
@@ -242,7 +243,7 @@
        <dependency>
          <groupId>com.google.cloud</groupId>
          <artifactId>google-cloud-core-bom</artifactId>
-         <version>1.94.7</version>
+         <version>${google.cloud.java.version}</version>
          <type>pom</type>
          <scope>import</scope>
        </dependency>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -57,10 +57,18 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
+      <!-- TODO: remove version once new google-cloud-bom with this version comes in -->
+      <version>1.113.16</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>
+    </dependency>
+    <!-- TODO: remove this element once new google-cloud-bom with this version comes in -->
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value-annotations</artifactId>
+      <version>1.8.1</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
# Problem in upgrading google-cloud-core in the Libraries BOM

Google-cloud-storage (from the google-cloud-bom)'s dependencies are old. https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/2034#issuecomment-826876998

```
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for com.google.auto.value:auto-value-annotations:1.7.4 paths to dependency are:
+-com.google.cloud.tools.opensource:upper-bounds-check:2.0.0-SNAPSHOT
  +-com.google.cloud:google-cloud-storage:1.113.15
    +-com.google.auto.value:auto-value-annotations:1.7.4
and
+-com.google.cloud.tools.opensource:upper-bounds-check:2.0.0-SNAPSHOT
  +-com.google.cloud:google-cloud-core:1.94.8
    +-com.google.auto.value:auto-value-annotations:1.7.4 (managed) <-- com.google.auto.value:auto-value-annotations:1.8.1
, 
Require upper bound dependencies error for org.threeten:threetenbp:1.5.0 paths to dependency are:
+-com.google.cloud.tools.opensource:upper-bounds-check:2.0.0-SNAPSHOT
  +-com.google.cloud:google-cloud-storage:1.113.15
    +-org.threeten:threetenbp:1.5.0
and
+-com.google.cloud.tools.opensource:upper-bounds-check:2.0.0-SNAPSHOT
  +-com.google.cloud:google-cloud-core:1.94.8
    +-org.threeten:threetenbp:1.5.1
]
```

### threetenbp
[Newer google-cloud-storage 1.113.16](https://search.maven.org/artifact/com.google.cloud/google-cloud-storage-parent/1.113.16/pom) uses https://search.maven.org/artifact/com.google.cloud/google-cloud-shared-dependencies/1.0.0/pom which has `org.threeten:threetenbp:1.5.1`.

### auto-value-annotations
The HEAD (ff0dae9e12873e87ac2bade4fe915aec3b835f95) in the master branch of java-cloud-bom has auto-value-annotations 1.8.1.

```
suztomo-macbookpro44% mvn help:effective-pom -Dverbose |grep -C3 auto-value-annotations 
      </dependency>
      <dependency>
        <groupId>com.google.auto.value</groupId>  <!-- com.google.cloud:google-cloud-shared-config:0.11.2, line 515 -->
        <artifactId>auto-value-annotations</artifactId>  <!-- com.google.cloud:google-cloud-shared-config:0.11.2, line 516 -->
        <version>1.8.1</version>  <!-- com.google.cloud:google-cloud-shared-config:0.11.2, line 517 -->
      </dependency>
      <dependency>
suztomo-macbookpro44% pwd
/Users/suztomo/java-cloud-bom
suztomo-macbookpro44% git log -1
commit ff0dae9e12873e87ac2bade4fe915aec3b835f95 (HEAD -> test_auto, origin/master, origin/HEAD)
Author: WhiteSource Renovate <bot@renovateapp.com>
Date:   Tue Apr 27 19:24:23 2021 +0200
...
```

# Problem in upgrading google-cloud-storage in google-cloud-bom

https://github.com/googleapis/java-cloud-bom/pull/1874#issuecomment-827777023

```
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for com.google.cloud:google-cloud-core:1.94.7 paths to dependency are:
+-com.google.cloud.tools.opensource:upper-bounds-check:2.0.0-SNAPSHOT
  +-com.google.cloud:google-cloud-core:1.94.7
and
+-com.google.cloud.tools.opensource:upper-bounds-check:2.0.0-SNAPSHOT
  +-com.google.cloud:google-cloud-storage:1.113.16
    +-com.google.cloud:google-cloud-core:1.94.7 (managed) <-- com.google.cloud:google-cloud-core:1.94.8
, 
Require upper bound dependencies error for com.google.cloud:google-cloud-core-http:1.94.7 paths to dependency are:
+-com.google.cloud.tools.opensource:upper-bounds-check:2.0.0-SNAPSHOT
  +-com.google.cloud:google-cloud-storage:1.113.16
    +-com.google.cloud:google-cloud-core-http:1.94.7 (managed) <-- com.google.cloud:google-cloud-core-http:1.94.8
]
```


