### PR TITLE
Release 1.0.12-lts: Bumping to next version post release

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>gcp-lts-bom</artifactId>
-  <version>1.0.12-SNAPSHOT</version>
+  <version>1.0.12</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Long Term Support BOM</name>

--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>gcp-lts-bom</artifactId>
-  <version>1.0.12</version>
+  <version>1.0.13-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Long Term Support BOM</name>


### PR DESCRIPTION
1st commit marks 1.0.12-lts release with the Git tag. 2nd commit bumps the version in the branch with SNAPSHOT suffix.