### PR TITLE
Bumping the major version for next major release

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>gcp-lts-bom</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Long Term Support BOM</name>


### PR DESCRIPTION
As per the new strategy of maintaining the LTS release branches, the version in the master branch should be the snapshot of the next major version.
https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/2168/files#diff-fbcf953b748e5cd914434b7cde92b7fcac33170a70fdf6af90eb91ddd2ff3143R45