### PR TITLE
chore: skip grpc-android during bom validation

### DIFF
--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/Bom.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/Bom.java
@@ -22,8 +22,6 @@ import com.google.common.collect.ImmutableList;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-
-import com.google.common.collect.ImmutableSet;
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.project.MavenProject;

--- a/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/Bom.java
+++ b/dependencies/src/main/java/com/google/cloud/tools/opensource/dependencies/Bom.java
@@ -22,6 +22,8 @@ import com.google.common.collect.ImmutableList;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.google.common.collect.ImmutableSet;
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.project.MavenProject;
@@ -145,6 +147,14 @@ public final class Bom {
   
     String type = artifact.getProperty(ArtifactProperties.TYPE, "jar");
     if ("test-jar".equals(type)) {
+      return true;
+    }
+
+    // Skipping grpc-android as it is not used by Google Cloud Client Libraries for Java. Checking
+    // for availability of
+    // this unused artifact on Maven Central has caused BOM validation check to fail in the past. See
+    // https://github.com/googleapis/sdk-platform-java/pull/1989#issuecomment-1724039670
+    if ("grpc-android".equals(artifact.getArtifactId())) {
       return true;
     }
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/BomTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/dependencies/BomTest.java
@@ -27,6 +27,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.List;
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.resolution.ArtifactDescriptorException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -77,4 +78,9 @@ public class BomTest {
         .inOrder();
   }
 
+  @Test
+  public void testIsSkipped_grpcAndroid() {
+    Artifact artifact = new DefaultArtifact("io.grpc:grpc-android:jar:1.58.0");
+    Truth.assertThat(Bom.shouldSkipBomMember(artifact)).isTrue();
+  }
 }


### PR DESCRIPTION
`Bom.readBom(bomPath);` is called in [`CreateBomCanaryProject`](https://github.com/googleapis/java-cloud-bom/blob/721ee5581994fb05f5b4a29652bfde9b58d29164/tests/validate-bom/src/main/java/com/google/cloud/CreateBomCanaryProject.java#L37) which creates a canary project (a sample directory with a pom) for BOM validation. 

The validation of `grpc-android` first failed in https://github.com/googleapis/sdk-platform-java/pull/1989 with the following error message  even though grpc-android is available at https://repo1.maven.org/maven2/io/grpc/grpc-android/1.58.0/grpc-android-1.58.0.aar :
```
Error:  Failed to execute goal on project bom-validation-canary-project: Could not resolve dependencies for project com.google.cloud:bom-validation-canary-project:jar:0.0.1-SNAPSHOT: The following artifacts could not be resolved: io.grpc:grpc-android:jar:1.58.0, io.grpc:grpc-binder:jar:1.58.0, androidx.annotation:annotation:jar:1.6.0, androidx.core:core:jar:1.10.1, androidx.lifecycle:lifecycle-common:jar:2.6.1, io.grpc:grpc-cronet:jar:1.58.0, org.chromium.net:cronet-api:jar:108.5359.79: Could not find artifact io.grpc:grpc-android:jar:1.58.0 in central (https://repo.maven.apache.org/maven2) -> [Help 1]
```

Since [grpc-android is not used in the java client libraries](https://github.com/search?q=org%3Agoogleapis+grpc-android&type=code&p=1), it's existence doesn't have to be verified. 
