### PR TITLE
libraries-bom: google-cloud-bom 0.169.0

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -48,7 +48,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>31.0.1-jre</guava.version>
-    <google.cloud.bom.version>0.167.0</google.cloud.bom.version>
+    <google.cloud.bom.version>0.168.1</google.cloud.bom.version>
     <google.cloud.core.version>2.4.0</google.cloud.core.version>
     <io.grpc.version>1.44.0</io.grpc.version>
     <http.version>1.41.2</http.version>

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -48,7 +48,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>31.0.1-jre</guava.version>
-    <google.cloud.bom.version>0.168.1</google.cloud.bom.version>
+    <google.cloud.bom.version>0.169.0</google.cloud.bom.version>
     <google.cloud.core.version>2.4.0</google.cloud.core.version>
     <io.grpc.version>1.44.0</io.grpc.version>
     <http.version>1.41.2</http.version>


### PR DESCRIPTION
The new version of Google Cloud BOM has been released today. The shared dependencies BOM version remains the same (2.7.0) since the last Google Cloud BOM release.