### PR TITLE
lts-bom: appengine-api-sdk 1.9.89

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -71,7 +71,7 @@
     <bigtable-hbase-beam.version>1.20.0-sp.1</bigtable-hbase-beam.version>
     <google.cloud.storage.version>1.113.14-sp.1</google.cloud.storage.version>
     <datastore.v1.proto.client.version>1.6.4-sp.1</datastore.v1.proto.client.version>
-    <appengine.api.1.0.sdk.version>1.9.86</appengine.api.1.0.sdk.version>
+    <appengine.api.1.0.sdk.version>1.9.89</appengine.api.1.0.sdk.version>
     <androidpublisher.version>v3-rev20210429-1.31.0</androidpublisher.version>
   </properties>
 


### PR DESCRIPTION
(Taking over https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/2124)

As per the chat room discussion, choosing the latest appengine API SDK.

CC: @AlanGasperini 