### PR TITLE
Libraries BOM: Upgrading Google Cloud BOM to 0.160.0 and associated libraries

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -45,16 +45,16 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>30.1.1-jre</guava.version>
-    <google.cloud.java.version>0.159.0</google.cloud.java.version>
-    <google.cloud.core.version>2.0.5</google.cloud.core.version>
-    <io.grpc.version>1.39.0</io.grpc.version>
+    <google.cloud.java.version>0.160.0</google.cloud.java.version>
+    <google.cloud.core.version>2.1.0</google.cloud.core.version>
+    <io.grpc.version>1.40.0</io.grpc.version>
     <http.version>1.39.2</http.version>
     <protobuf.version>3.17.3</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>2.1.0</gax.version>
-    <gax.httpjson.version>0.86.0</gax.httpjson.version>
-    <auth.version>1.0.0</auth.version>
+    <gax.version>2.3.0</gax.version>
+    <gax.httpjson.version>0.88.0</gax.httpjson.version>
+    <auth.version>1.1.0</auth.version>
     <api-common.version>2.0.1</api-common.version>
     <common.protos.version>2.3.2</common.protos.version>
     <iam.protos.version>1.0.14</iam.protos.version>


### PR DESCRIPTION
- Upgrading the Google Cloud BOM to 0.160.0.
- As per [its dashboard](https://storage.googleapis.com/java-cloud-bom-dashboard/com.google.cloud/google-cloud-bom/0.160.0/index.html), the libraries in google-cloud-bom 0.160.0 used [the shared dependencies BOM 2.1.0](https://search.maven.org/artifact/com.google.cloud/google-cloud-shared-dependencies/2.1.0/pom). It has the following values for the library versions:
  ```
    <grpc.version>1.40.0</grpc.version>
    <gax.version>2.3.0</gax.version>
    <grpc-gcp.version>1.1.0</grpc-gcp.version>
    <guava.version>30.1.1-jre</guava.version>
    <protobuf.version>3.17.3</protobuf.version>
    <google.api-common.version>2.0.1</google.api-common.version>
    <google.common-protos.version>2.3.2</google.common-protos.version>
    <google.core.version>2.1.0</google.core.version>
    <google.auth.version>1.1.0</google.auth.version>
    <google.http-client.version>1.39.2</google.http-client.version>
    <google.oauth-client.version>1.31.5</google.oauth-client.version>
    <google.api-client.version>1.32.1</google.api-client.version>
  ```
- gax-bom 2.3.0 had gax-httpjson 0.88.0 https://search.maven.org/artifact/com.google.api/gax-bom/2.3.0/pom