### PR TITLE
Updating BOM document URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/Linkage-Checke
 
 # GCP Libraries BOM
 
-The [GCP Libraries BOM](https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM) is a Bill-of-Materials (BOM) that
+The [GCP Libraries BOM](https://cloud.google.com/java/docs/bom) is a Bill-of-Materials (BOM) that
 provides consistent versions of Google Cloud Java libraries that work together
 without linkage errors.
 

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -13,9 +13,9 @@
   <name>Google Cloud Platform Supported Libraries</name>
   <description>
     A compatible set of Google Cloud open source libraries.
-    Document: https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM
+    Document: https://cloud.google.com/java/docs/bom
   </description>
-  <url>https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM</url>
+  <url>https://cloud.google.com/java/docs/bom</url>
   <organization>
     <name>Google LLC</name>
     <url>https://cloud.google.com</url>


### PR DESCRIPTION
It's moved to https://cloud.google.com/java/docs/bom