### PR TITLE
GitHub Actions setup not to use Maven Central mirror

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ jobs:
       with:
         java-version: ${{matrix.java}}
     - run: java -version
-    - run: mkdir -p ~/.m2 && cp settings.xml ~/.m2/
     - run: ./mvnw -B -e -ntp install
     - run: cd gradle-plugin && ./gradlew build publishToMavenLocal
 


### PR DESCRIPTION
GitHub Actions do not run Google's infrastructure. Therefore they don't have much benefit of using Google's Maven Central mirror.