### PR TITLE
Google Cloud BOM 0.164.0

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -48,19 +48,19 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>31.0.1-jre</guava.version>
-    <google.cloud.bom.version>0.163.0</google.cloud.bom.version>
-    <google.cloud.core.version>2.2.0</google.cloud.core.version>
-    <io.grpc.version>1.41.0</io.grpc.version>
+    <google.cloud.bom.version>0.164.0</google.cloud.bom.version>
+    <google.cloud.core.version>2.3.3</google.cloud.core.version>
+    <io.grpc.version>1.42.1</io.grpc.version>
     <http.version>1.40.1</http.version>
-    <protobuf.version>3.18.1</protobuf.version>
+    <protobuf.version>3.19.1</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>2.6.1</gax.version>
-    <gax.httpjson.version>0.91.1</gax.httpjson.version>
-    <auth.version>1.2.1</auth.version>
-    <api-common.version>2.0.5</api-common.version>
-    <common.protos.version>2.6.0</common.protos.version>
-    <iam.protos.version>1.1.6</iam.protos.version>
+    <gax.version>2.7.1</gax.version>
+    <gax.httpjson.version>0.92.1</gax.httpjson.version>
+    <auth.version>1.3.0</auth.version>
+    <api-common.version>2.1.1</api-common.version>
+    <common.protos.version>2.7.0</common.protos.version>
+    <iam.protos.version>1.1.7</iam.protos.version>
   </properties>
 
   <distributionManagement>

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -409,8 +409,20 @@
       <Class name="com.google.common.flogger.util.JavaLangAccessStackGetter" />
     </Source>
     <Reason>
-      The JavaLangAccessStackGetter tries to use available classes in different JDK versions.
-      Certain classes are unavailable in Java 8.
+      Flogger's JavaLangAccessStackGetter and StackWalkerStackGetter trys to use available classes
+      in different JDK versions. Certain classes are unavailable in a JDK.
+    </Reason>
+  </LinkageError>
+  <LinkageError>
+    <Target>
+      <Package name="java" />
+    </Target>
+    <Source>
+      <Class name="com.google.common.flogger.util.StackWalkerStackGetter" />
+    </Source>
+    <Reason>
+      Flogger's JavaLangAccessStackGetter and StackWalkerStackGetter trys to use available classes
+      in different JDK versions. Certain classes are unavailable in a JDK.
     </Reason>
   </LinkageError>
 </LinkageCheckerFilter>

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -12,9 +12,6 @@
   </LinkageError>
 
   <LinkageError>
-    <Target>
-      <Package name="jdk.vm.ci" />
-    </Target>
     <Source>
       <Package name="com.oracle.svm" />
     </Source>

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -401,4 +401,16 @@
       https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1871
     </Reason>
   </LinkageError>
+  <LinkageError>
+    <Target>
+      <Package name="sun.misc" />
+    </Target>
+    <Source>
+      <Class name="com.google.common.flogger.util.JavaLangAccessStackGetter" />
+    </Source>
+    <Reason>
+      The JavaLangAccessStackGetter tries to use available classes in different JDK versions.
+      Certain classes are unavailable in Java 8.
+    </Reason>
+  </LinkageError>
 </LinkageCheckerFilter>

--- a/enforcer-rules/src/it/bom-project-using-spring-repository/verify.groovy
+++ b/enforcer-rules/src/it/bom-project-using-spring-repository/verify.groovy
@@ -14,6 +14,6 @@ assert !buildLog.text.contains("NullPointerException")
 
 // 4 linkage errors are references to java.util.concurrent.Flow class, which does not exist in
 // Java 8 runtime yet.
-def expectedErrorCount = System.getProperty("java.version").startsWith("1.8.") ? 798 : 794
+def expectedErrorCount = System.getProperty("java.version").startsWith("1.8.") ? 111 : 107
 
 assert buildLog.text.contains("Linkage Checker rule found $expectedErrorCount errors:")


### PR DESCRIPTION
- [Google Cloud BOM 0.164.0](https://search.maven.org/artifact/com.google.cloud/google-cloud-bom/0.164.0/pom) was released yesterday.
- The libraries in the shared dependencies BOM 2.5.1 https://github.com/googleapis/java-shared-dependencies/blob/v2.5.1/first-party-dependencies/pom.xml

# Adding linkage error suppression

`com.oracle.svm` package has linkage errors because these classes are referencing classes available in GraalVM. Filtering these classes https://gist.github.com/suztomo/c542c412ebaa104ffd70d68fa5f0cf09

Flogger classes change their behavior depending on the availability of classes in JDK. Certain classes are unavailable in a version of JDK. Therefore this PR filters out the flogger's `util` package from the linkage errors.
