### PR TITLE
Release 2.0.1-lts

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>gcp-lts-bom</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.1</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Long Term Support BOM</name>

--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>gcp-lts-bom</artifactId>
-  <version>2.0.1</version>
+  <version>2.0.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Long Term Support BOM</name>


### PR DESCRIPTION
This is the diff since 2.0.0 release:

```
~/cloud-opensource-java $ git diff v2.0.0-lts v2.0.1-lts -- boms/cloud-lts-bom/pom.xml git[branch:2.0.x-lts-storage-2.1.10]
diff --git a/boms/cloud-lts-bom/pom.xml b/boms/cloud-lts-bom/pom.xml
index fc9c2592..e73b0cc6 100644
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>gcp-lts-bom</artifactId>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Long Term Support BOM</name>
@@ -73,7 +73,7 @@
     <google-cloud-bigquery.version>2.3.3</google-cloud-bigquery.version>
     <google-api-services-bigquery.version>v2-rev20211017-1.32.1</google-api-services-bigquery.version>
     <google-cloud-bigquerystorage.version>2.4.2</google-cloud-bigquerystorage.version>
-    <google-cloud-storage.version>2.1.9</google-cloud-storage.version>
+    <google-cloud-storage.version>2.1.10</google-cloud-storage.version>
     <google-cloud-trace.version>2.0.6</google-cloud-trace.version>
     <google-cloud-monitoring.version>3.1.0</google-cloud-monitoring.version>
     <google-cloud-spanner.version>6.14.1</google-cloud-spanner.version>
```