### PR TITLE
deps: bigtable-hbase 2.1.2 on 3.0.x-lts

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -80,7 +80,7 @@
     <google-cloud-monitoring.version>3.2.10</google-cloud-monitoring.version>
     <google-cloud-spanner.version>6.23.4</google-cloud-spanner.version>
     <google-cloud-tasks.version>2.1.12</google-cloud-tasks.version>
-    <bigtable-hbase-beam.version>2.1.1</bigtable-hbase-beam.version>
+    <bigtable-hbase-beam.version>2.1.2</bigtable-hbase-beam.version>
     <google-cloud-bigtable.version>2.6.3</google-cloud-bigtable.version>
     <google-cloud-pubsub.version>1.117.1</google-cloud-pubsub.version>
     <!-- the proto-google-cloud-pubsub-v1 used by the google-cloud-pubsub version above -->


### PR DESCRIPTION
https://github.com/googleapis/java-bigtable-hbase/releases/tag/v2.1.2 was released yesterday. The previous version was 2.1.1.