### PR TITLE
Release 22.0.0-bom

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>22.0.0</version>
+  <version>22.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>22.0.0</version>
+        <version>22.0.1-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
This is a major version bump because grafeas had a major version bump in google-cloud-bom:

> update dependency io.grafeas:grafeas to v2

https://github.com/googleapis/java-cloud-bom/releases/tag/v0.160.0

diff:

```
suztomo-macbookpro44% git diff v21.0.0-bom v22.0.0-bom -- boms/cloud-oss-bom/pom.xml
diff --git a/boms/cloud-oss-bom/pom.xml b/boms/cloud-oss-bom/pom.xml
index a770a253..603c60c1 100644
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>21.0.0</version>
+  <version>22.0.0</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>
@@ -45,16 +45,16 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>30.1.1-jre</guava.version>
-    <google.cloud.java.version>0.159.0</google.cloud.java.version>
-    <google.cloud.core.version>2.0.5</google.cloud.core.version>
-    <io.grpc.version>1.39.0</io.grpc.version>
+    <google.cloud.java.version>0.160.0</google.cloud.java.version>
+    <google.cloud.core.version>2.1.0</google.cloud.core.version>
+    <io.grpc.version>1.40.0</io.grpc.version>
     <http.version>1.39.2</http.version>
     <protobuf.version>3.17.3</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>2.1.0</gax.version>
-    <gax.httpjson.version>0.86.0</gax.httpjson.version>
-    <auth.version>1.0.0</auth.version>
+    <gax.version>2.3.0</gax.version>
+    <gax.httpjson.version>0.88.0</gax.httpjson.version>
+    <auth.version>1.1.0</auth.version>
     <api-common.version>2.0.1</api-common.version>
     <common.protos.version>2.3.2</common.protos.version>
     <iam.protos.version>1.0.14</iam.protos.version>
```


