### PR TITLE
Google Cloud BOM 0.173.0 and associated dependencies

### DIFF
--- a/boms/cloud-oss-bom/pom.xml
+++ b/boms/cloud-oss-bom/pom.xml
@@ -49,19 +49,19 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>31.1-jre</guava.version>
     <gson.version>2.9.0</gson.version>
-    <google.cloud.bom.version>0.172.0</google.cloud.bom.version>
-    <google.cloud.core.version>2.5.11</google.cloud.core.version>
-    <io.grpc.version>1.45.0</io.grpc.version>
-    <http.version>1.41.5</http.version>
+    <google.cloud.bom.version>0.173.0</google.cloud.bom.version>
+    <google.cloud.core.version>2.6.0</google.cloud.core.version>
+    <io.grpc.version>1.45.1</io.grpc.version>
+    <http.version>1.41.7</http.version>
     <protobuf.version>3.19.4</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>2.13.0</gax.version>
-    <gax.httpjson.version>0.98.0</gax.httpjson.version>
+    <gax.version>2.16.0</gax.version>
+    <gax.httpjson.version>0.101.0</gax.httpjson.version>
     <auth.version>1.6.0</auth.version>
     <api-common.version>2.1.5</api-common.version>
-    <common.protos.version>2.8.0</common.protos.version>
-    <iam.protos.version>1.2.10</iam.protos.version>
+    <common.protos.version>2.8.3</common.protos.version>
+    <iam.protos.version>1.3.1</iam.protos.version>
   </properties>
 
   <distributionManagement>

--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -2,6 +2,7 @@
 
 set JAVA_HOME=c:\program files\java\jdk1.8.0_152
 set PATH=%JAVA_HOME%\bin;%PATH%
+set MAVEN_OPTS="-Xmx8g"
 
 cd github/cloud-opensource-java
 

--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -5,6 +5,8 @@ set -e
 # Display commands being run.
 set -x
 
+export MAVEN_OPTS="-Xmx8g"
+
 cd github/cloud-opensource-java
 
 ./mvnw -V -B -ntp clean install javadoc:jar


### PR DESCRIPTION
Google Cloud BOM 0.173.0 was built with the shared dependencies
BOM 2.10.0.
https://github.com/googleapis/java-shared-dependencies/blob/v2.10.0/first-party-dependencies/pom.xml

Gax-bom 2.16.0 has gax-httpjson 0.101.0
https://search.maven.org/artifact/com.google.api/gax-bom/2.16.0/pom
