### PR TITLE
Beam 2.30 for gcp-lts-bom

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -50,7 +50,7 @@
     
     <!-- interrim placeholder versions -->
     <!-- TODO: For each library, update the versions to the LTS version -->
-    <beam.version>2.28.0</beam.version>
+    <beam.version>2.30.0</beam.version>
     
     <!-- finalized versions -->    
     <!-- JRE for Java 8. Beam's dependency (gcsio) uses JRE flavor -->


### PR DESCRIPTION
https://beam.apache.org/blog/beam-2.30.0/

It's available in Maven Central https://search.maven.org/artifact/org.apache.beam/beam-sdks-java-io-google-cloud-platform/2.30.0/jar