### PR TITLE
Updating bigtable-hbase-beam patch version

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -68,7 +68,7 @@
     <google.cloud.pubsub.version>1.111.0-sp.1</google.cloud.pubsub.version>
     <google.cloud.bigquery.version>1.127.12-sp.1</google.cloud.bigquery.version>
     <google.cloud.bigtable.version>1.22.0-sp.1</google.cloud.bigtable.version>
-    <bigtable-hbase-beam.version>1.20.0-sp.1</bigtable-hbase-beam.version>
+    <bigtable-hbase-beam.version>1.20.0-sp.2</bigtable-hbase-beam.version>
     <google.cloud.storage.version>1.113.14-sp.1</google.cloud.storage.version>
     <datastore.v1.proto.client.version>1.6.4-sp.1</datastore.v1.proto.client.version>
     <appengine.api.1.0.sdk.version>1.9.89</appengine.api.1.0.sdk.version>


### PR DESCRIPTION
This PR modifies the 1.0.0-lts branch.

Memo:

```
suztomo-macbookpro44% gh pr create  --base 1.0.0-lts 
Warning: 21 uncommitted changes
? Where should we push the '1.0.0-lts' branch? suztomo/cloud-opensource-java

Creating pull request for suztomo:1.0.0-lts into 1.0.0-lts in GoogleCloudPlatform/cloud-opensource-java

? Title Updating bigtable-hbase-beam patch version
? Body <Received>
? What's next? Submit
warning: server does not support wait-for-done
warning: push negotiation failed; proceeding anyway with push
remote: 
remote: 
To https://github.com/suztomo/cloud-opensource-java
 * [new branch]        HEAD -> 1.0.0-lts
Branch '1.0.0-lts' set up to track remote branch '1.0.0-lts' from 'suztomo'.
https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/2165

```