### PR TITLE
chore: update linkage tests

### DIFF
--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -214,11 +214,6 @@ public class DashboardTest {
 
   @Test
   public void testLinkageReports() {
-    Nodes reports = details.query("//p[@class='jar-linkage-report']");
-    // appengine-api-sdk, shown as first item in linkage errors, has these errors
-    assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
-        .isEqualTo("5 target classes causing linkage errors referenced from 5 source classes.");
-
     Nodes dependencyPaths = details.query("//p[@class='linkage-check-dependency-paths']");
     Node dependencyPathMessageOnProblem = dependencyPaths.get(dependencyPaths.size() - 1);
     Assert.assertEquals(
@@ -296,6 +291,12 @@ public class DashboardTest {
     assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
         .isEqualTo("100 target classes causing linkage errors referenced from 540 source classes.");
 
+
+    Nodes artifactDetailsReports = details.query("//p[@class='jar-linkage-report']");
+    // appengine-api-sdk, shown as first item in linkage errors, has these errors
+    assertThat(trimAndCollapseWhiteSpace(artifactDetailsReports.get(0).getValue()))
+        .isEqualTo("4 target classes causing linkage errors referenced from 4 source classes.");
+
     Nodes causes = document.query("//p[@class='jar-linkage-report-cause']");
     assertWithMessage(
             "google-http-client-appengine should show linkage errors for RpcStubDescriptor")
@@ -312,6 +313,11 @@ public class DashboardTest {
     // javaMajorVersion is 1 when we use Java 8. Still good indicator to ensure Java 11 or higher.
     int javaMajorVersion = Integer.parseInt(javaVersion.split("\\.")[0]);
     Assume.assumeTrue(javaMajorVersion >= 11);
+
+    Nodes artifactDetailsReports = details.query("//p[@class='jar-linkage-report']");
+    // appengine-api-sdk, shown as first item in linkage errors, has these errors
+    assertThat(trimAndCollapseWhiteSpace(artifactDetailsReports.get(0).getValue()))
+        .isEqualTo("5 target classes causing linkage errors referenced from 5 source classes.");
 
     // The version used in libraries-bom 1.0.0. The google-http-client-appengine has been known to
     // have linkage errors in its dependency appengine-api-1.0-sdk:1.9.71.

--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -217,7 +217,7 @@ public class DashboardTest {
     Nodes reports = details.query("//p[@class='jar-linkage-report']");
     // appengine-api-sdk, shown as first item in linkage errors, has these errors
     assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
-        .isEqualTo("4 target classes causing linkage errors referenced from 4 source classes.");
+        .isEqualTo("5 target classes causing linkage errors referenced from 5 source classes.");
 
     Nodes dependencyPaths = details.query("//p[@class='linkage-check-dependency-paths']");
     Node dependencyPathMessageOnProblem = dependencyPaths.get(dependencyPaths.size() - 1);

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -5,7 +5,7 @@ Linkage Checker is a tool that finds [linkage errors](
 path. It scans the class files in the class path for references to other
 classes and reports any reference that cannot be satisfied.
 
-#### User Documentation
+### User Documentation
 
 Linkage Checker can be used from Maven or Gradle.
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -34,6 +34,7 @@ import org.hamcrest.core.StringStartsWith;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class LinkageCheckerMainIntegrationTest {
@@ -160,6 +161,9 @@ public class LinkageCheckerMainIntegrationTest {
   }
 
   @Test
+  @Ignore("Began failing after Oct 4, 2023 and before Nov 9, 2023 without source changes")
+  // Error: expected:<Found 75[6] linkage errors> but was:<Found 75[8] linkage errors>
+  // No previous list of 756 expected linkage errors exists to compare against the new error count.
   public void testBom_java11()
       throws IOException, RepositoryException, TransformerException, XMLStreamException {
     // The number of linkage errors differs between Java 8 and Java 11 runtime.

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -161,7 +161,6 @@ public class LinkageCheckerMainIntegrationTest {
   }
 
   @Test
-  @Ignore("Began failing after Oct 4, 2023 and before Nov 9, 2023 without source changes")
   // Error: expected:<Found 75[6] linkage errors> but was:<Found 75[8] linkage errors>
   // No previous list of 756 expected linkage errors exists to compare against the new error count.
   public void testBom_java11()
@@ -176,7 +175,7 @@ public class LinkageCheckerMainIntegrationTest {
       LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 756 linkage errors", expected.getMessage());
+      assertEquals("Found 758 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -34,7 +34,6 @@ import org.hamcrest.core.StringStartsWith;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class LinkageCheckerMainIntegrationTest {

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -160,8 +160,6 @@ public class LinkageCheckerMainIntegrationTest {
   }
 
   @Test
-  // Error: expected:<Found 75[6] linkage errors> but was:<Found 75[8] linkage errors>
-  // No previous list of 756 expected linkage errors exists to compare against the new error count.
   public void testBom_java11()
       throws IOException, RepositoryException, TransformerException, XMLStreamException {
     // The number of linkage errors differs between Java 8 and Java 11 runtime.

--- a/enforcer-rules/src/it/bom-project-using-spring-repository/verify.groovy
+++ b/enforcer-rules/src/it/bom-project-using-spring-repository/verify.groovy
@@ -14,6 +14,6 @@ assert !buildLog.text.contains("NullPointerException")
 
 // 4 linkage errors are references to java.util.concurrent.Flow class, which does not exist in
 // Java 8 runtime yet.
-def expectedErrorCount = System.getProperty("java.version").startsWith("1.8.") ? 111 : 107
+def expectedErrorCount = System.getProperty("java.version").startsWith("1.8.") ? 111 : 108
 
 assert buildLog.text.contains("Linkage Checker rule found $expectedErrorCount errors:")


### PR DESCRIPTION
This PR updates the linkage tests to reflect the new expected error counts, as suggested by @suztomo .