### PR TITLE
Release 1.0.10-lts

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>gcp-lts-bom</artifactId>
-  <version>1.0.10-SNAPSHOT</version>
+  <version>1.0.10</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Long Term Support BOM</name>

--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>gcp-lts-bom</artifactId>
-  <version>1.0.10</version>
+  <version>1.0.11-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Long Term Support BOM</name>


### PR DESCRIPTION
Release 1.0.10-lts

```
~/cloud-opensource-java $ git diff v1.0.9-lts v1.0.10-lts -- boms/cloud-lts-bom/pom.xml
diff --git a/boms/cloud-lts-bom/pom.xml b/boms/cloud-lts-bom/pom.xml
index 2031b480..102e5f31 100644
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>gcp-lts-bom</artifactId>
-  <version>1.0.9</version>
+  <version>1.0.10</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Long Term Support BOM</name>
@@ -70,7 +70,7 @@
     <google.cloud.bigquery.version>1.127.12-sp.2</google.cloud.bigquery.version>
     <google.api.services.bigquery>v2-rev20210410-1.31.0</google.api.services.bigquery>
     <google.cloud.bigtable.version>1.22.0-sp.3</google.cloud.bigtable.version>
-    <bigtable-hbase-beam.version>1.20.0-sp.5</bigtable-hbase-beam.version>
+    <bigtable-hbase-beam.version>1.20.0-sp.6</bigtable-hbase-beam.version>
     <google.cloud.storage.version>1.113.14-sp.3</google.cloud.storage.version>
     <datastore.v1.proto.client.version>1.6.4-sp.1</datastore.v1.proto.client.version>
     <proto.google.cloud.datastore.v1>0.89.5-sp.1</proto.google.cloud.datastore.v1>
```