### PR TITLE
update the url of google-cloud-bom

### DIFF
--- a/docs/JLBP-0015.md
+++ b/docs/JLBP-0015.md
@@ -47,7 +47,7 @@ dependencies in its `<dependencyManagement>` section to ensure that its
 build is consistent, but these dependency versions shouldn't be imported by
 consumers who import the BOM.
 
-Example BOM: [google-cloud-bom](https://github.com/GoogleCloudPlatform/google-cloud-java/blob/master/google-cloud-bom/pom.xml).
+Example BOM: [google-cloud-bom](https://github.com/googleapis/java-cloud-bom/blob/main/pom.xml).
 
 ## Libraries built with Gradle
 


### PR DESCRIPTION
The BOM configuration has moved to https://github.com/googleapis/java-cloud-bom