### PR TITLE
Fixing BOM release script to work for a patch release

### DIFF
--- a/boms/cloud-lts-bom/RELEASING.md
+++ b/boms/cloud-lts-bom/RELEASING.md
@@ -38,13 +38,16 @@ We maintain multiple branches for the LTS BOM releases.
 Let's call the branches _LTS release branches_.
 An LTS release branch has a name "N.0.0-lts", where N is the major release version number,
 such as `1.0.0-lts` and `2.0.0-lts`.
-In this GitHub repository, the branches are configured as protected,
-so that we do not accidentally push changes to them.
+In this GitHub repository, the branches are [configured as protected](
+https://github.com/GoogleCloudPlatform/cloud-opensource-java/settings/branches),
+so that we do not accidentally push changes into them.
 
-Any change for a patch release to the LTS BOM should be merged to one of the LTS release branches.
-This practice enables us to release multiple versions of the BOM at the same time.
+Any changes for a patch release to the LTS BOM should be merged to one of the LTS release branches.
+This practice enables us to release a patch version of one of the old versions of the BOM,
+without using the master branch (or _HEAD_).
+
 Note that even when you prepare a patch release with higher patch number than 1,
-you commit changes to `N.0.0-lts` branch (the patch part is `0`).
+you commit changes to `N.0.0-lts` branch (the patch part is "0").
 For example, when you make changes for LTS BOM release 5.0.3, your pull request would merge
 the changes into `5.0.0-lts` branch.
 The branch includes all the changes between 5.0.0 and 5.0.2 releases.
@@ -69,3 +72,5 @@ has non-zero patch part.
 For example, when you run the release script with argument `./scripts/release.sh lts 5.0.3`,
 it creates a release branch `5.0.3-lts` based on the LTS release branch `5.0.0-lts`.
 
+For LTS patch releases, the release script creates a pull request that bumps the patch version of the LTS release branch
+(not the master branch).

--- a/boms/cloud-lts-bom/RELEASING.md
+++ b/boms/cloud-lts-bom/RELEASING.md
@@ -51,3 +51,4 @@ For example, when you run the release script with argument `./scripts/release.sh
 it creates a release branch `2.0.4-lts` from the LTS release branch `2.0.0-lts`,
 (not from `2.0.3-lts`).
 
+

--- a/boms/cloud-lts-bom/RELEASING.md
+++ b/boms/cloud-lts-bom/RELEASING.md
@@ -29,3 +29,25 @@ The Rapid workflow uploads the artifact to OSSRH staging repository.
 [Instructions for releasing from OSSRH are on the internal team 
 site](https://g3doc.corp.google.com/company/teams/cloud-java/tools/developers/releasing.md#verify-and-release).
 
+
+## Making changes to a released LTS BOM
+
+We maintain the branch of each release, such as `1.0.0-lts` and `2.0.0-lts`. Let's call
+them _LTS release branches_. An LTS release branch has a name "N.0.0-lts", where N is
+the major release version number.
+They are configured as protected branches so that we do not accidentally make changes.
+
+Any change for a patch release should be merged to the LTS release branches , rather than the master branch;
+otherwise we cannot release multiple versions of the BOM at the same time.
+Note that even when you prepare a patch release with higher patch number than 1,
+you commit changes to `N.0.0-lts` branch.
+For example, when you make changes for 2.0.5 LTS BOM release, your pull request would merge
+the changes into `2.0.0-lts` branch. The branch includes all the changes between
+2.0.0 and 2.0.4 releases.
+
+The release script creates a release branch for a patch release by checking out the LTS release
+branches (`N.0.0-lts`) if the releasing version has non-zero patch version.
+For example, when you run the release script with argument `./scripts/release.sh lts 2.0.4`,
+it creates a release branch `2.0.4-lts` from the LTS release branch `2.0.0-lts`,
+(not from `2.0.3-lts`).
+

--- a/boms/cloud-lts-bom/RELEASING.md
+++ b/boms/cloud-lts-bom/RELEASING.md
@@ -15,7 +15,7 @@ All on your corp desktop:
 the `cloud-opensource-java` directory:
 
 ```
-$ ./scripts/release.sh lts <release version> <post-release-version>
+$ ./scripts/release.sh lts <release version>
 ```
 
 This script creates a pull request and initiates the Rapid release workflow.
@@ -30,25 +30,42 @@ The Rapid workflow uploads the artifact to OSSRH staging repository.
 site](https://g3doc.corp.google.com/company/teams/cloud-java/tools/developers/releasing.md#verify-and-release).
 
 
-## Making changes to a released LTS BOM
+## Making changes for a patch release
 
-We maintain the branch of each release, such as `1.0.0-lts` and `2.0.0-lts`. Let's call
-them _LTS release branches_. An LTS release branch has a name "N.0.0-lts", where N is
-the major release version number.
-They are configured as protected branches so that we do not accidentally make changes.
+Changes for a patch release should be committed to LTS release branches (not the master branch).
 
-Any change for a patch release should be merged to the LTS release branches , rather than the master branch;
-otherwise we cannot release multiple versions of the BOM at the same time.
+We maintain multiple branches for the LTS BOM releases.
+Let's call the branches _LTS release branches_.
+An LTS release branch has a name "N.0.0-lts", where N is the major release version number,
+such as `1.0.0-lts` and `2.0.0-lts`.
+In this GitHub repository, the branches are configured as protected,
+so that we do not accidentally push changes to them.
+
+Any change for a patch release to the LTS BOM should be merged to one of the LTS release branches.
+This practice enables us to release multiple versions of the BOM at the same time.
 Note that even when you prepare a patch release with higher patch number than 1,
-you commit changes to `N.0.0-lts` branch.
-For example, when you make changes for 2.0.5 LTS BOM release, your pull request would merge
-the changes into `2.0.0-lts` branch. The branch includes all the changes between
-2.0.0 and 2.0.4 releases.
+you commit changes to `N.0.0-lts` branch (the patch part is `0`).
+For example, when you make changes for LTS BOM release 5.0.3, your pull request would merge
+the changes into `5.0.0-lts` branch.
+The branch includes all the changes between 5.0.0 and 5.0.2 releases.
 
-The release script creates a release branch for a patch release by checking out the LTS release
-branches (`N.0.0-lts`) if the releasing version has non-zero patch version.
-For example, when you run the release script with argument `./scripts/release.sh lts 2.0.4`,
-it creates a release branch `2.0.4-lts` from the LTS release branch `2.0.0-lts`,
-(not from `2.0.3-lts`).
+Example pull request: https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/2165
 
+This pull request was created for LTS BOM patch release 1.0.1.
+Notice that the destination branch is `1.0.0-lts`.
+
+## Performing a patch release
+
+The command for patch releases is the same as the normal releases: 
+
+```
+$ ./scripts/release.sh lts <patch release version>
+```
+
+Behind the scene, for a patch release the release script creates a release branch based on the
+corresponding LTS release branch.
+The script determines whether it's a patch release or not by checking the version
+has non-zero patch part.
+For example, when you run the release script with argument `./scripts/release.sh lts 5.0.3`,
+it creates a release branch `5.0.3-lts` based on the LTS release branch `5.0.0-lts`.
 

--- a/boms/cloud-lts-bom/RELEASING.md
+++ b/boms/cloud-lts-bom/RELEASING.md
@@ -11,16 +11,39 @@ All on your corp desktop:
 
 1. Run gcert if you have not done so in the last twelve hours or so.
 
-2. Run `release.sh` with `lts` argument in 
+2. If this is a major version release, create a LTS release branch `N.0.x-lts`, where
+N is the release number.
+
+For example:
+
+```
+$ git checkout -b 2.0.x-lts origin/master
+$ git push --set-upstream origin 2.0.x-lts
+```
+
+If this is a patch version release, the LTS release branch already exists.
+No action required for this step #2.
+
+3. Run `release.sh` with `lts` argument in 
 the `cloud-opensource-java` directory:
 
 ```
 $ ./scripts/release.sh lts <release version>
 ```
 
-This script creates a pull request and initiates the Rapid release workflow.
+With the `lts` argument, this script creates a pull request and that bumps the patch version of
+the LTS release branch (not the master branch).
+Ask a teammate to review and approve the PR.
 
-Ask a teammate to review and approve the PR. 
+Behind the scenes, the release script creates a release branch based on the
+corresponding LTS release branch.
+For example, when you run the release script with argument `./scripts/release.sh lts 5.0.3`,
+it creates a release branch `5.0.3-lts` based on the LTS release branch `5.0.x-lts`.
+
+The script also initiates the Rapid release workflow.
+
+4. After you finish the release, if this is a major version release, bump the major version of the
+   BOM (`boms/cloud-lts-bom/pom.xml`) in the master branch.
 
 ## OSSRH
 
@@ -32,12 +55,12 @@ site](https://g3doc.corp.google.com/company/teams/cloud-java/tools/developers/re
 
 ## Making changes for a patch release
 
-Changes for a patch release should be committed to LTS release branches (not the master branch).
+Changes for a patch release should be committed to LTS release branches (not to the master branch).
 
 We maintain multiple branches for the LTS BOM releases.
 Let's call the branches _LTS release branches_.
-An LTS release branch has a name "N.0.0-lts", where N is the major release version number,
-such as `1.0.0-lts` and `2.0.0-lts`.
+An LTS release branch has a name "N.0.x-lts", where N is the major release version number,
+such as `1.0.x-lts` and `2.0.x-lts`.
 In this GitHub repository, the branches are [configured as protected](
 https://github.com/GoogleCloudPlatform/cloud-opensource-java/settings/branches),
 so that we do not accidentally push changes into them.
@@ -45,32 +68,3 @@ so that we do not accidentally push changes into them.
 Any changes for a patch release to the LTS BOM should be merged to one of the LTS release branches.
 This practice enables us to release a patch version of one of the old versions of the BOM,
 without using the master branch (or _HEAD_).
-
-Note that even when you prepare a patch release with higher patch number than 1,
-you commit changes to `N.0.0-lts` branch (the patch part is "0").
-For example, when you make changes for LTS BOM release 5.0.3, your pull request would merge
-the changes into `5.0.0-lts` branch.
-The branch includes all the changes between 5.0.0 and 5.0.2 releases.
-
-Example pull request: https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/2165
-
-This pull request was created for LTS BOM patch release 1.0.1.
-Notice that the destination branch is `1.0.0-lts`.
-
-## Performing a patch release
-
-The command for patch releases is the same as the normal releases: 
-
-```
-$ ./scripts/release.sh lts <patch release version>
-```
-
-Behind the scene, for a patch release the release script creates a release branch based on the
-corresponding LTS release branch.
-The script determines whether it's a patch release or not by checking the version
-has non-zero patch part.
-For example, when you run the release script with argument `./scripts/release.sh lts 5.0.3`,
-it creates a release branch `5.0.3-lts` based on the LTS release branch `5.0.0-lts`.
-
-For LTS patch releases, the release script creates a pull request that bumps the patch version of the LTS release branch
-(not the master branch).

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -
-# Usage: ./release.sh <dependencies|bom> <release version>
+# Usage: ./release.sh <dependencies|bom|lts> <release version>
 
 set -e
 
@@ -27,9 +27,9 @@ CheckVersion() {
 # Usage: IncrementVersion <version>
 IncrementVersion() {
   local version=$1
-  local minorVersion=$(echo $version | sed 's/[0-9][0-9]*\.[0-9][0-9]*\.\([0-9][0-9]\)*/\1/')
+  local minorVersion=$(echo $version | sed 's/[0-9]\+\.[0-9]\+\.\([0-9]\+\)*/\1/')
   local nextMinorVersion=$((minorVersion+1))
-  echo $version | sed "s/\([0-9][0-9]*\.[0-9][0-9]*\)\.[0-9][0-9]*/\1.$nextMinorVersion/"
+  echo $version | sed "s/\([0-9]\+\.[0-9]\+\)\.[0-9]\+/\1.$nextMinorVersion/"
 }
 
 [ $# -ne 2 ] && [ $# -ne 3 ] && DieUsage
@@ -61,8 +61,9 @@ if [[ $(git status -uno --porcelain) ]]; then
 fi
 
 if [[ "${SUFFIX}" = "lts" && "${VERSION}" != *.*.0 ]]; then
-  # LTS patch release is based on N.0.0-lts branch, where N is the major release number.
-  BASE_VERSION=$(echo $VERSION | sed 's/\([0-9][0-9]*\.[0-9][0-9]*\)\.[0-9][0-9]*/\1.0/')
+  # LTS patch release (the patch version is non-zero) is based on N.0.0-lts branch, where N is the
+  # major release number. (Note that the minor version part of this BOM is always zero)
+  BASE_VERSION=$(echo $VERSION | sed 's/\([0-9]\+\.[0-9]\+\)\.[0-9]\+/\1.0/')
   # For example, LTS BOM patch release 5.0.3 would create "5.0.3-lts" branch based on the base
   # branch "5.0.0-lts". For the details of a patch release, see boms/cloud-lts-bom/RELEASING.md.
   BASE_BRANCH=${BASE_VERSION}-lts

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -60,13 +60,12 @@ if [[ $(git status -uno --porcelain) ]]; then
   Die 'There are uncommitted changes.'
 fi
 
-if [[ "${SUFFIX}" = "lts" && "${VERSION}" != *.*.0 ]]; then
-  # LTS patch release (the patch version is non-zero) is based on N.0.0-lts branch, where N is the
-  # major release number. (Note that the minor version part of this BOM is always zero)
-  BASE_VERSION=$(echo $VERSION | sed 's/\([0-9]\+\.[0-9]\+\)\.[0-9]\+/\1.0/')
+if [[ "${SUFFIX}" = "lts" ]]; then
+  # LTS releases are based on N.0.x-lts branch, where N is the major release number.
+  # (Note that the minor version part of this BOM is always zero)
+  BASE_BRANCH=$(echo $VERSION | sed 's/\([0-9]\+\.[0-9]\+\)\.[0-9]\+/\1.x-lts/')
   # For example, LTS BOM patch release 5.0.3 would create "5.0.3-lts" branch based on the base
-  # branch "5.0.0-lts". For the details of a patch release, see boms/cloud-lts-bom/RELEASING.md.
-  BASE_BRANCH=${BASE_VERSION}-lts
+  # branch "5.0.x-lts". For the details of a patch release, see boms/cloud-lts-bom/RELEASING.md.
 else
   # Make sure client is up to date with the latest changes.
   BASE_BRANCH=master

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -63,7 +63,10 @@ fi
 if [[ "${SUFFIX}" = "lts" ]]; then
   # LTS releases are based on N.0.x-lts branch, where N is the major release number.
   # (Note that the minor version part of this BOM is always zero)
-  BASE_BRANCH=$(echo $VERSION | sed 's/\([0-9]\+\.[0-9]\+\)\.[0-9]\+/\1.x-lts/')
+  BASE_BRANCH=$(echo $VERSION | sed 's/\([0-9]\+\).0\.[0-9]\+/\1.0.x-lts/')
+  if [[ "${BASE_BRANCH}" != *0.x-lts ]]; then
+    Die 'The LTS release version did not match expected format. The minor version is always 0.'
+  fi
   # For example, LTS BOM patch release 5.0.3 would create "5.0.3-lts" branch based on the base
   # branch "5.0.x-lts". For the details of a patch release, see boms/cloud-lts-bom/RELEASING.md.
 else

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -63,8 +63,8 @@ fi
 if [[ "${SUFFIX}" = "lts" ]]; then
   # LTS releases are based on N.0.x-lts branch, where N is the major release number.
   # (Note that the minor version part of this BOM is always zero)
-  BASE_BRANCH=$(echo $VERSION | sed 's/\([0-9]\+\).0\.[0-9]\+/\1.0.x-lts/')
-  if [[ "${BASE_BRANCH}" != *0.x-lts ]]; then
+  BASE_BRANCH=$(echo $VERSION | sed 's/\([0-9]\+\)\.0\.[0-9]\+/\1.0.x-lts/')
+  if [[ "${BASE_BRANCH}" != *.0.x-lts ]]; then
     Die 'The LTS release version did not match expected format. The minor version is always 0.'
   fi
   # For example, LTS BOM patch release 5.0.3 would create "5.0.3-lts" branch based on the base


### PR DESCRIPTION
Before this PR, the release script always worked on the master branch.

However, for making a patch release on top of an old BOM release, we need to commit changes to a release branch so that we can release patch versions of old releases. The release script needs to adjust to follow this practice. Updating RELEASING.md with this explanation.

