### PR TITLE
Release 23.1.0-bom

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>23.1.0</version>
+  <version>23.1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>23.0.1-SNAPSHOT</version>
+  <version>23.1.0</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>23.0.1-SNAPSHOT</version>
+        <version>23.1.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>23.1.0</version>
+        <version>23.1.1-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Release 23.1.0-bom

Difference since last release:

```diff
suztomo@suztomo:~/cloud-opensource-java$ git diff v23.0.0-bom v23.1.0-bom  -- boms/cloud-oss-bom/pom.xml
diff --git a/boms/cloud-oss-bom/pom.xml b/boms/cloud-oss-bom/pom.xml
index 380b93ff..f60704b2 100644
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>23.0.0</version>
+  <version>23.1.0</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>
@@ -45,19 +45,19 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>30.1.1-jre</guava.version>
-    <google.cloud.java.version>0.161.0</google.cloud.java.version>
-    <google.cloud.core.version>2.1.2</google.cloud.core.version>
+    <google.cloud.bom.version>0.162.0</google.cloud.bom.version>
+    <google.cloud.core.version>2.1.6</google.cloud.core.version>
     <io.grpc.version>1.40.1</io.grpc.version>
     <http.version>1.40.0</http.version>
     <protobuf.version>3.17.3</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>2.4.0</gax.version>
-    <gax.httpjson.version>0.89.0</gax.httpjson.version>
+    <gax.version>2.5.0</gax.version>
+    <gax.httpjson.version>0.90.0</gax.httpjson.version>
     <auth.version>1.1.0</auth.version>
     <api-common.version>2.0.2</api-common.version>
     <common.protos.version>2.5.0</common.protos.version>
-    <iam.protos.version>1.1.0</iam.protos.version>
+    <iam.protos.version>1.1.2</iam.protos.version>
   </properties>
 
   <distributionManagement>
@@ -214,7 +214,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bom</artifactId>
-        <version>${google.cloud.java.version}</version>
+        <version>${google.cloud.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
```

It's a minor version bump as there's no major version bump in https://github.com/googleapis/java-cloud-bom/releases/tag/v0.162.0