### PR TITLE
Allow protected member access of java.lang.Object

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageChecker.java
@@ -509,6 +509,11 @@ public class LinkageChecker {
       if (ClassDumper.classesInSamePackage(targetClass.getClassName(), sourceClassName)) {
         return true;
       }
+      if (Object.class.getName().equals(targetClass.getClassName())) {
+        // All objects are subclasses of java.lang.Object. Therefore the protected members are
+        // accessible to all objects.
+        return true;
+      }
       try {
         JavaClass sourceClass = classDumper.loadJavaClass(sourceClassName);
         if (ClassDumper.isClassSubClassOf(sourceClass, targetClass)) {

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -1321,11 +1321,9 @@ public class LinkageCheckerTest {
 
   @Test
   public void testProtectedMethodsOfObject() throws Exception {
-    Artifact groovy =
-        new DefaultArtifact("org.codehaus.groovy:groovy-all:2.3.6");
+    Artifact groovy = new DefaultArtifact("org.codehaus.groovy:groovy-all:2.3.6");
     ClassPathResult classPathResult =
-        new ClassPathBuilder()
-            .resolve(ImmutableList.of(groovy), false, DependencyMediation.MAVEN);
+        new ClassPathBuilder().resolve(ImmutableList.of(groovy), false, DependencyMediation.MAVEN);
 
     LinkageChecker linkageChecker = LinkageChecker.create(classPathResult.getClassPath());
     ImmutableSet<LinkageProblem> linkageProblems = linkageChecker.findLinkageProblems();
@@ -1340,7 +1338,6 @@ public class LinkageCheckerTest {
             Correspondence.transforming(
                 (LinkageProblem problem) -> problem.getSymbol().getClassBinaryName(),
                 "has linkage errors that reference symbols on class"))
-        .doesNotContain(
-            "java.lang.Object");
+        .doesNotContain("java.lang.Object");
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerTest.java
@@ -1318,4 +1318,29 @@ public class LinkageCheckerTest {
                 "has source class belonging to artifact"))
         .contains("com.google.cloud:google-cloud-core:jar:tests:1.96.0");
   }
+
+  @Test
+  public void testProtectedMethodsOfObject() throws Exception {
+    Artifact groovy =
+        new DefaultArtifact("org.codehaus.groovy:groovy-all:2.3.6");
+    ClassPathResult classPathResult =
+        new ClassPathBuilder()
+            .resolve(ImmutableList.of(groovy), false, DependencyMediation.MAVEN);
+
+    LinkageChecker linkageChecker = LinkageChecker.create(classPathResult.getClassPath());
+    ImmutableSet<LinkageProblem> linkageProblems = linkageChecker.findLinkageProblems();
+
+    // Some class files in the Groovy library contains references to java.lang.Object's finalize()
+    // and clone() methods. Because these methods have protected accessor (accessible from
+    // subclasses) and all objects are subclasses of java.lang.Object, there should not be linkage
+    // errors on the references.
+    // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/2177
+    Truth.assertThat(linkageProblems)
+        .comparingElementsUsing(
+            Correspondence.transforming(
+                (LinkageProblem problem) -> problem.getSymbol().getClassBinaryName(),
+                "has linkage errors that reference symbols on class"))
+        .doesNotContain(
+            "java.lang.Object");
+  }
 }


### PR DESCRIPTION
Allow protected member access of java.lang.Object, because all objects are subclasses of java.lang.Object.

Fixes #2177. Before this change Linkage Checker would throw errors on the methods of java.lang.Object:

```
java.lang.Object's method finalize() is not accessible;
  referenced by 6 class files
    groovy.lang.GroovyLogTestCase (org.codehaus.groovy:groovy-all:2.3.6)
    groovy.util.GroovyShellTestCase (org.codehaus.groovy:groovy-all:2.3.6)
    groovy.util.JavadocAssertionTestSuite (org.codehaus.groovy:groovy-all:2.3.6)
    org.codehaus.groovy.tools.shell.CommandsMultiCompleter (org.codehaus.groovy:groovy-all:2.3.6)
```

However, the member is "protected" (https://docs.oracle.com/javase/7/docs/api/java/lang/Object.html#finalize()) and java.lang.Object is the super class of all Java classes. These errors are false positives. This PR fixes this problem.
