### PR TITLE
Release 24.2.0-bom

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>24.2.0</version>
+  <version>24.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>24.1.3-SNAPSHOT</version>
+  <version>24.2.0</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>24.2.0</version>
+        <version>24.2.1-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>24.1.3-SNAPSHOT</version>
+        <version>24.2.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Release 24.2.0-bom

This is a minor version upgrade release. The diff since the last release doesn't have a major version upgrade and we have at least one minor version upgrade (such as `proto-google-iam-v1`)

```diff
diff --git a/boms/cloud-oss-bom/pom.xml b/boms/cloud-oss-bom/pom.xml
index a8ffd7a9..af47eecf 100644
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>24.1.2</version>
+  <version>24.2.0</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>
@@ -48,19 +48,19 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>31.0.1-jre</guava.version>
-    <google.cloud.bom.version>0.165.0</google.cloud.bom.version>
-    <google.cloud.core.version>2.3.3</google.cloud.core.version>
-    <io.grpc.version>1.42.1</io.grpc.version>
-    <http.version>1.40.1</http.version>
+    <google.cloud.bom.version>0.166.0</google.cloud.bom.version>
+    <google.cloud.core.version>2.3.5</google.cloud.core.version>
+    <io.grpc.version>1.43.2</io.grpc.version>
+    <http.version>1.41.0</http.version>
     <protobuf.version>3.19.2</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>2.7.1</gax.version>
-    <gax.httpjson.version>0.92.1</gax.httpjson.version>
+    <gax.version>2.8.1</gax.version>
+    <gax.httpjson.version>0.93.1</gax.httpjson.version>
     <auth.version>1.3.0</auth.version>
-    <api-common.version>2.1.1</api-common.version>
-    <common.protos.version>2.7.0</common.protos.version>
-    <iam.protos.version>1.1.7</iam.protos.version>
+    <api-common.version>2.1.2</api-common.version>
+    <common.protos.version>2.7.1</common.protos.version>
+    <iam.protos.version>1.2.0</iam.protos.version>
   </properties>
 
   <distributionManagement>
```