### PR TITLE
Upgrading google-cloud-bom and its associated shared dependencies

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -44,7 +44,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <guava.version>30.1.1-android</guava.version>
+    <guava.version>30.1.1-jre</guava.version>
     <google.cloud.java.version>0.159.0</google.cloud.java.version>
     <google.cloud.core.version>2.0.5</google.cloud.core.version>
     <io.grpc.version>1.39.0</io.grpc.version>
@@ -55,6 +55,7 @@
     <gax.version>2.1.0</gax.version>
     <gax.httpjson.version>0.86.0</gax.httpjson.version>
     <auth.version>1.0.0</auth.version>
+    <api-common.version>2.0.1</api-common.version>
     <common.protos.version>2.3.2</common.protos.version>
     <iam.protos.version>1.0.14</iam.protos.version>
   </properties>
@@ -217,7 +218,7 @@
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>api-common</artifactId>
-        <version>1.10.4</version>
+        <version>${api-common.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -70,12 +70,16 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Not using Guava-bom because it includes guava-gwt, which has many invalid references -->
       <dependency>
         <groupId>com.google.guava</groupId>
-        <artifactId>guava-bom</artifactId>
+        <artifactId>guava</artifactId>
         <version>${guava.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava-testlib</artifactId>
+        <version>${guava.version}</version>
       </dependency>
 
       <!-- protobufs from https://github.com/protocolbuffers/protobuf/tree/master/java -->

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -45,16 +45,16 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>30.1.1-android</guava.version>
-    <google.cloud.java.version>0.158.0</google.cloud.java.version>
-    <google.cloud.core.version>1.95.4</google.cloud.core.version>
+    <google.cloud.java.version>0.159.0</google.cloud.java.version>
+    <google.cloud.core.version>2.0.5</google.cloud.core.version>
     <io.grpc.version>1.39.0</io.grpc.version>
     <http.version>1.39.2</http.version>
     <protobuf.version>3.17.3</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>1.66.0</gax.version>
-    <gax.httpjson.version>0.83.0</gax.httpjson.version>
-    <auth.version>0.26.0</auth.version>
+    <gax.version>2.1.0</gax.version>
+    <gax.httpjson.version>0.86.0</gax.httpjson.version>
+    <auth.version>1.0.0</auth.version>
     <common.protos.version>2.3.2</common.protos.version>
     <iam.protos.version>1.0.14</iam.protos.version>
   </properties>


### PR DESCRIPTION
Upgrading google-cloud-bom 0.159.0 and updating other dependencies referencing the shared dependencies BOM 2.0.1 (as per Neenu) (https://search.maven.org/artifact/com.google.cloud/google-cloud-shared-dependencies/2.0.1/pom).

- gax-bom 2.1.0 has https://search.maven.org/artifact/com.google.api/gax-bom/2.1.0/pom

```diff
diff --git a/pom.xml b/pom.xml
index 3f58b57..0685cdd 100644
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-shared-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.4.0</version><!-- {x-version-update:google-cloud-shared-dependencies:current} -->
+  <version>2.0.1</version><!-- {x-version-update:google-cloud-shared-dependencies:current} -->
   <name>Google Cloud Shared Dependencies</name>
   <url>https://github.com/googleapis/java-shared-dependencies</url>
   <description>
@@ -14,7 +14,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>0.12.0</version>
+    <version>1.0.0</version>
   </parent>
 
   <organization>
@@ -36,11 +36,11 @@
   <distributionManagement>
     <snapshotRepository>
       <id>sonatype-nexus-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://google.oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
     <repository>
       <id>sonatype-nexus-staging</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <url>https://google.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
 
@@ -56,14 +56,14 @@
     <site.installationModule>${project.artifactId}</site.installationModule>
 
     <grpc.version>1.39.0</grpc.version>
-    <gax.version>1.66.0</gax.version>
-    <grpc-gcp.version>1.0.0</grpc-gcp.version>
-    <guava.version>30.1.1-android</guava.version>
+    <gax.version>2.1.0</gax.version>
+    <grpc-gcp.version>1.1.0</grpc-gcp.version>
+    <guava.version>30.1.1-jre</guava.version>
     <protobuf.version>3.17.3</protobuf.version>
-    <google.api-common.version>1.10.4</google.api-common.version>
+    <google.api-common.version>2.0.1</google.api-common.version>
     <google.common-protos.version>2.3.2</google.common-protos.version>
-    <google.core.version>1.95.4</google.core.version>
-    <google.auth.version>0.26.0</google.auth.version>
+    <google.core.version>2.0.5</google.core.version>
+    <google.auth.version>1.0.0</google.auth.version>
     <google.http-client.version>1.39.2</google.http-client.version>
     <google.oauth-client.version>1.31.5</google.oauth-client.version>
     <google.api-client.version>1.32.1</google.api-client.version>
@@ -74,8 +74,8 @@
     <iam.version>1.0.14</iam.version>
     <opencensus.version>0.28.0</opencensus.version>
     <findbugs.version>3.0.2</findbugs.version>
-    <errorprone.version>2.7.1</errorprone.version>
-    <jackson.version>2.12.3</jackson.version>
+    <errorprone.version>2.8.1</errorprone.version>
+    <jackson.version>2.12.4</jackson.version>
     <codec.version>1.15</codec.version>
     <httpcomponents.httpcore.version>4.4.14</httpcomponents.httpcore.version>
     <httpcomponents.httpclient.version>4.5.13</httpcomponents.httpclient.version>
```