### PR TITLE
BOM import type check

### DIFF
--- a/boms/integration-tests/src/test/java/com/google/cloud/BomContentTest.java
+++ b/boms/integration-tests/src/test/java/com/google/cloud/BomContentTest.java
@@ -65,6 +65,7 @@ public class BomContentTest {
 
     assertNoDowngradeRule(bom);
     assertUniqueClasses(artifacts);
+    assertBomIsImported(bom);
   }
 
   private static String buildMavenCentralUrl(Artifact artifact) {
@@ -215,5 +216,15 @@ public class BomContentTest {
               + " in the BOM");
     }
     return violations.build();
+  }
+
+  private void assertBomIsImported(Bom bom) {
+    // BOMs must be declared as "import" type. Otherwise, the BOM users would see
+    // "google-cloud-XXX-bom" as an artifact declared in the BOM, not the content of it.
+    for (Artifact artifact : bom.getManagedDependencies()) {
+      String artifactId = artifact.getArtifactId();
+      Assert.assertFalse(
+          artifactId + " must be declared with import type", artifactId.endsWith("-bom"));
+    }
   }
 }


### PR DESCRIPTION
This check fails when we forget to declare "importing" a BOM.