### PR TITLE
Cherry-pick: Update Spanner library version and add proto lib API surface

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -62,7 +62,7 @@
     <api.common.version>1.10.1-sp.1</api.common.version>
     <google.auth.library.version>0.25.2-sp.1</google.auth.library.version>
     <google.oauth.client.version>1.31.4-sp.1</google.oauth.client.version>
-    <google.cloud.spanner.version>3.3.3-sp.1</google.cloud.spanner.version>
+    <google.cloud.spanner.version>6.4.4-sp.1</google.cloud.spanner.version>
     <google.cloud.monitoring.version>2.1.0-sp.1</google.cloud.monitoring.version>
     <google.cloud.trace.version>1.3.0-sp.1</google.cloud.trace.version>
     <google.cloud.pubsub.version>1.111.0-sp.1</google.cloud.pubsub.version>
@@ -299,6 +299,11 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-spanner</artifactId>
+        <version>${google.cloud.spanner.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-cloud-spanner-admin-database-v1</artifactId>
         <version>${google.cloud.spanner.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
This is PR is to apply the spanner change to 1.0.x-lts branch to master. The commit is created from `git cherry-pick d3205a7cfc7dae754509839a4a325ed4bb5851e7` 

(This is not urgent)