### PR TITLE
Libraries BOM: fix indentation

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -86,10 +86,10 @@
       </dependency>
 
       <!-- google-http-java-client from https://github.com/googleapis/google-http-java-client -->
-     <dependency>
-       <groupId>com.google.http-client</groupId>
-       <artifactId>google-http-client</artifactId>
-       <version>${http.version}</version>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client</artifactId>
+        <version>${http.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
@@ -216,57 +216,57 @@
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>api-common</artifactId>
-         <version>1.10.3</version>
-       </dependency>
-       <dependency>
-         <groupId>com.google.api</groupId>
-         <artifactId>gax</artifactId>
-         <version>${gax.version}</version>
-       </dependency>
-       <dependency>
-         <groupId>com.google.api</groupId>
-         <artifactId>gax-grpc</artifactId>
-         <version>${gax.version}</version>
-       </dependency>
-       <dependency>
-         <groupId>com.google.api</groupId>
-         <artifactId>gax-httpjson</artifactId>
-         <version>${gax.httpjson.version}</version>
-       </dependency>
-       <dependency>
-         <groupId>com.google.auth</groupId>
-         <artifactId>google-auth-library-bom</artifactId>
-         <version>0.25.5</version>
-         <type>pom</type>
-         <scope>import</scope>
-       </dependency>
-       <dependency>
-         <groupId>com.google.cloud</groupId>
-         <artifactId>google-cloud-core-bom</artifactId>
-         <version>${google.cloud.core.version}</version>
-         <type>pom</type>
-         <scope>import</scope>
-       </dependency>
+        <version>1.10.3</version>
+      </dependency>
       <dependency>
-         <groupId>com.google.api.grpc</groupId>
-         <artifactId>proto-google-common-protos</artifactId>
-         <version>${common.protos.version}</version>
-       </dependency>
-       <dependency>
-         <groupId>com.google.api.grpc</groupId>
-         <artifactId>grpc-google-common-protos</artifactId>
-         <version>${common.protos.version}</version>
-       </dependency>
-       <dependency>
-         <groupId>com.google.api.grpc</groupId>
-         <artifactId>proto-google-iam-v1</artifactId>
-         <version>${iam.protos.version}</version>
-       </dependency>
-       <dependency>
-         <groupId>com.google.api.grpc</groupId>
-         <artifactId>grpc-google-iam-v1</artifactId>
-         <version>${iam.protos.version}</version>
-       </dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax</artifactId>
+        <version>${gax.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-grpc</artifactId>
+        <version>${gax.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-httpjson</artifactId>
+        <version>${gax.httpjson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-bom</artifactId>
+        <version>0.25.5</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-core-bom</artifactId>
+        <version>${google.cloud.core.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-common-protos</artifactId>
+        <version>${common.protos.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>grpc-google-common-protos</artifactId>
+        <version>${common.protos.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-iam-v1</artifactId>
+        <version>${iam.protos.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>grpc-google-iam-v1</artifactId>
+        <version>${iam.protos.version}</version>
+      </dependency>
 
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Fixing the indentation of libraries-bom.

Split diff view is easy to read:

<img width="1006" alt="Screen Shot 2021-05-18 at 09 54 16" src="https://user-images.githubusercontent.com/28604/118663857-05455b00-b7bf-11eb-91a2-ce2b6b1fd5bc.png">
