### PR TITLE
Exclude appengine artifacts from duplicate class check

### DIFF
--- a/boms/integration-tests/src/test/java/com/google/cloud/BomContentTest.java
+++ b/boms/integration-tests/src/test/java/com/google/cloud/BomContentTest.java
@@ -49,6 +49,7 @@ import org.junit.Test;
  * Central yet, use "-DdisableMavenCentralCheck=true" system property when running this test.
  */
 public class BomContentTest {
+
   private static VersionScheme versionScheme = new GenericVersionScheme();
 
   // List of Maven dependency scopes that are visible to library users. For example "provided" scope
@@ -110,12 +111,16 @@ public class BomContentTest {
     for (ClassPathEntry classPathEntry : result.getClassPath()) {
       Artifact currentArtifact = classPathEntry.getArtifact();
 
-      if (!currentArtifact.getGroupId().contains("google")
-          || currentArtifact.getGroupId().contains("com.google.android")
-          || currentArtifact.getGroupId().contains("com.google.cloud.bigtable")
-          || currentArtifact.getArtifactId().startsWith("proto-")
-          || currentArtifact.getArtifactId().equals("protobuf-javalite")
-          || currentArtifact.getArtifactId().equals("appengine-testing")) {
+      String artifactId = currentArtifact.getArtifactId();
+      String groupId = currentArtifact.getGroupId();
+      if (!groupId.contains("google")
+          || groupId.contains("com.google.android")
+          || groupId.contains("com.google.cloud.bigtable")
+          || artifactId.startsWith("proto-")
+          || artifactId.equals("protobuf-javalite")
+          || artifactId.equals("appengine-testing")
+          || artifactId.equals("appengine-remote-api")
+          || artifactId.equals("appengine-api-1.0-sdk")) {
         // Skip libraries that produce false positives.
         // See: https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/2226
         continue;

--- a/boms/integration-tests/src/test/java/com/google/cloud/BomContentTest.java
+++ b/boms/integration-tests/src/test/java/com/google/cloud/BomContentTest.java
@@ -49,7 +49,6 @@ import org.junit.Test;
  * Central yet, use "-DdisableMavenCentralCheck=true" system property when running this test.
  */
 public class BomContentTest {
-
   private static VersionScheme versionScheme = new GenericVersionScheme();
 
   // List of Maven dependency scopes that are visible to library users. For example "provided" scope


### PR DESCRIPTION
Appengine API SDK is known to have duplicate classes from the same source in Google-internal source code repository. Because they are from the same source and having the same content, it will not cause dependency conflicts.

@blakeli0 Can you confirm the error you observed was at `testLtsBom`:

```
  @Test
  public void testLtsBom() throws Exception {
    Path bomPath = Paths.get("..", "cloud-lts-bom", "pom.xml").toAbsolutePath();
```

This in turn calls `checkBom` and then `assertUniqueClasses`, where this fix is applied.