### PR TITLE
Extending periodic job timeout to avoid flaky.

### DIFF
--- a/kokoro/ubuntu/periodic.cfg
+++ b/kokoro/ubuntu/periodic.cfg
@@ -3,6 +3,8 @@
 # Location of the periodic build bash script in git.
 build_file: "cloud-opensource-java/kokoro/ubuntu/periodic.sh"
 
+timeout_mins: 240
+
 action {
   define_artifacts {
     regex: "**/target/com.google.cloud/**"


### PR DESCRIPTION
Extending timeout from default 3hours to 4 hours to avoid timeout error:
`ERROR: Aborting VM command due to timeout of 10800 seconds`