### PR TITLE
Libraries BOM: Updating Google Cloud BOM to 0.161.0 and associated dependencies

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -45,19 +45,19 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>30.1.1-jre</guava.version>
-    <google.cloud.java.version>0.160.0</google.cloud.java.version>
-    <google.cloud.core.version>2.1.0</google.cloud.core.version>
-    <io.grpc.version>1.40.0</io.grpc.version>
-    <http.version>1.39.2</http.version>
+    <google.cloud.java.version>0.161.0</google.cloud.java.version>
+    <google.cloud.core.version>2.1.2</google.cloud.core.version>
+    <io.grpc.version>1.40.1</io.grpc.version>
+    <http.version>1.40.0</http.version>
     <protobuf.version>3.17.3</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>2.3.0</gax.version>
-    <gax.httpjson.version>0.88.0</gax.httpjson.version>
+    <gax.version>2.4.0</gax.version>
+    <gax.httpjson.version>0.89.0</gax.httpjson.version>
     <auth.version>1.1.0</auth.version>
-    <api-common.version>2.0.1</api-common.version>
-    <common.protos.version>2.3.2</common.protos.version>
-    <iam.protos.version>1.0.14</iam.protos.version>
+    <api-common.version>2.0.2</api-common.version>
+    <common.protos.version>2.5.0</common.protos.version>
+    <iam.protos.version>1.1.0</iam.protos.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
Google Cloud BOM 0.161.0 was released. It uses the shared dependencies BOM 2.2.0 ([dashboard](https://storage.googleapis.com/java-cloud-bom-dashboard/com.google.cloud/google-cloud-bom/0.161.0/index.html)). For the first-party dependencies, the values are listed in:

They come from 

```
    <grpc.version>1.40.1</grpc.version>
    <gax.version>2.4.0</gax.version>
    <grpc-gcp.version>1.1.0</grpc-gcp.version>
    <guava.version>30.1.1-jre</guava.version>
    <protobuf.version>3.17.3</protobuf.version>
    <google.api-common.version>2.0.2</google.api-common.version>
    <google.common-protos.version>2.5.0</google.common-protos.version>
    <google.core.version>2.1.2</google.core.version>
    <google.auth.version>1.1.0</google.auth.version>
    <google.http-client.version>1.40.0</google.http-client.version>
    <google.oauth-client.version>1.32.1</google.oauth-client.version>
    <google.api-client.version>1.32.1</google.api-client.version>
    <iam.version>1.1.0</iam.version>
```

https://search.maven.org/artifact/com.google.cloud/first-party-dependencies/2.2.0/pom



gax-bom 2.4.0 includes gax-httpjson 0.89.0.
https://search.maven.org/artifact/com.google.api/gax-bom/2.4.0/pom