### PR TITLE
Release 20.8.0-bom

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>20.8.0</version>
+  <version>20.8.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>20.8.0-SNAPSHOT</version>
+  <version>20.8.0</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>20.8.0-SNAPSHOT</version>
+        <version>20.8.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>20.8.0</version>
+        <version>20.8.1-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Release 20.8.0-bom

No major version change in the libraries or ones in google-cloud-bom (https://github.com/googleapis/java-cloud-bom/releases/tag/v0.157.0).  There are minor version change (gRPC for example). So the BOM version is 20.8.0 (previous: 20.7.0).

```
diff --git a/boms/cloud-oss-bom/pom.xml b/boms/cloud-oss-bom/pom.xml
index 6ae6d787..54f05900 100644
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>20.7.0</version>
+  <version>20.8.0</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>
@@ -45,15 +45,15 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>30.1.1-android</guava.version>
-    <google.cloud.java.version>0.156.0</google.cloud.java.version>
-    <google.cloud.core.version>1.95.2</google.cloud.core.version>
-    <io.grpc.version>1.38.1</io.grpc.version>
+    <google.cloud.java.version>0.157.0</google.cloud.java.version>
+    <google.cloud.core.version>1.95.4</google.cloud.core.version>
+    <io.grpc.version>1.39.0</io.grpc.version>
     <http.version>1.39.2</http.version>
     <protobuf.version>3.17.3</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>1.65.1</gax.version>
-    <gax.httpjson.version>0.82.1</gax.httpjson.version>
+    <gax.version>1.66.0</gax.version>
+    <gax.httpjson.version>0.83.0</gax.httpjson.version>
     <auth.version>0.26.0</auth.version>
     <common.protos.version>2.3.2</common.protos.version>
     <iam.protos.version>1.0.14</iam.protos.version>
@@ -205,7 +205,7 @@
         <version>${io.grpc.version}</version>
       </dependency>
 
-      <!-- google-cloud-java from https://github.com/googleapis/google-cloud-java -->
+      <!-- google-cloud-java from https://github.com/googleapis/java-cloud-bom-->
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bom</artifactId>

```

As per https://storage.googleapis.com/java-cloud-bom-dashboard/com.google.cloud/google-cloud-bom/0.157.0/index.html, the Google Cloud BOM 0.157.0 uses shared dependencies BOM 1.4.0.

The libraries included in [the shared dependencies BOM 1.4.0](https://search.maven.org/artifact/com.google.cloud/google-cloud-shared-dependencies/1.4.0/pom) match the diff above.