### PR TITLE
Upgrading Gradle plugin version in the example

### DIFF
--- a/example-problems/gradle-project/build.gradle
+++ b/example-problems/gradle-project/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-  id "com.google.cloud.tools.linkagechecker" version "1.5.6"
   id "java"
+  id "com.google.cloud.tools.linkagechecker" version "1.5.10"
 }
 
 repositories {
@@ -31,3 +31,5 @@ linkageChecker {
   configurations = ['compile']
   reportOnlyReachable = true
 }
+linkageCheck.dependsOn('build')
+


### PR DESCRIPTION
Upgrading the version to the latest 1.5.10. Note that this project is not built as part of the GitHub Actions / Kokoro build (because it's intended to fail and report linkage errors).