### PR TITLE
chore: update Temurin/SLES installation instructions

### DIFF
--- a/temurin-install-testing/startup.sh
+++ b/temurin-install-testing/startup.sh
@@ -59,6 +59,15 @@ EOM
 }
 
 function prepare_installer_sles {
+  # [START centos_major_version]
+  eval "$(grep VERSION_ID /etc/os-release)"
+  OLD_IFS=$IFS
+  IFS='.'
+  read -ra split_version <<<"$VERSION_ID"
+  IFS=$OLD_IFS
+  MAJOR_VERSION=$split_version
+  # [END centos_major_version]
+
   # [START sles_adoptium_key]
   sudo mkdir -p /etc/zypp/keyrings
   sudo wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public |
@@ -67,8 +76,7 @@ function prepare_installer_sles {
   # [START sles_adoptium_key]
 
   # [START sles_adoptium_repo]
-  eval "$(grep VERSION_ID /etc/os-release)"
-  sudo zypper ar -f "https://packages.adoptium.net/artifactory/rpm/opensuse/$VERSION_ID/$(uname -m)" adoptium
+  sudo zypper ar -f "https://packages.adoptium.net/artifactory/rpm/sles/$MAJOR_VERSION/$(uname -m)" adoptium
   # [START sles_adoptium_repo]
 
   export INSTALLER="zypper"

--- a/temurin-install-testing/test-all.sh
+++ b/temurin-install-testing/test-all.sh
@@ -27,8 +27,10 @@ wait
 BUCKET_FOLDER=$(terraform output --raw bucket_folder)
 terraform apply -auto-approve
 terraform apply -var="enable_linux=true" -var="bucket_folder=$BUCKET_FOLDER" -auto-approve
+# For single invocations: terraform apply -var="enable_linux=true" -auto-approve
 wait
 terraform apply -auto-approve
 terraform apply -var="enable_windows=true" -var="bucket_folder=$BUCKET_FOLDER" -auto-approve
+# For single invocations: terraform apply -var="enable_windows=true" -auto-approve
 wait
 terraform apply -auto-approve


### PR DESCRIPTION
Adoptium does not support openSUSE 15 SP5, but has general support for SLES 15.

This PR converts instructions to use the SLES-specific repository for Temurin installation.