### PR TITLE
ci: update github actions and java version for sonar

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -18,13 +18,14 @@ jobs:
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 17
       - name: Cache SonarCloud packages
         uses: actions/cache@v2
         with:

--- a/temurin-install-testing/variables.tf
+++ b/temurin-install-testing/variables.tf
@@ -69,36 +69,38 @@ variable "x86_machine_types" {
   ]
 }
 
-# See https://cloud.google.com/compute/docs/images
+# See https://cloud.google.com/compute/docs/images/os-details
 variable "x86_boot_images" {
   type        = list(string)
   description = "GCE boot image to use with created instance"
   default     = [
-    "debian-cloud/debian-11",
-    "debian-cloud/debian-10",
-
-    "rhel-cloud/rhel-9",
-    "rhel-cloud/rhel-7",
-    "rhel-sap-cloud/rhel-9-0-sap-ha",
-    "rhel-sap-cloud/rhel-7-7-sap-ha",
-
-    "centos-cloud/centos-stream-9",
-    "centos-cloud/centos-stream-8",
-    "centos-cloud/centos-7",
-
-    "rocky-linux-cloud/rocky-linux-9-optimized-gcp",
-    "rocky-linux-cloud/rocky-linux-8-optimized-gcp",
-    "rocky-linux-cloud/rocky-linux-8",
-
-    "ubuntu-os-cloud/ubuntu-2204-lts",
-    "ubuntu-os-cloud/ubuntu-2004-lts",
-    "ubuntu-os-pro-cloud/ubuntu-pro-2204-lts",
-    "ubuntu-os-pro-cloud/ubuntu-pro-1804-lts",
-    "ubuntu-os-pro-cloud/ubuntu-pro-1604-lts",
+#    "debian-cloud/debian-11",
+#    "debian-cloud/debian-10",
+#
+#    "rhel-cloud/rhel-9",
+#    "rhel-cloud/rhel-7",
+#    "rhel-sap-cloud/rhel-9-0-sap-ha",
+#    "rhel-sap-cloud/rhel-7-9-sap-ha",
+#
+#    "centos-cloud/centos-stream-9",
+#    "centos-cloud/centos-stream-8",
+#    "centos-cloud/centos-7",
+#
+#    "rocky-linux-cloud/rocky-linux-9-optimized-gcp",
+#    "rocky-linux-cloud/rocky-linux-8-optimized-gcp",
+#    "rocky-linux-cloud/rocky-linux-8",
+#
+#    "ubuntu-os-cloud/ubuntu-2204-lts",
+#    "ubuntu-os-cloud/ubuntu-2004-lts",
+#    "ubuntu-os-pro-cloud/ubuntu-pro-2204-lts",
+#    "ubuntu-os-pro-cloud/ubuntu-pro-1804-lts",
+#    "ubuntu-os-pro-cloud/ubuntu-pro-1604-lts",
 
     "suse-cloud/sles-15",
-    "suse-byos-cloud/sles-12-byos",
-    "suse-sap-cloud/sles-12-sp5-sap",
+    "suse-sap-cloud/sles-15-sp5-sap",
+    "suse-sap-cloud/sles-15-sp4-sap",
+#    "suse-byos-cloud/sles-12-byos",
+#    "suse-sap-cloud/sles-12-sp5-sap",
   ]
 }
 


### PR DESCRIPTION
Resolves message in recent PRs:
> The version of Java (11.0.20) you have used to run this analysis is deprecated and we will stop accepting it soon. Please update to at least Java 17.