### PR TITLE
Libraries BOM: adding document URL to description

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -11,7 +11,10 @@
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>
-  <description>A compatible set of Google Cloud open source libraries.</description>
+  <description>
+    A compatible set of Google Cloud open source libraries.
+    Document: https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM
+  </description>
   <url>https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM</url>
   <organization>
     <name>Google LLC</name>


### PR DESCRIPTION
Adding the document URL to the description field would give URL shown to users who search the Maven artifact in mvnrepository.com.

![6owiyvbn92m3HZx](https://user-images.githubusercontent.com/28604/139905548-0fdad61b-40f5-4874-aa49-8e8b9b6c5565.png)
