### PR TITLE
Spanner 6.4.4-sp.3 patch release

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -62,7 +62,7 @@
     <api.common.version>1.10.1-sp.1</api.common.version>
     <google.auth.library.version>0.25.2-sp.1</google.auth.library.version>
     <google.oauth.client.version>1.31.4-sp.1</google.oauth.client.version>
-    <google.cloud.spanner.version>6.4.4-sp.1</google.cloud.spanner.version>
+    <google.cloud.spanner.version>6.4.4-sp.3</google.cloud.spanner.version>
     <google.cloud.monitoring.version>2.1.0-sp.1</google.cloud.monitoring.version>
     <google.cloud.trace.version>1.3.0-sp.1</google.cloud.trace.version>
     <google.cloud.pubsub.version>1.111.0-sp.1</google.cloud.pubsub.version>


### PR DESCRIPTION
Spanner 6.4.4-sp.3 patch release.

The artifact is not yet in Maven Central (and thus the build should fail). Once it becomes green, then merge this PR and release a new version of the BOM.