### PR TITLE
Remove BOM_SKIP_ARTIFACT_IDS

### DIFF
--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -421,7 +421,8 @@ public class DashboardTest {
     String bomUpgradeMessage = globalUpperBoundBomUpgradeNodes.get(0).getValue();
     assertThat(bomUpgradeMessage)
         .contains(
-            "Upgrade com.google.protobuf:protobuf-java-util:jar:3.6.1 in the BOM to version \"3.7.1\"");
+            "Upgrade com.google.protobuf:protobuf-java-util:jar:3.6.1 in the BOM to version"
+                + " \"3.7.1\"");
 
     // Case 2: Dependency needs to be updated
     Nodes globalUpperBoundDependencyUpgradeNodes =

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -469,7 +469,7 @@ public class DashboardTest {
     Nodes dependencyTreeParagraph = document.query("//p[@class='dependency-tree-node']");
 
     // characterization test
-    assertThat(dependencyTreeParagraph).hasSize(38391);
+    assertThat(dependencyTreeParagraph).hasSize(39649);
     Assert.assertEquals(
         "com.google.protobuf:protobuf-java:jar:3.6.1", dependencyTreeParagraph.get(0).getValue());
   }

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/Bom.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/Bom.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.opensource.dependencies;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/Bom.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/Bom.java
@@ -38,9 +38,6 @@ import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
 import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 
 public final class Bom {
-  
-  private static final ImmutableSet<String> BOM_SKIP_ARTIFACT_IDS =
-      ImmutableSet.of("google-cloud-logging-logback", "google-cloud-contrib");
 
   private final ImmutableList<Artifact> artifacts;
   private final String coordinates;
@@ -151,12 +148,7 @@ public final class Bom {
     if ("test-jar".equals(type)) {
       return true;
     }
-  
-    // TODO remove this hack once we get these out of google-cloud-java's BOM
-    if (BOM_SKIP_ARTIFACT_IDS.contains(artifact.getArtifactId())) {
-      return true;
-    }
-  
+
     return false;
   }
 }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -108,7 +108,7 @@ public class ClassPathBuilderTest {
         .isEqualTo("com.google.api:api-common:1.7.0"); // first element in the BOM
     int bomSize = managedDependencies.size();
     String lastFileName = entries.get(bomSize - 1).toString();
-    assertThat(lastFileName).isEqualTo("com.google.api:gax-httpjson:0.57.0"); // last element in BOM
+    assertThat(lastFileName).isEqualTo("com.google.code.findbugs:jsr305:3.0.2"); // last element in BOM
   }
 
   @Test

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ClassPathBuilderTest.java
@@ -108,7 +108,8 @@ public class ClassPathBuilderTest {
         .isEqualTo("com.google.api:api-common:1.7.0"); // first element in the BOM
     int bomSize = managedDependencies.size();
     String lastFileName = entries.get(bomSize - 1).toString();
-    assertThat(lastFileName).isEqualTo("com.google.code.findbugs:jsr305:3.0.2"); // last element in BOM
+    assertThat(lastFileName)
+        .isEqualTo("com.google.code.findbugs:jsr305:3.0.2"); // last element in BOM
   }
 
   @Test

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ExclusionFilesTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ExclusionFilesTest.java
@@ -344,10 +344,11 @@ public class ExclusionFilesTest {
 
     String expected =
         new String(
-            Files.readAllBytes(
-                absolutePathOfResource(
-                    "exclusion-sample-rules/expected-exclusion-output-file.xml")),
-            StandardCharsets.UTF_8);
+                Files.readAllBytes(
+                    absolutePathOfResource(
+                        "exclusion-sample-rules/expected-exclusion-output-file.xml")),
+                StandardCharsets.UTF_8)
+            .replaceAll("\\R", "\n");
 
     assertEquals(expected, actual);
   }

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ExclusionFilesTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/ExclusionFilesTest.java
@@ -340,7 +340,7 @@ public class ExclusionFilesTest {
 
     ExclusionFiles.write(output, linkageErrors);
 
-    String actual = new String(Files.readAllBytes(output));
+    String actual = new String(Files.readAllBytes(output)).replaceAll("\\R", "\n");
 
     String expected =
         new String(

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -172,7 +172,7 @@ public class LinkageCheckerMainIntegrationTest {
       LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 760 linkage errors", expected.getMessage());
+      assertEquals("Found 756 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -138,7 +138,7 @@ public class LinkageCheckerMainIntegrationTest {
       LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 631 linkage errors", expected.getMessage());
+      assertEquals("Found 755 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -172,7 +172,7 @@ public class LinkageCheckerMainIntegrationTest {
       LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 653 linkage errors", expected.getMessage());
+      assertEquals("Found 756 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -172,7 +172,7 @@ public class LinkageCheckerMainIntegrationTest {
       LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 756 linkage errors", expected.getMessage());
+      assertEquals("Found 760 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -138,7 +138,7 @@ public class LinkageCheckerMainIntegrationTest {
       LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 755 linkage errors", expected.getMessage());
+      assertEquals("Found 734 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/BomTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/BomTest.java
@@ -39,7 +39,7 @@ public class BomTest {
     List<Artifact> managedDependencies = bom.getManagedDependencies();
     // Characterization test. As long as the artifact doesn't change (and it shouldn't)
     // the answer won't change.
-    Assert.assertEquals(134, managedDependencies.size());
+    Assert.assertEquals(136, managedDependencies.size());
     Assert.assertEquals("com.google.cloud:google-cloud-bom:0.61.0-alpha", bom.getCoordinates());
   }
 

--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -1,6 +1,6 @@
 @echo on
 
-set JAVA_HOME=c:\program files\java\jdk1.8.0_152
+set JAVA_HOME=c:\program files\java\jdk1.8.0_211
 set PATH=%JAVA_HOME%\bin;%PATH%
 set MAVEN_OPTS="-Xmx12g"
 


### PR DESCRIPTION
The BOM_SKIP_ARTIFACT_IDS has been hiding the google-cloud-logging-logback artifact from appearing in the release note.  https://github.com/googleapis/java-cloud-bom/releases/tag/v26.14.0