### PR TITLE
bigtable-hbase-beam v1.20.0-sp.6 in lts 1 (1.0.x-lts branch)

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -70,7 +70,7 @@
     <google.cloud.bigquery.version>1.127.12-sp.2</google.cloud.bigquery.version>
     <google.api.services.bigquery>v2-rev20210410-1.31.0</google.api.services.bigquery>
     <google.cloud.bigtable.version>1.22.0-sp.3</google.cloud.bigtable.version>
-    <bigtable-hbase-beam.version>1.20.0-sp.5</bigtable-hbase-beam.version>
+    <bigtable-hbase-beam.version>1.20.0-sp.6</bigtable-hbase-beam.version>
     <google.cloud.storage.version>1.113.14-sp.3</google.cloud.storage.version>
     <datastore.v1.proto.client.version>1.6.4-sp.1</datastore.v1.proto.client.version>
     <proto.google.cloud.datastore.v1>0.89.5-sp.1</proto.google.cloud.datastore.v1>


### PR DESCRIPTION
https://search.maven.org/artifact/com.google.cloud.bigtable/bigtable-hbase-beam/1.20.0-sp.6/jar is now available.