### PR TITLE
Optimizing the periodic build. No need to run tests

### DIFF
--- a/kokoro/ubuntu/periodic.sh
+++ b/kokoro/ubuntu/periodic.sh
@@ -6,8 +6,8 @@ set -e
 set -x
 
 cd github/cloud-opensource-java
-# M2_HOME is not used since Maven 3.5.0 https://maven.apache.org/docs/3.5.0/release-notes.html
-mvn -V -B clean install
+# No need to run tests
+./mvnw -V -B -ntp clean install -DskipTests -Denforcer.skip -Dinvoker.skip
 
 # Running target of dashboard submodule
 # https://stackoverflow.com/questions/3459928/running-a-specific-maven-plugin-goal-from-the-command-line-in-a-sub-module-of-a/26448447#26448447
@@ -15,8 +15,8 @@ mvn -V -B clean install
 cd dashboard
 
 # For all versions available in Maven Central and local repository
-mvn -V -B exec:java -Dexec.mainClass="com.google.cloud.tools.opensource.dashboard.DashboardMain" \
+../mvnw -V -B -ntp exec:java -Dexec.mainClass="com.google.cloud.tools.opensource.dashboard.DashboardMain" \
   -Dexec.arguments="-a com.google.cloud:libraries-bom"
 
-mvn -V -B exec:java -Dexec.mainClass="com.google.cloud.tools.opensource.dashboard.DashboardMain" \
+../mvnw -V -B -ntp exec:java -Dexec.mainClass="com.google.cloud.tools.opensource.dashboard.DashboardMain" \
   -Dexec.arguments="-a com.google.cloud:gcp-lts-bom"


### PR DESCRIPTION
The periodic build does not need to run tests.

Also using mvnw rather than mvn.