### PR TITLE
Merging the latest gcp-lts-bom to master branch

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -62,16 +62,16 @@
     <api.common.version>1.10.1-sp.1</api.common.version>
     <google.auth.library.version>0.25.2-sp.1</google.auth.library.version>
     <google.oauth.client.version>1.31.4-sp.1</google.oauth.client.version>
-    <google.cloud.spanner.version>6.4.4-sp.1</google.cloud.spanner.version>
+    <google.cloud.spanner.version>6.4.4-sp.3</google.cloud.spanner.version>
     <google.cloud.monitoring.version>2.1.0-sp.1</google.cloud.monitoring.version>
     <google.cloud.trace.version>1.3.0-sp.1</google.cloud.trace.version>
     <google.cloud.pubsub.version>1.111.0-sp.1</google.cloud.pubsub.version>
     <proto.google.cloud.pubsub.version.v1>1.93.0-sp.1</proto.google.cloud.pubsub.version.v1>
     <google.cloud.bigquery.version>1.127.12-sp.1</google.cloud.bigquery.version>
     <google.api.services.bigquery>v2-rev20210410-1.31.0</google.api.services.bigquery>
-    <google.cloud.bigtable.version>1.22.0-sp.1</google.cloud.bigtable.version>
-    <bigtable-hbase-beam.version>1.20.0-sp.1</bigtable-hbase-beam.version>
-    <google.cloud.storage.version>1.113.14-sp.1</google.cloud.storage.version>
+    <google.cloud.bigtable.version>1.22.0-sp.2</google.cloud.bigtable.version>
+    <bigtable-hbase-beam.version>1.20.0-sp.3</bigtable-hbase-beam.version>
+    <google.cloud.storage.version>1.113.14-sp.2</google.cloud.storage.version>
     <datastore.v1.proto.client.version>1.6.4-sp.1</datastore.v1.proto.client.version>
     <proto.google.cloud.datastore.v1>0.89.5-sp.1</proto.google.cloud.datastore.v1>
     <appengine.api.1.0.sdk.version>1.9.89</appengine.api.1.0.sdk.version>


### PR DESCRIPTION
With this change the version in  is only difference between master and the 1.0.x-lts branch on boms/cloud-lts-bom/pom.xml :

```
~/cloud-opensource-java $ git diff origin/1.0.x-lts -- boms/cloud-lts-bom/pom.xml                             git[branch:gcb_163]
diff --git a/boms/cloud-lts-bom/pom.xml b/boms/cloud-lts-bom/pom.xml
index 5f6f85d9..56a2ef99 100644
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>gcp-lts-bom</artifactId>
-  <version>1.0.8-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Long Term Support BOM</name>
```

This is preparation to add more artifacts.