### PR TITLE
1.0.x-lts: google-cloud-storage 1.113.14-sp.4

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -71,7 +71,7 @@
     <google.api.services.bigquery>v2-rev20210410-1.31.0</google.api.services.bigquery>
     <google.cloud.bigtable.version>1.22.0-sp.3</google.cloud.bigtable.version>
     <bigtable-hbase-beam.version>1.20.0-sp.6</bigtable-hbase-beam.version>
-    <google.cloud.storage.version>1.113.14-sp.3</google.cloud.storage.version>
+    <google.cloud.storage.version>1.113.14-sp.4</google.cloud.storage.version>
     <datastore.v1.proto.client.version>1.6.4-sp.1</datastore.v1.proto.client.version>
     <proto.google.cloud.datastore.v1>0.89.5-sp.1</proto.google.cloud.datastore.v1>
     <appengine.api.1.0.sdk.version>1.9.93</appengine.api.1.0.sdk.version>


### PR DESCRIPTION
To apply the patch release to 1.0.x branch.