### PR TITLE
libraries-bom: google-cloud-bom 0.166.0 and shared-deps 2.6.0

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -48,19 +48,19 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>31.0.1-jre</guava.version>
-    <google.cloud.bom.version>0.165.0</google.cloud.bom.version>
-    <google.cloud.core.version>2.3.3</google.cloud.core.version>
-    <io.grpc.version>1.42.1</io.grpc.version>
-    <http.version>1.40.1</http.version>
+    <google.cloud.bom.version>0.166.0</google.cloud.bom.version>
+    <google.cloud.core.version>2.3.5</google.cloud.core.version>
+    <io.grpc.version>1.43.2</io.grpc.version>
+    <http.version>1.41.0</http.version>
     <protobuf.version>3.19.2</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>2.7.1</gax.version>
-    <gax.httpjson.version>0.92.1</gax.httpjson.version>
+    <gax.version>2.8.1</gax.version>
+    <gax.httpjson.version>0.93.1</gax.httpjson.version>
     <auth.version>1.3.0</auth.version>
-    <api-common.version>2.1.1</api-common.version>
-    <common.protos.version>2.7.0</common.protos.version>
-    <iam.protos.version>1.1.7</iam.protos.version>
+    <api-common.version>2.1.2</api-common.version>
+    <common.protos.version>2.7.1</common.protos.version>
+    <iam.protos.version>1.2.0</iam.protos.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
Google Cloud BOM 0.166.0 is built on the shared dependnecies
BOM 2.6.0
https://github.com/googleapis/java-shared-dependencies/blob/v2.6.0/first-party-dependencies/pom.xml

There, GAX is 2.8.1 and it has gax-httpjson 0.93.1
https://search.maven.org/artifact/com.google.api/gax-bom/2.8.1/pom
