### PR TITLE
Libraries BOM: Google Cloud BOM 0.172.0 and associated dependencies

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -47,21 +47,21 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <guava.version>31.0.1-jre</guava.version>
+    <guava.version>31.1-jre</guava.version>
     <gson.version>2.9.0</gson.version>
-    <google.cloud.bom.version>0.171.0</google.cloud.bom.version>
-    <google.cloud.core.version>2.5.6</google.cloud.core.version>
-    <io.grpc.version>1.44.1</io.grpc.version>
-    <http.version>1.41.4</http.version>
+    <google.cloud.bom.version>0.172.0</google.cloud.bom.version>
+    <google.cloud.core.version>2.5.11</google.cloud.core.version>
+    <io.grpc.version>1.45.0</io.grpc.version>
+    <http.version>1.41.5</http.version>
     <protobuf.version>3.19.4</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>2.12.2</gax.version>
-    <gax.httpjson.version>0.97.2</gax.httpjson.version>
-    <auth.version>1.5.3</auth.version>
-    <api-common.version>2.1.4</api-common.version>
-    <common.protos.version>2.7.4</common.protos.version>
-    <iam.protos.version>1.2.6</iam.protos.version>
+    <gax.version>2.13.0</gax.version>
+    <gax.httpjson.version>0.98.0</gax.httpjson.version>
+    <auth.version>1.6.0</auth.version>
+    <api-common.version>2.1.5</api-common.version>
+    <common.protos.version>2.8.0</common.protos.version>
+    <iam.protos.version>1.2.10</iam.protos.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
Google Cloud BOM 0.172.0 was released. The client libraries were built and tested with the shared dependencies BOM 2.9.0 (https://github.com/googleapis/java-shared-dependencies/blob/v2.9.0/first-party-dependencies/pom.xml). Upgrading the associated dependencies in the BOM too as usual.

It has GAX 2.13.0. GAX BOM 2.13.0 (https://search.maven.org/artifact/com.google.api/gax-bom/2.13.0/pom) has gax-httpjson 0.98.0.
