### PR TITLE
Release 24.1.2-bom

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>24.1.2-SNAPSHOT</version>
+  <version>24.1.2</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>24.1.2</version>
+  <version>24.1.3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>24.1.2-SNAPSHOT</version>
+        <version>24.1.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>24.1.2</version>
+        <version>24.1.3-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
This is a patch version bump because only patch version of the content changed:

```
~/cloud-opensource-java $ git diff v24.1.1-bom v24.1.2-bom -- boms/cloud-oss-bom/             git[branch:beam_2.35.0]
diff --git a/boms/cloud-oss-bom/pom.xml b/boms/cloud-oss-bom/pom.xml
index 2002bd78..a8ffd7a9 100644
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>24.1.1</version>
+  <version>24.1.2</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>
@@ -52,7 +52,7 @@
     <google.cloud.core.version>2.3.3</google.cloud.core.version>
     <io.grpc.version>1.42.1</io.grpc.version>
     <http.version>1.40.1</http.version>
-    <protobuf.version>3.19.1</protobuf.version>
+    <protobuf.version>3.19.2</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
     <gax.version>2.7.1</gax.version>
```