### PR TITLE
Google Cloud BOM 0.167.0 and other related dependencies

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -48,19 +48,19 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>31.0.1-jre</guava.version>
-    <google.cloud.bom.version>0.166.0</google.cloud.bom.version>
-    <google.cloud.core.version>2.3.5</google.cloud.core.version>
-    <io.grpc.version>1.43.2</io.grpc.version>
-    <http.version>1.41.0</http.version>
-    <protobuf.version>3.19.2</protobuf.version>
+    <google.cloud.bom.version>0.167.0</google.cloud.bom.version>
+    <google.cloud.core.version>2.4.0</google.cloud.core.version>
+    <io.grpc.version>1.44.0</io.grpc.version>
+    <http.version>1.41.2</http.version>
+    <protobuf.version>3.19.3</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>2.8.1</gax.version>
-    <gax.httpjson.version>0.93.1</gax.httpjson.version>
-    <auth.version>1.3.0</auth.version>
-    <api-common.version>2.1.2</api-common.version>
-    <common.protos.version>2.7.1</common.protos.version>
-    <iam.protos.version>1.2.0</iam.protos.version>
+    <gax.version>2.11.0</gax.version>
+    <gax.httpjson.version>0.96.0</gax.httpjson.version>
+    <auth.version>1.4.0</auth.version>
+    <api-common.version>2.1.3</api-common.version>
+    <common.protos.version>2.7.2</common.protos.version>
+    <iam.protos.version>1.2.1</iam.protos.version>
   </properties>
 
   <distributionManagement>

--- a/boms/integration-tests/pom.xml
+++ b/boms/integration-tests/pom.xml
@@ -39,6 +39,7 @@
             <!-- To avoid ForkedBooter loading issue -->
             <useSystemClassLoader>false</useSystemClassLoader>
             <argLine>-Xms128m -Xmx2048m</argLine>
+            <trimStackTrace>false</trimStackTrace>
           </configuration>
         </plugin>
       </plugins>

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageProblem.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/classpath/LinkageProblem.java
@@ -218,10 +218,12 @@ public abstract class LinkageProblem {
 
     for (AbstractMethodProblem abstractMethodProblem : abstractMethodProblems.build()) {
       output.append(abstractMethodProblem + "\n");
-      output.append("  Cause:\n");
       LinkageProblemCause cause = abstractMethodProblem.getCause();
-      String causeWithIndent = cause.toString().replaceAll("\n", "\n    ");
-      output.append("    " + causeWithIndent + "\n");
+      if (cause != null) {
+        output.append("  Cause:\n");
+        String causeWithIndent = cause.toString().replaceAll("\n", "\n    ");
+        output.append("    " + causeWithIndent + "\n");
+      }
     }
 
     if (classPathResult != null) {

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -26,17 +26,16 @@
     <Target>
       <Package name="jdk.vm.ci" />
     </Target>
-    <Source>
-      <Package name="com.oracle.graal" />
-    </Source>
   </LinkageError>
   <LinkageError>
     <Target>
       <Package name="jdk.vm.ci" />
     </Target>
-    <Source>
-      <Package name="org.graalvm" />
-    </Source>
+    <Reason>
+      Substrate VM is part of GraalVM and the virtual machine references classes in the JVM-internal
+      package 'sun.text.normalizer' that are not available in JVM runtime.
+      https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1825
+    </Reason>
   </LinkageError>
   <LinkageError>
     <Target>
@@ -423,6 +422,27 @@
     <Reason>
       Flogger's JavaLangAccessStackGetter and StackWalkerStackGetter trys to use available classes
       in different JDK versions. Certain classes are unavailable in a JDK.
+    </Reason>
+  </LinkageError>
+  <LinkageError>
+    <Source>
+      <Package name="com.sun.mail.smtp" />
+    </Source>
+    <Reason>
+      Google Cloud libraries do not use SMTP protocols. There are discrepancy in
+      javax.mail:mail:1.4.3 com.sun.mail:javax.mail:1.6.2 in dependency graph.
+    </Reason>
+  </LinkageError>
+  <LinkageError>
+    <Source>
+      <Package name="com.ctc.wstx.shaded" />
+    </Source>
+    <Target>
+      <Class name="com.ctc.wstx.shaded.msv_core.driver.textui.Driver" />
+    </Target>
+    <Reason>
+      Shaded class in com.fasterxml.woodstox:woodstox-core:6.2.6 has a class
+      reference to the textui.Driver but the shading process didn't include it.
     </Reason>
   </LinkageError>
 </LinkageCheckerFilter>

--- a/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
+++ b/dependencies/src/main/resources/linkage-checker-exclusion-default.xml
@@ -10,7 +10,17 @@
       https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/816
     </Reason>
   </LinkageError>
-
+  <LinkageError>
+    <Source>
+      <Package name="com.oracle.objectfile" />
+    </Source>
+    <Reason>
+      GraalVM-related libraries depend on Java Compiler Interface (JVMCI) that
+      only exists in special JDK. These missing classes are false positives, because
+      the code is only invoked when running in a GraalVM.
+      https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/929
+    </Reason>
+  </LinkageError>
   <LinkageError>
     <Source>
       <Package name="com.oracle.svm" />


### PR DESCRIPTION
# Google Cloud BOM 0.167.0

https://github.com/googleapis/java-cloud-bom/releases/tag/v0.167.0

# Libraries in the shared dependencies BOM 2.7.0

https://github.com/googleapis/java-shared-dependencies/blob/v2.7.0/first-party-dependencies/pom.xml

```
  <properties>
    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
    <site.installationModule>${project.artifactId}</site.installationModule>
    <grpc.version>1.44.0</grpc.version>
    <gax.version>2.11.0</gax.version>
    <grpc-gcp.version>1.1.0</grpc-gcp.version>
    <guava.version>31.0.1-jre</guava.version>
    <protobuf.version>3.19.3</protobuf.version>
    <google.api-common.version>2.1.3</google.api-common.version>
    <google.common-protos.version>2.7.2</google.common-protos.version>
    <google.core.version>2.4.0</google.core.version>
    <google.auth.version>1.4.0</google.auth.version>
    <google.http-client.version>1.41.2</google.http-client.version>
    <google.oauth-client.version>1.33.0</google.oauth-client.version>
    <google.api-client.version>1.33.1</google.api-client.version>
    <iam.version>1.2.1</iam.version>
  </properties>
```
