### PR TITLE
The default exclusion rules to have the linkage errors from commons-logging to Avalon Logger

### DIFF
--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -228,19 +228,6 @@ public class DashboardTest {
     Assert.assertEquals(
         "The following paths contain com.google.guava:guava:27.1-android:",
         trimAndCollapseWhiteSpace(dependencyPathMessageOnSource.getValue()));
-
-    Nodes nodesWithPathsSummary = details.query("//p[@class='linkage-check-dependency-paths']");
-    Truth.assertWithMessage("The dashboard should not show repetitive dependency paths")
-        .that(nodesWithPathsSummary)
-        .comparingElementsUsing(
-            Correspondence.<Node, String>transforming(
-                node -> trimAndCollapseWhiteSpace(node.getValue()), "has text"))
-        .contains("Dependency path 'org.apache.httpcomponents:httpclient >"
-                + " commons-logging:commons-logging' exists"
-                + " in all 57 dependency paths. Example path:"
-                + " com.google.http-client:google-http-client:1.29.1 (compile) /"
-                + " org.apache.httpcomponents:httpclient:4.5.5 (compile) /"
-                + " commons-logging:commons-logging:1.2 (compile)");
   }
 
   @Test
@@ -304,11 +291,9 @@ public class DashboardTest {
     Document document = parseOutputFile(
         "com.google.http-client_google-http-client-appengine_1.29.1.html");
     Nodes reports = document.query("//p[@class='jar-linkage-report']");
-    Assert.assertEquals(2, reports.size());
+    Assert.assertEquals(1, reports.size());
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
         .isEqualTo("100 target classes causing linkage errors referenced from 540 source classes.");
-    Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(1).getValue()))
-        .isEqualTo("3 target classes causing linkage errors referenced from 3 source classes.");
 
     Nodes causes = document.query("//p[@class='jar-linkage-report-cause']");
     Truth.assertWithMessage(
@@ -328,20 +313,17 @@ public class DashboardTest {
     Assume.assumeTrue(javaMajorVersion >= 11);
 
     // The version used in libraries-bom 1.0.0. The google-http-client-appengine has been known to
-    // have linkage errors in its dependencies ("commons-logging:commons-logging:1.2" and
-    // "com.google.appengine:appengine-api-1.0-sdk:1.9.71").
-    Document document = parseOutputFile(
-        "com.google.http-client_google-http-client-appengine_1.29.1.html");
+    // have linkage errors in its dependency appengine-api-1.0-sdk:1.9.71.
+    Document document =
+        parseOutputFile("com.google.http-client_google-http-client-appengine_1.29.1.html");
     Nodes reports = document.query("//p[@class='jar-linkage-report']");
-    Assert.assertEquals(2, reports.size());
+    Assert.assertEquals(1, reports.size());
 
     // This number of linkage errors differs between Java 8 and Java 11 for the javax.activation
     // package removal (JEP 320: Remove the Java EE and CORBA Modules). For the detail, see
     // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1849.
     Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
         .isEqualTo("105 target classes causing linkage errors referenced from 562 source classes.");
-    Truth.assertThat(trimAndCollapseWhiteSpace(reports.get(1).getValue()))
-        .isEqualTo("3 target classes causing linkage errors referenced from 3 source classes.");
 
     Nodes causes = document.query("//p[@class='jar-linkage-report-cause']");
     Truth.assertWithMessage(

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -376,4 +376,32 @@
       https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/2045
     </Reason>
   </LinkageError>
+  <LinkageError>
+    <Target>
+      <Class name="org.apache.avalon.framework.logger.Logger" />
+    </Target>
+    <Source>
+      <Class name="org.apache.commons.logging.impl.AvalonLogger" />
+    </Source>
+    <Reason>
+      The AvalonLogger is used only when commons-logging users want to use Apache Avalon, which
+      has been closed since 2004. For those who don't use Apache Avalon, the class references does
+      not cause a problem.
+      https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1871
+    </Reason>
+  </LinkageError>
+  <LinkageError>
+    <Target>
+      <Package name="org.apache.log" />
+    </Target>
+    <Source>
+      <Class name="org.apache.commons.logging.impl.LogKitLogger" />
+    </Source>
+    <Reason>
+      The LogKitLogger is used only when commons-logging users want to use Apache Avalon, which
+      has been closed since 2004. For those who don't use Apache Avalon, the class references does
+      not cause a problem.
+      https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1871
+    </Reason>
+  </LinkageError>
 </LinkageCheckerFilter>

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -97,7 +97,8 @@ public class LinkageCheckerMainIntegrationTest {
           new String[] {"-a", "com.google.http-client:google-http-client-appengine:1.39.2"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 562 linkage errors", expected.getMessage());
+      int expectedErrorCount = System.getProperty("java.version").startsWith("1.8.") ? 562 : 584;
+      assertEquals("Found " + expectedErrorCount + " linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -92,27 +92,28 @@ public class LinkageCheckerMainIntegrationTest {
       throws IOException, RepositoryException, TransformerException, XMLStreamException {
     try {
       LinkageCheckerMain.main(
-          // protobuf-java:3.13.0 in
-          new String[] {"-a", "com.google.cloud:google-cloud-firestore:1.35.2"});
+          // google-http-client-appengine depends on appengien-api-1.0-sdk which shades its
+          // dependencies, resulting in many linkage errors.
+          new String[] {"-a", "com.google.http-client:google-http-client-appengine:1.39.2"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 3 linkage errors", expected.getMessage());
+      assertEquals("Found 562 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();
     Truth.assertThat(output)
         .contains(
-            "Class org.apache.avalon.framework.logger.Logger is not found;\n"
-                + "  referenced by 1 class file\n"
-                + "    org.apache.commons.logging.impl.AvalonLogger"
-                + " (commons-logging:commons-logging:1.2)");
+            "Class com.google.net.rpc3.client.RpcStubDescriptor is not found;\n"
+                + "  referenced by 21 class files\n"
+                + "    com.google.appengine.api.appidentity.AppIdentityServicePb"
+                + " (com.google.appengine:appengine-api-1.0-sdk:1.9.71)");
 
     // Show the dependency path to the problematic artifact
     Truth.assertThat(output)
         .contains(
-            "commons-logging:commons-logging:1.2 is at:\n"
-                + "  com.google.cloud:google-cloud-firestore:jar:1.35.2 /"
-                + " commons-logging:commons-logging:1.2 (compile)\n");
+            "com.google.appengine:appengine-api-1.0-sdk:1.9.71 is at:\n"
+                + "  com.google.http-client:google-http-client-appengine:jar:1.39.2 /"
+                + " com.google.appengine:appengine-api-1.0-sdk:1.9.71 (provided)\n");
   }
 
   @Test
@@ -136,7 +137,7 @@ public class LinkageCheckerMainIntegrationTest {
       LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 634 linkage errors", expected.getMessage());
+      assertEquals("Found 631 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();
@@ -170,7 +171,7 @@ public class LinkageCheckerMainIntegrationTest {
       LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 656 linkage errors", expected.getMessage());
+      assertEquals("Found 653 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -19,6 +19,8 @@ package com.google.cloud.tools.opensource.classpath;
 import static com.google.cloud.tools.opensource.classpath.TestHelper.COORDINATES;
 import static com.google.cloud.tools.opensource.classpath.TestHelper.classPathEntryOfResource;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -35,7 +37,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.truth.Correspondence;
-import com.google.common.truth.Truth;
 import com.google.common.truth.Truth8;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -100,19 +101,19 @@ public class LinkageCheckerTest {
     // These example symbols below are picked up through javap command. For example
     // javap -classpath src/test/resources/testdata/guava-23.5-jre.jar \
     //   -v com/google/common/util/concurrent/Monitor
-    Truth.assertThat(symbolReferences.getClassSymbols(
-        new ClassFile(guavaJar, "com.google.common.util.concurrent.Service")))
-        .contains(
-            new ClassSymbol("java.util.concurrent.TimeoutException"));
+    assertThat(
+            symbolReferences.getClassSymbols(
+                new ClassFile(guavaJar, "com.google.common.util.concurrent.Service")))
+        .contains(new ClassSymbol("java.util.concurrent.TimeoutException"));
     ClassFile monitor = new ClassFile(guavaJar, "com.google.common.util.concurrent.Monitor");
-    Truth.assertThat(symbolReferences.getMethodSymbols(monitor))
+    assertThat(symbolReferences.getMethodSymbols(monitor))
         .contains(
             new MethodSymbol(
                 "com.google.common.base.Preconditions",
                 "checkNotNull",
                 "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
                 false));
-    Truth.assertThat(symbolReferences.getFieldSymbols(monitor))
+    assertThat(symbolReferences.getFieldSymbols(monitor))
         .contains(
             new FieldSymbol("com.google.common.util.concurrent.Monitor$Guard", "waiterCount", "I"));
   }
@@ -147,7 +148,7 @@ public class LinkageCheckerTest {
     ImmutableSet<LinkageProblem> problems =
         linkageChecker.cloneWith(builder.build()).findLinkageProblems();
 
-    Truth.assertThat(problems).isEmpty();
+    assertThat(problems).isEmpty();
   }
 
   @Test
@@ -554,7 +555,7 @@ public class LinkageCheckerTest {
     ImmutableSet<LinkageProblem> problems =
         linkageChecker.cloneWith(builder.build()).findLinkageProblems();
 
-    Truth.assertThat(problems).isEmpty();
+    assertThat(problems).isEmpty();
   }
 
   @Test
@@ -582,7 +583,7 @@ public class LinkageCheckerTest {
             .filter(problem -> problem.getSymbol() instanceof ClassSymbol)
             .collect(toImmutableList());
 
-    Truth.assertThat(inaccessibleClassProblems).hasSize(1);
+    assertThat(inaccessibleClassProblems).hasSize(1);
     LinkageProblem firstProblem = inaccessibleClassProblems.get(0);
 
     assertEquals(
@@ -608,7 +609,7 @@ public class LinkageCheckerTest {
     // classes in the dependencies. As we do not provide the dependencies in the class path, it
     // should report the linkage errors. The source class of the error should not be reported as
     // an inner class.
-    Truth.assertThat(problems).isNotEmpty();
+    assertThat(problems).isNotEmpty();
     long innerClassCount =
         problems.stream()
             .map(LinkageProblem::getSourceClass)
@@ -631,10 +632,10 @@ public class LinkageCheckerTest {
             .resolve(parsedArguments.getArtifacts(), true, DependencyMediation.MAVEN)
             .getClassPath();
 
-    Truth.assertThat(inputClasspath).isNotEmpty();
+    assertThat(inputClasspath).isNotEmpty();
 
     // The first artifacts
-    Truth.assertThat(inputClasspath)
+    assertThat(inputClasspath)
         .comparingElementsUsing(COORDINATES)
         .containsAtLeast(
             "com.google.api:api-common:1.7.0",
@@ -661,15 +662,14 @@ public class LinkageCheckerTest {
             .resolve(parsedArguments.getArtifacts(), true, DependencyMediation.MAVEN)
             .getClassPath();
 
-    Truth.assertWithMessage(
-            "The first 2 items in the classpath should be the 2 artifacts in the input")
+    assertWithMessage("The first 2 items in the classpath should be the 2 artifacts in the input")
         .that(inputClasspath.subList(0, 2))
         .comparingElementsUsing(COORDINATES)
         .containsExactly(
             "com.google.cloud:google-cloud-compute:0.67.0-alpha",
             "com.google.cloud:google-cloud-bigtable:0.66.0-alpha")
         .inOrder();
-    Truth.assertWithMessage("The dependencies of the 2 artifacts should also be included")
+    assertWithMessage("The dependencies of the 2 artifacts should also be included")
         .that(inputClasspath.subList(2, inputClasspath.size()))
         .isNotEmpty();
   }
@@ -694,7 +694,7 @@ public class LinkageCheckerTest {
             .resolve(parsedArguments.getArtifacts(), true, DependencyMediation.MAVEN)
             .getClassPath();
 
-    Truth.assertThat(inputClasspath)
+    assertThat(inputClasspath)
         .comparingElementsUsing(COORDINATES)
         .contains("org.mortbay.jasper:apache-jsp:8.0.9.M3");
   }
@@ -713,7 +713,7 @@ public class LinkageCheckerTest {
         classPathBuilder
             .resolve(parsedArguments.getArtifacts(), true, DependencyMediation.MAVEN)
             .getArtifactProblems();
-    Truth.assertThat(artifactProblems)
+    assertThat(artifactProblems)
         .comparingElementsUsing(
             Correspondence.transforming(
                 (UnresolvableArtifactProblem problem) -> problem.getArtifact().toString(),
@@ -763,11 +763,11 @@ public class LinkageCheckerTest {
             false));
     ImmutableSet<LinkageProblem> linkageProblems65First =
         linkageChecker65First.cloneWith(builder.build()).findLinkageProblems();
-    Truth.assertThat(linkageProblems65First).hasSize(1);
+    assertThat(linkageProblems65First).hasSize(1);
 
     ImmutableSet<LinkageProblem> linkageProblems66First =
         linkageChecker66First.cloneWith(builder.build()).findLinkageProblems();
-    Truth.assertThat(linkageProblems66First).isEmpty();
+    assertThat(linkageProblems66First).isEmpty();
   }
 
   @Test
@@ -781,7 +781,7 @@ public class LinkageCheckerTest {
 
     ImmutableSet<LinkageProblem> problems = linkageChecker.findLinkageProblems();
 
-    Truth.assertThat(problems).isEmpty();
+    assertThat(problems).isEmpty();
   }
 
   @Test
@@ -831,8 +831,7 @@ public class LinkageCheckerTest {
 
     ImmutableList<ClassFile> sourcesOfInvalidReferences =
         problems.stream().map(LinkageProblem::getSourceClass).collect(toImmutableList());
-    Truth.assertThat(sourcesOfInvalidReferences)
-        .doesNotContain(new ClassFile(slf4jJar, "org.slf4j.MDC"));
+    assertThat(sourcesOfInvalidReferences).doesNotContain(new ClassFile(slf4jJar, "org.slf4j.MDC"));
   }
 
   @Test
@@ -890,7 +889,7 @@ public class LinkageCheckerTest {
 
     ImmutableList<ClassFile> sourceClasses =
         problems.stream().map(LinkageProblem::getSourceClass).collect(toImmutableList());
-    Truth.assertThat(sourceClasses)
+    assertThat(sourceClasses)
         .doesNotContain(new ClassFile(jars.get(0), "reactor.core.publisher.Traces"));
   }
 
@@ -938,7 +937,7 @@ public class LinkageCheckerTest {
     LinkageChecker linkageChecker = LinkageChecker.create(jars);
 
     ImmutableSet<LinkageProblem> linkageProblems = linkageChecker.findLinkageProblems();
-    Truth.assertWithMessage("Missing classes from jdk.vm.ci should not be reported")
+    assertWithMessage("Missing classes from jdk.vm.ci should not be reported")
         .that(linkageProblems)
         .isEmpty();
   }
@@ -996,8 +995,8 @@ public class LinkageCheckerTest {
                 "(Lcom/google/auth/Credentials;)Lcom/google/api/gax/rpc/TransportChannelProvider;",
                 false), transportChannelProvider
         );
-    Truth.assertThat(problems).contains(expectedProblemOnNeedsCredentials);
-    Truth.assertThat(problems).contains(expectedProblemOnWithCredentials);
+    assertThat(problems).contains(expectedProblemOnNeedsCredentials);
+    assertThat(problems).contains(expectedProblemOnWithCredentials);
   }
 
   @Test
@@ -1013,7 +1012,7 @@ public class LinkageCheckerTest {
     // CContext$Directives interface. But this should not be reported as an error because the
     // interface has default implementation for the methods.
     String unexpectedClass = "com.oracle.svm.core.LibCHelperDirectives";
-    Truth.assertThat(problems)
+    assertThat(problems)
         .comparingElementsUsing(HAS_SYMBOL_IN_CLASS)
         .doesNotContain(unexpectedClass);
   }
@@ -1047,7 +1046,7 @@ public class LinkageCheckerTest {
             "(Ljava/util/concurrent/Executor;[Ljava/lang/Object;)Lio/netty/util/concurrent/EventExecutor;",
             false);
 
-    Truth.assertThat(problems)
+    assertThat(problems)
         .comparingElementsUsing(
             Correspondence.transforming(LinkageProblem::getSymbol, "has symbol"))
         .contains(expectedMethodSymbol);
@@ -1066,7 +1065,7 @@ public class LinkageCheckerTest {
     // com.oracle.svm.core.heap.PinnedAllocator. The superclass has native methods, such as
     // "newInstance". These native methods should not be reported as unimplemented methods.
     String unexpectedClass = "com.oracle.svm.core.genscavenge.PinnedAllocatorImpl";
-    Truth.assertThat(problems)
+    assertThat(problems)
         .comparingElementsUsing(HAS_SYMBOL_IN_CLASS)
         .doesNotContain(unexpectedClass);
   }
@@ -1098,7 +1097,7 @@ public class LinkageCheckerTest {
             "reactor.blockhound.shaded.net.bytebuddy.agent.VirtualMachine");
 
     for (String unexpectedSourceClass : unexpectedClasses) {
-      Truth.assertThat(problems)
+      assertThat(problems)
           .comparingElementsUsing(
               Correspondence.transforming(
                   (LinkageProblem problem) -> problem.getSourceClass().getBinaryName(),
@@ -1120,7 +1119,7 @@ public class LinkageCheckerTest {
     LinkageChecker linkageChecker = LinkageChecker.create(classPathResult.getClassPath());
 
     ImmutableSet<LinkageProblem> problems = linkageChecker.findLinkageProblems();
-    Truth.assertThat(problems).isEmpty();
+    assertThat(problems).isEmpty();
   }
 
   @Test
@@ -1160,7 +1159,7 @@ public class LinkageCheckerTest {
     LinkageChecker linkageChecker = LinkageChecker.create(jars);
     ImmutableSet<LinkageProblem> problems = linkageChecker.findLinkageProblems();
 
-    Truth.assertThat(problems)
+    assertThat(problems)
         .comparingElementsUsing(
             Correspondence.transforming(
                 (LinkageProblem problem) -> problem.getSourceClass().getBinaryName(),
@@ -1191,7 +1190,7 @@ public class LinkageCheckerTest {
             methodSymbol,
             "java.nio.Buffer");
 
-    Truth.assertThat(linkageProblems).contains(expectedProblem);
+    assertThat(linkageProblems).contains(expectedProblem);
   }
 
   @Test
@@ -1216,8 +1215,7 @@ public class LinkageCheckerTest {
     SymbolReferences symbolReferences = classDumper.findSymbolReferences();
     ImmutableSet<ClassSymbol> classSymbols =
         symbolReferences.getClassSymbols(new ClassFile(classPath.get(0), wsgenOptionsClassName));
-    Truth.assertThat(classSymbols)
-        .contains(new ClassSymbol("com.sun.xml.ws.api.BindingID$SOAPHTTPImpl"));
+    assertThat(classSymbols).contains(new ClassSymbol("com.sun.xml.ws.api.BindingID$SOAPHTTPImpl"));
 
     LinkageChecker linkageChecker = LinkageChecker.create(classPath);
 
@@ -1262,7 +1260,7 @@ public class LinkageCheckerTest {
                         .equals("java.lang.invoke.MethodHandle"))
             .collect(toImmutableList());
 
-    Truth.assertThat(problemsOnMethodHandle).isEmpty();
+    assertThat(problemsOnMethodHandle).isEmpty();
   }
 
   @Test

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -1108,6 +1108,22 @@ public class LinkageCheckerTest {
   }
 
   @Test
+  public void testFindLinkageProblems_unusedClassesFromCommonsLogging() throws Exception {
+    // The commons-logging has references to unused classes in optional dependencies.
+    // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1871
+    // As we know they are not harmful, the exclusion file skips them.
+    ClassPathResult classPathResult =
+        classPathBuilder.resolve(
+            ImmutableList.of(new DefaultArtifact("commons-logging:commons-logging:1.2")),
+            false,
+            DependencyMediation.MAVEN);
+    LinkageChecker linkageChecker = LinkageChecker.create(classPathResult.getClassPath());
+
+    ImmutableSet<LinkageProblem> problems = linkageChecker.findLinkageProblems();
+    Truth.assertThat(problems).isEmpty();
+  }
+
+  @Test
   public void testFindLinkageProblems_ensureNoSelfReferencingSymbolProblem()
       throws IOException, URISyntaxException {
     // This JAR file contains com.google.firestore.v1beta1.FirestoreGrpc under BOOT-INF/classes.

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -1108,10 +1108,10 @@ public class LinkageCheckerTest {
   }
 
   @Test
-  public void testFindLinkageProblems_unusedClassesFromCommonsLogging() throws Exception {
-    // The commons-logging has references to unused classes in optional dependencies.
+  public void testFindLinkageProblems_unusedAvalonClassesFromCommonsLogging() throws Exception {
+    // The commons-logging has references to Avalon classes in optional dependencies.
     // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1871
-    // As we know they are not harmful, the exclusion file skips them.
+    // As we know they are not harmful, the default exclusion file skips them.
     ClassPathResult classPathResult =
         classPathBuilder.resolve(
             ImmutableList.of(new DefaultArtifact("commons-logging:commons-logging:1.2")),

--- a/enforcer-rules/src/it/bom-project-error/verify.groovy
+++ b/enforcer-rules/src/it/bom-project-error/verify.groovy
@@ -1,22 +1,7 @@
 def buildLog = new File(basedir, "build.log").text.replaceAll("\\r\\n", "\n")
 
 assert buildLog.contains('''\
-[ERROR] Linkage Checker rule found 4 errors:
-Class org.apache.avalon.framework.logger.Logger is not found;
-  referenced by 1 class file
-    org.apache.commons.logging.impl.AvalonLogger (commons-logging:commons-logging:1.1.1)
-  Cause:
-    The valid symbol is in avalon-framework:avalon-framework:jar:4.1.3 at com.google.api-client:google-api-client:1.27.0 (compile) / com.google.oauth-client:google-oauth-client:1.27.0 (compile) / com.google.http-client:google-http-client:1.27.0 (compile) / com.google.android:android:1.5_r4 (provided) / commons-logging:commons-logging:1.1.1 (compile) / avalon-framework:avalon-framework:4.1.3 (compile, optional) but it was not selected because the path contains a provided-scope dependency
-Class org.apache.log.Hierarchy is not found;
-  referenced by 1 class file
-    org.apache.commons.logging.impl.LogKitLogger (commons-logging:commons-logging:1.1.1)
-  Cause:
-    The valid symbol is in logkit:logkit:jar:1.0.1 at com.google.api-client:google-api-client:1.27.0 (compile) / com.google.oauth-client:google-oauth-client:1.27.0 (compile) / com.google.http-client:google-http-client:1.27.0 (compile) / com.google.android:android:1.5_r4 (provided) / commons-logging:commons-logging:1.1.1 (compile) / logkit:logkit:1.0.1 (compile, optional) but it was not selected because the path contains a provided-scope dependency
-Class org.apache.log.Logger is not found;
-  referenced by 1 class file
-    org.apache.commons.logging.impl.LogKitLogger (commons-logging:commons-logging:1.1.1)
-  Cause:
-    The valid symbol is in logkit:logkit:jar:1.0.1 at com.google.api-client:google-api-client:1.27.0 (compile) / com.google.oauth-client:google-oauth-client:1.27.0 (compile) / com.google.http-client:google-http-client:1.27.0 (compile) / com.google.android:android:1.5_r4 (provided) / commons-logging:commons-logging:1.1.1 (compile) / logkit:logkit:1.0.1 (compile, optional) but it was not selected because the path contains a provided-scope dependency
+[ERROR] Linkage Checker rule found 1 error:
 (com.google.guava:guava:20.0) com.google.common.base.Verify's method verify(boolean, String, Object) is not found;
   referenced by 3 class files
     io.grpc.internal.ServiceConfigInterceptor (io.grpc:grpc-core:1.17.1)
@@ -29,9 +14,6 @@ Class org.apache.log.Logger is not found;
 ''')
 
 assert buildLog.contains('''Problematic artifacts in the dependency tree:
-commons-logging:commons-logging:1.1.1 is at:
-  com.google.api-client:google-api-client:1.27.0 (compile) / com.google.oauth-client:google-oauth-client:1.27.0 (compile) / com.google.http-client:google-http-client:1.27.0 (compile) / com.google.android:android:1.5_r4 (provided) / commons-logging:commons-logging:1.1.1 (compile)
-  and 3 other dependency paths.
 com.google.guava:guava:20.0 is at:
   com.google.api-client:google-api-client:1.27.0 (compile) / com.google.guava:guava:20.0 (compile)
   and 3 other dependency paths.

--- a/enforcer-rules/src/it/fail-build-for-linkage-errors/verify.groovy
+++ b/enforcer-rules/src/it/fail-build-for-linkage-errors/verify.groovy
@@ -1,13 +1,6 @@
 def buildLog = new File(basedir, "build.log").text.replaceAll("\\r\\n", "\n")
 
 assert buildLog.contains('''\
-[ERROR] Linkage Checker rule found 4 errors:
-Class org.apache.avalon.framework.logger.Logger is not found;
-  referenced by 1 class file
-    org.apache.commons.logging.impl.AvalonLogger (commons-logging:commons-logging:1.1.1)
-''')
-
-assert buildLog.contains('''\
 (com.google.guava:guava:20.0) com.google.common.base.Verify's method verify(boolean, String, Object) is not found;
   referenced by 3 class files
     io.grpc.internal.ServiceConfigInterceptor (io.grpc:grpc-core:1.17.1)
@@ -21,15 +14,6 @@ assert buildLog.contains('''\
 
 assert buildLog.contains('''\
 Problematic artifacts in the dependency tree:
-commons-logging:commons-logging:1.1.1 is at:
-  com.google.cloud.tools.opensource:test-no-such-method-error-example:jar:1.0-SNAPSHOT \
-/ com.google.api-client:google-api-client:1.27.0 (compile) \
-/ com.google.oauth-client:google-oauth-client:1.27.0 (compile) \
-/ com.google.http-client:google-http-client:1.27.0 (compile) \
-/ com.google.android:android:1.5_r4 (provided) \
-/ commons-logging:commons-logging:1.1.1 (compile)
-''')
-assert buildLog.contains('''\
 com.google.guava:guava:20.0 is at:
   com.google.cloud.tools.opensource:test-no-such-method-error-example:jar:1.0-SNAPSHOT \
 / com.google.api-client:google-api-client:1.27.0 (compile) \

--- a/gradle-plugin/src/functionalTest/groovy/com/google/cloud/tools/dependencies/gradle/ExclusionFileFunctionalTest.groovy
+++ b/gradle-plugin/src/functionalTest/groovy/com/google/cloud/tools/dependencies/gradle/ExclusionFileFunctionalTest.groovy
@@ -156,10 +156,9 @@ class ExclusionFileFunctionalTest extends Specification {
           mavenCentral()
         }
         
-        // These two have incompatible dependencies
-        // https://github.com/grpc/grpc-java/issues/7002
+        // This old version of gax-grpc has dependency conflicts.
         dependencies {
-          compile 'com.google.api:gax:1.57.0'
+          compile 'com.google.api:gax-grpc:1.42.0'
         }
         
         linkageChecker {
@@ -168,36 +167,27 @@ class ExclusionFileFunctionalTest extends Specification {
         }
         """
 
-    // When resolved by Gradle's dependency resolution logic, gax has the following linkage errors.
+    // When resolved by Gradle's dependency resolution logic, gax-grpc has the following errors.
     File exclusionFile = testProjectDir.newFile(exclusionFileName)
     exclusionFile << """
         <LinkageCheckerFilter>
           <LinkageError>
-            <Target>
-              <Class name="org.apache.avalon.framework.logger.Logger" />
-            </Target>
             <Source>
-              <Class name="org.apache.commons.logging.impl.AvalonLogger" />
+              <Package name="io.grpc.netty.shaded" />
             </Source>
-            <Reason>we do not use the logger</Reason>
+            <Reason>Netty's shading generates linkage errors</Reason>
           </LinkageError>
           <LinkageError>
-            <Target>
-              <Class name="org.apache.log.Hierarchy" />
-            </Target>
             <Source>
-              <Class name="org.apache.commons.logging.impl.LogKitLogger" />
+              <Package name="com.google.common" />
             </Source>
-            <Reason>we do not use the logger</Reason>
+            <Reason>guava-jdk5 is too old to work with new Guava</Reason>
           </LinkageError>
           <LinkageError>
-            <Target>
-              <Class name="org.apache.log.Logger" />
-            </Target>
             <Source>
-              <Class name="org.apache.commons.logging.impl.LogKitLogger" />
+              <Package name="com.google.api.client.testing" />
             </Source>
-            <Reason>we do not use the logger</Reason>
+            <Reason>dependency conflict on Apache HTTP Client</Reason>
           </LinkageError>
         </LinkageCheckerFilter>
         """

--- a/gradle-plugin/src/functionalTest/groovy/com/google/cloud/tools/dependencies/gradle/ExclusionFileFunctionalTest.groovy
+++ b/gradle-plugin/src/functionalTest/groovy/com/google/cloud/tools/dependencies/gradle/ExclusionFileFunctionalTest.groovy
@@ -84,8 +84,8 @@ class ExclusionFileFunctionalTest extends Specification {
     result.output.contains("Task :linkageCheck")
     result.output.contains("BUILD FAILED")
     // Ensure it outputs the linkage errors
-    result.output.contains("Class org.apache.avalon.framework.logger.Logger is not found")
-
+    result.output.contains(
+        "io.grpc.internal.GrpcAttributes's field ATTR_LB_ADDR_AUTHORITY is not found")
     // BaseDnsNameResolverProvider is referenced by SecretGrpclbNameResolverProvider, which we
     // suppress via the exclusion file.
     !result.output.contains("io.grpc.internal.BaseDnsNameResolverProvider")
@@ -141,8 +141,8 @@ class ExclusionFileFunctionalTest extends Specification {
     result.output.contains("Task :linkageCheck")
     result.output.contains("BUILD FAILED")
     // Ensure it outputs the linkage errors
-    result.output.contains("Class org.apache.avalon.framework.logger.Logger is not found")
-
+    result.output.contains(
+        "io.grpc.internal.GrpcAttributes's field ATTR_LB_ADDR_AUTHORITY is not found")
     // BaseDnsNameResolverProvider is referenced by SecretGrpclbNameResolverProvider, which we
     // suppress via the exclusion file.
     !result.output.contains("io.grpc.internal.BaseDnsNameResolverProvider")


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1871

> It's better to suppress specific linkage errors rather than suppressing many unknowns.

Changes:
- Update the default exclusion rules ([file](https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/2164/files#r682649024)) to include the references from commons-logging to Avalon Logger.
- Update test assertions not to rely on the linkage errors from commons-logging to Avalon Logger.
