### PR TITLE
Gradle plugin: avoid printing duplicate dependency paths

### DIFF
--- a/gradle-plugin/src/functionalTest/groovy/com/google/cloud/tools/dependencies/gradle/BuildStatusFunctionalTest.groovy
+++ b/gradle-plugin/src/functionalTest/groovy/com/google/cloud/tools/dependencies/gradle/BuildStatusFunctionalTest.groovy
@@ -111,6 +111,17 @@ class BuildStatusFunctionalTest extends Specification {
         |io.grpc:grpc-grpclb:1.28.1 is at:
         |  g:test-123:0.1.0-SNAPSHOT / com.google.cloud:google-cloud-logging:1.101.1 / com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-alts:1.28.1 / io.grpc:grpc-grpclb:1.28.1
         |""".stripMargin())
+
+    // "(omitted for duplicate)" should come after the non-omitted items
+    result.output.contains("""
+        |io.grpc:grpc-alts:1.28.1 is at:
+        |  g:test-123:0.1.0-SNAPSHOT / com.google.cloud:google-cloud-logging:1.101.1 / com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-alts:1.28.1
+        |""".stripMargin())
+
+    // Ensure the node closest to the root is printed
+    result.output.contains("g:test-123:0.1.0-SNAPSHOT / io.grpc:grpc-core:1.29.0")
+    // Ensure that the relationship between grpc-netty-shaded to grpc-core is only printed once
+    result.output.count("io.grpc:grpc-netty-shaded:1.28.1 / io.grpc:grpc-core:1.29.0") == 1
     result.task(":linkageCheck").outcome == TaskOutcome.FAILED
   }
 

--- a/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/DependencyNode.java
+++ b/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/DependencyNode.java
@@ -16,28 +16,25 @@
 
 package com.google.cloud.tools.dependencies.gradle;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayDeque;
-import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 
 /** Dependency nodes to record dependency paths while traversing the dependency tree */
-class DependencyNode {
+final class DependencyNode {
   ResolvedComponentResult componentResult;
 
   DependencyNode parent;
 
-  DependencyNode(
-      ResolvedComponentResult componentResult, DependencyNode parent) {
+  DependencyNode(ResolvedComponentResult componentResult, DependencyNode parent) {
     this.componentResult = componentResult;
     this.parent = parent;
   }
 
-   boolean isDescendantOf(ResolvedComponentResult other) {
+  boolean isDescendantOf(ResolvedComponentResult other) {
     if (componentResult.equals(other)) {
       return true;
     }
@@ -47,12 +44,13 @@ class DependencyNode {
     return parent.isDescendantOf(other);
   }
 
-   String pathFromRoot() {
-     return rootToNode().stream().map(LinkageCheckTask::formatComponentResult)
-         .collect(Collectors.joining(" / "));
+  String pathFromRoot() {
+    return fromRootToNode().stream()
+        .map(LinkageCheckTask::formatComponentResult)
+        .collect(Collectors.joining(" / "));
   }
 
-  ImmutableList<ResolvedComponentResult> rootToNode() {
+  ImmutableList<ResolvedComponentResult> fromRootToNode() {
     ArrayDeque<ResolvedComponentResult> nodes = new ArrayDeque<>();
     for (DependencyNode iter = this; iter != null; iter = iter.parent) {
       nodes.addFirst(iter.componentResult);

--- a/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/DependencyNode.java
+++ b/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/DependencyNode.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.dependencies.gradle;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+
+/** Dependency nodes to record dependency paths while traversing the dependency tree */
+class DependencyNode {
+  ResolvedComponentResult componentResult;
+
+  DependencyNode parent;
+
+  DependencyNode(
+      ResolvedComponentResult componentResult, DependencyNode parent) {
+    this.componentResult = componentResult;
+    this.parent = parent;
+  }
+
+   boolean isDescendantOf(ResolvedComponentResult other) {
+    if (componentResult.equals(other)) {
+      return true;
+    }
+    if (parent == null) {
+      return false;
+    }
+    return parent.isDescendantOf(other);
+  }
+
+   String pathFromRoot() {
+     return rootToNode().stream().map(LinkageCheckTask::formatComponentResult)
+         .collect(Collectors.joining(" / "));
+  }
+
+  ImmutableList<ResolvedComponentResult> rootToNode() {
+    ArrayDeque<ResolvedComponentResult> nodes = new ArrayDeque<>();
+    for (DependencyNode iter = this; iter != null; iter = iter.parent) {
+      nodes.addFirst(iter.componentResult);
+    }
+    return ImmutableList.copyOf(nodes);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("componentResult", componentResult)
+        .add("parent", parent)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    DependencyNode that = (DependencyNode) other;
+    return Objects.equals(componentResult, that.componentResult)
+        && Objects.equals(parent, that.parent);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(componentResult, parent);
+  }
+}

--- a/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/LinkageCheckTask.java
+++ b/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/LinkageCheckTask.java
@@ -225,11 +225,9 @@ public class LinkageCheckTask extends DefaultTask {
     }
 
     public String pathFromRoot() {
-      ResolvedComponentResultNode iter = this;
       List<String> dependencyPathElementsReversed = new ArrayList<>();
-      while (iter != null) {
+      for (ResolvedComponentResultNode iter = this; iter != null; iter = iter.parent) {
         dependencyPathElementsReversed.add(formatComponentResult(iter.componentResult));
-        iter = iter.parent;
       }
       Collections.reverse(dependencyPathElementsReversed);
       String dependencyPath = Joiner.on(" / ").join(dependencyPathElementsReversed);
@@ -302,10 +300,8 @@ public class LinkageCheckTask extends DefaultTask {
           String dependencyPath = node.pathFromRoot();
           coordinatesToDependencyPaths.put(targetCoordinates, dependencyPath);
 
-          ResolvedComponentResultNode iter = node.parent;
-          while (iter != null) {
+          for (ResolvedComponentResultNode iter = node.parent; iter != null; iter = iter.parent) {
             nodesDependOnTarget.add(iter.componentResult);
-            iter = iter.parent;
           }
         }
 
@@ -316,10 +312,8 @@ public class LinkageCheckTask extends DefaultTask {
           String dependencyPath = node.pathFromRoot() + " (omitted for duplicate)";
           coordinatesToDependencyPaths.put(targetCoordinates, dependencyPath);
 
-          ResolvedComponentResultNode iter = node;
-          while (iter != null) {
+          for (ResolvedComponentResultNode iter = node; iter != null; iter = iter.parent) {
             nodesDependOnTarget.add(iter.componentResult);
-            iter = iter.parent;
           }
           continue;
         }

--- a/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/LinkageCheckTask.java
+++ b/gradle-plugin/src/main/java/com/google/cloud/tools/dependencies/gradle/LinkageCheckTask.java
@@ -242,18 +242,15 @@ public class LinkageCheckTask extends DefaultTask {
           if (node.parent != null) {
             nodesDependOnTarget.addAll(node.parent.rootToNode());
           }
-        }
-
-        if (nodesDependOnTarget.contains(item)) {
+        } else if (nodesDependOnTarget.contains(item)) {
           // Omitting duplicate dependency paths by checking nodesDependOnTarget.
           String dependencyPath = node.pathFromRoot() + " (omitted for duplicate)";
           coordinatesToDependencyPaths.put(targetCoordinates, dependencyPath);
 
           nodesDependOnTarget.addAll(node.rootToNode());
-          continue;
+        } else {
+          queue.addAll(getDependencies(node));
         }
-
-        queue.addAll(getDependencies(node));
       }
     }
 


### PR DESCRIPTION
Avoid printing duplicate dependency paths. For a large dependency graph, the previous approach of not omitting duplicate paths would cause OutOfMemoryError.

# Before this change

https://gist.github.com/suztomo/31a67085163a8a99a171cb22345a188b

```
io.grpc:grpc-core:1.29.0 is at:
  :gradle-project:unspecified / com.google.cloud:google-cloud-logging:1.101.1 / com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-netty-shaded:1.28.1 / io.grpc:grpc-core:1.29.0
  :gradle-project:unspecified / com.google.cloud:google-cloud-logging:1.101.1 / com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-alts:1.28.1 / io.grpc:grpc-grpclb:1.28.1 / io.grpc:grpc-core:1.29.0
  :gradle-project:unspecified / com.google.cloud:google-cloud-logging:1.101.1 / com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-alts:1.28.1 / io.grpc:grpc-core:1.29.0
  :gradle-project:unspecified / com.google.cloud:google-cloud-logging:1.101.1 / com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-alts:1.28.1 / io.grpc:grpc-netty-shaded:1.28.1 / io.grpc:grpc-core:1.29.0
  :gradle-project:unspecified / com.google.cloud:google-cloud-logging:1.101.1 / com.google.cloud:google-cloud-core-grpc:1.93.4 / com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-netty-shaded:1.28.1 / io.grpc:grpc-core:1.29.0
  :gradle-project:unspecified / com.google.cloud:google-cloud-logging:1.101.1 / com.google.cloud:google-cloud-core-grpc:1.93.4 / com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-alts:1.28.1 / io.grpc:grpc-grpclb:1.28.1 / io.grpc:grpc-core:1.29.0
  :gradle-project:unspecified / com.google.cloud:google-cloud-logging:1.101.1 / com.google.cloud:google-cloud-core-grpc:1.93.4 / com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-alts:1.28.1 / io.grpc:grpc-core:1.29.0
  :gradle-project:unspecified / com.google.cloud:google-cloud-logging:1.101.1 / com.google.cloud:google-cloud-core-grpc:1.93.4 / com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-alts:1.28.1 / io.grpc:grpc-netty-shaded:1.28.1 / io.grpc:grpc-core:1.29.0
  :gradle-project:unspecified / com.google.cloud:google-cloud-logging:1.101.1 / com.google.cloud:google-cloud-core-grpc:1.93.4 / io.grpc:grpc-core:1.29.0
  :gradle-project:unspecified / com.google.cloud:google-cloud-logging:1.101.1 / io.grpc:grpc-core:1.29.0
  :gradle-project:unspecified / io.grpc:grpc-core:1.29.0
```

Notice `com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-netty-shaded:1.28.1 / io.grpc:grpc-core:1.29.0` is appearing twice (1st and 5th lines).

This was bad because the number of paths would become much larger. Suppose there are 5 paths from artifact A to artifact B, 3 paths from artifact B to artifact C, and 6 paths from C to D. Then the previous implementation  would print 5 x 3 x 6 = 90 dependency paths.

# After this PR

https://gist.github.com/suztomo/202c001c682238ee0fe922383d9a2e4d

```
io.grpc:grpc-core:1.29.0 is at:
  g:test-123:0.1.0-SNAPSHOT / io.grpc:grpc-core:1.29.0
  g:test-123:0.1.0-SNAPSHOT / com.google.cloud:google-cloud-logging:1.101.1 / io.grpc:grpc-core:1.29.0
  g:test-123:0.1.0-SNAPSHOT / com.google.cloud:google-cloud-logging:1.101.1 / com.google.cloud:google-cloud-core-grpc:1.93.4 / io.grpc:grpc-core:1.29.0
  g:test-123:0.1.0-SNAPSHOT / com.google.cloud:google-cloud-logging:1.101.1 / com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-netty-shaded:1.28.1 / io.grpc:grpc-core:1.29.0
  g:test-123:0.1.0-SNAPSHOT / com.google.cloud:google-cloud-logging:1.101.1 / com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-alts:1.28.1 / io.grpc:grpc-core:1.29.0
  g:test-123:0.1.0-SNAPSHOT / com.google.cloud:google-cloud-logging:1.101.1 / com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-alts:1.28.1 / io.grpc:grpc-netty-shaded:1.28.1 (omitted for duplicate)
  g:test-123:0.1.0-SNAPSHOT / com.google.cloud:google-cloud-logging:1.101.1 / com.google.cloud:google-cloud-core-grpc:1.93.4 / com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-netty-shaded:1.28.1 (omitted for duplicate)
  g:test-123:0.1.0-SNAPSHOT / com.google.cloud:google-cloud-logging:1.101.1 / com.google.cloud:google-cloud-core-grpc:1.93.4 / com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-alts:1.28.1 (omitted for duplicate)
  g:test-123:0.1.0-SNAPSHOT / com.google.cloud:google-cloud-logging:1.101.1 / com.google.api:gax-grpc:1.56.0 / io.grpc:grpc-alts:1.28.1 / io.grpc:grpc-grpclb:1.28.1 / io.grpc:grpc-core:1.29.0
```

`io.grpc:grpc-netty-shaded:1.28.1 / io.grpc:grpc-core:1.29.0` appears only once, and it now shows "omitted for duplicate" message.