### PR TITLE
Release 24.4.0-bom: Bumping to next version post release

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>24.4.0</version>
+  <version>24.4.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>24.3.1-SNAPSHOT</version>
+  <version>24.4.0</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>24.4.0</version>
+        <version>24.4.1-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/boms/upper-bounds-check/pom.xml
+++ b/boms/upper-bounds-check/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>24.3.1-SNAPSHOT</version>
+        <version>24.4.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
1st commit marks 24.4.0-bom release with the Git tag. 2nd commit bumps the version in the branch with SNAPSHOT suffix.

The release version is 24.4.0. It's a minor version bump because the google-cloud-bom had a minor version bump (e.g., spanner) without a major version bump. https://github.com/googleapis/java-cloud-bom/releases/tag/v0.168.1
