### PR TITLE
Libraries BOM: Updating Google Cloud BOM to 0.162.0

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -45,19 +45,19 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>30.1.1-jre</guava.version>
-    <google.cloud.bom.version>0.161.0</google.cloud.bom.version>
-    <google.cloud.core.version>2.1.2</google.cloud.core.version>
+    <google.cloud.bom.version>0.162.0</google.cloud.bom.version>
+    <google.cloud.core.version>2.1.6</google.cloud.core.version>
     <io.grpc.version>1.40.1</io.grpc.version>
     <http.version>1.40.0</http.version>
     <protobuf.version>3.17.3</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>2.4.0</gax.version>
-    <gax.httpjson.version>0.89.0</gax.httpjson.version>
+    <gax.version>2.5.0</gax.version>
+    <gax.httpjson.version>0.90.0</gax.httpjson.version>
     <auth.version>1.1.0</auth.version>
     <api-common.version>2.0.2</api-common.version>
     <common.protos.version>2.5.0</common.protos.version>
-    <iam.protos.version>1.1.0</iam.protos.version>
+    <iam.protos.version>1.1.2</iam.protos.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
Updating Google Cloud BOM to 0.162.0 and associated dependencies Google Cloud BOM 0.162.0 is based on the shared dependencies BOM 2.3.0.

The previous version of Google Cloud BOM was 0.161.0 and was based on the shared dependencies BOM 2.2.0. The diff of the shared dependencies BOM:

```diff
# At /Users/suztomo/java-shared-dependencies
$ git diff v2.2.0 v2.3.0 -- first-party-dependencies/pom.xml
diff --git a/first-party-dependencies/pom.xml b/first-party-dependencies/pom.xml
...
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <site.installationModule>${project.artifactId}</site.installationModule>
     <grpc.version>1.40.1</grpc.version>
-    <gax.version>2.4.0</gax.version>
+    <gax.version>2.5.0</gax.version>
     <grpc-gcp.version>1.1.0</grpc-gcp.version>
     <guava.version>30.1.1-jre</guava.version>
     <protobuf.version>3.17.3</protobuf.version>
     <google.api-common.version>2.0.2</google.api-common.version>
     <google.common-protos.version>2.5.0</google.common-protos.version>
-    <google.core.version>2.1.2</google.core.version>
+    <google.core.version>2.1.6</google.core.version>
     <google.auth.version>1.1.0</google.auth.version>
     <google.http-client.version>1.40.0</google.http-client.version>
     <google.oauth-client.version>1.32.1</google.oauth-client.version>
     <google.api-client.version>1.32.1</google.api-client.version>
-    <iam.version>1.1.0</iam.version>
+    <iam.version>1.1.2</iam.version>
   </properties>
 
   <dependencyManagement>
```
