### PR TITLE
Release 20.6.0-bom

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>20.6.0-SNAPSHOT</version>
+  <version>20.6.0</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>20.6.0</version>
+  <version>20.6.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>20.6.0-SNAPSHOT</version>
+        <version>20.6.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>20.6.0</version>
+        <version>20.6.1-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Release 20.6.0-bom


```
suztomo-macbookpro44% git diff v20.5.0-bom v20.6.0-bom -- boms/cloud-oss-bom/pom.xml
diff --git a/boms/cloud-oss-bom/pom.xml b/boms/cloud-oss-bom/pom.xml
index ca42b95b..0d81bcd1 100644
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>20.5.0</version>
+  <version>20.6.0</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>
@@ -45,17 +45,17 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>30.1.1-android</guava.version>
-    <google.cloud.java.version>0.154.0</google.cloud.java.version>
-    <google.cloud.core.version>1.94.8</google.cloud.core.version>
+    <google.cloud.java.version>0.155.0</google.cloud.java.version>
+    <google.cloud.core.version>1.95.0</google.cloud.core.version>
     <io.grpc.version>1.38.0</io.grpc.version>
     <http.version>1.39.2</http.version>
-    <protobuf.version>3.17.0</protobuf.version>
+    <protobuf.version>3.17.2</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>1.64.0</gax.version>
-    <gax.httpjson.version>0.81.0</gax.httpjson.version>
+    <gax.version>1.65.0</gax.version>
+    <gax.httpjson.version>0.82.0</gax.httpjson.version>
     <auth.version>0.26.0</auth.version>
-    <common.protos.version>2.3.0</common.protos.version>
+    <common.protos.version>2.3.2</common.protos.version>
     <iam.protos.version>1.0.14</iam.protos.version>
   </properties>
 
```