### PR TITLE
Gradle plugin: suppress duplicate circular dependency output

### DIFF
--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -1,6 +1,7 @@
 # Linkage Checker Gradle Plugin
 
-For usage of this plugin, see the documentation.
+For usage of this plugin, see [the plugin documentation](
+https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/Linkage-Checker-with-Gradle).
 
 # Build Instruction
 
@@ -27,7 +28,27 @@ This command installs the Linkage Checker Gradle plugin in the local Maven repos
    linkage-checker-gradle-plugin-0.1.0-SNAPSHOT.jar
    linkage-checker-gradle-plugin-0.1.0-SNAPSHOT.pom
    ```
-    
+
+## Using the plugin in the local Maven repository
+
+To use the plugin that is installed in the local Maven repository, write the following code
+in your `settings.gradle`.
+
+```
+buildscript{
+  repositories {
+    mavenLocal()
+
+    dependencies{
+      classpath 'com.google.cloud.tools:linkage-checker-gradle-plugin:1.5.10-SNAPSHOT'
+    }
+  }
+}
+```
+
+If you do this, remove the version of the plugin in `build.gradle`; otherwise Gradle shows an error
+message to do so.
+
 # Debug
 
    ```

--- a/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/LinkageCheckTask.java
+++ b/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/LinkageCheckTask.java
@@ -327,9 +327,9 @@ public class LinkageCheckTask extends DefaultTask {
 
       Set<ResolvedArtifact> moduleArtifacts = node.getModuleArtifacts();
       if (moduleArtifacts.isEmpty()) {
-        // Maven's dependency tree, Gradle's dependency tree includes such nodes that don't have
-        // associated artifacts. A BOM, such as com.fasterxml.jackson:jackson-bom:2.12.3, fall in
-        // this category.
+        // Unlike Maven's dependency tree, Gradle's dependency tree may include nodes that do not
+        // have associated artifacts. BOMs, such as com.fasterxml.jackson:jackson-bom:2.12.3, fall
+        // in this category. For the detailed observation, see the issue below:
         // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/2174#issuecomment-897174898
         getLogger()
             .warn(


### PR DESCRIPTION
When dealing with an artifact with large dependency tree, the circular dependency message is printed many times (picture below). This PR fixes that.

<img width="1085" alt="Screen Shot 2021-08-11 at 19 52 22" src="https://user-images.githubusercontent.com/28604/129118050-ab5342c1-4621-47fe-b77e-0ac2c2b3c96c.png">
