### PR TITLE
Revert "chore: update linkage tests (#2358)"

### DIFF
--- a/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
+++ b/dashboard/src/test/java/com/google/cloud/tools/opensource/dashboard/DashboardTest.java
@@ -214,6 +214,11 @@ public class DashboardTest {
 
   @Test
   public void testLinkageReports() {
+    Nodes reports = details.query("//p[@class='jar-linkage-report']");
+    // appengine-api-sdk, shown as first item in linkage errors, has these errors
+    assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
+        .isEqualTo("4 target classes causing linkage errors referenced from 4 source classes.");
+
     Nodes dependencyPaths = details.query("//p[@class='linkage-check-dependency-paths']");
     Node dependencyPathMessageOnProblem = dependencyPaths.get(dependencyPaths.size() - 1);
     Assert.assertEquals(
@@ -291,12 +296,6 @@ public class DashboardTest {
     assertThat(trimAndCollapseWhiteSpace(reports.get(0).getValue()))
         .isEqualTo("100 target classes causing linkage errors referenced from 540 source classes.");
 
-
-    Nodes artifactDetailsReports = details.query("//p[@class='jar-linkage-report']");
-    // appengine-api-sdk, shown as first item in linkage errors, has these errors
-    assertThat(trimAndCollapseWhiteSpace(artifactDetailsReports.get(0).getValue()))
-        .isEqualTo("4 target classes causing linkage errors referenced from 4 source classes.");
-
     Nodes causes = document.query("//p[@class='jar-linkage-report-cause']");
     assertWithMessage(
             "google-http-client-appengine should show linkage errors for RpcStubDescriptor")
@@ -313,11 +312,6 @@ public class DashboardTest {
     // javaMajorVersion is 1 when we use Java 8. Still good indicator to ensure Java 11 or higher.
     int javaMajorVersion = Integer.parseInt(javaVersion.split("\\.")[0]);
     Assume.assumeTrue(javaMajorVersion >= 11);
-
-    Nodes artifactDetailsReports = details.query("//p[@class='jar-linkage-report']");
-    // appengine-api-sdk, shown as first item in linkage errors, has these errors
-    assertThat(trimAndCollapseWhiteSpace(artifactDetailsReports.get(0).getValue()))
-        .isEqualTo("5 target classes causing linkage errors referenced from 5 source classes.");
 
     // The version used in libraries-bom 1.0.0. The google-http-client-appengine has been known to
     // have linkage errors in its dependency appengine-api-1.0-sdk:1.9.71.

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -5,7 +5,7 @@ Linkage Checker is a tool that finds [linkage errors](
 path. It scans the class files in the class path for references to other
 classes and reports any reference that cannot be satisfied.
 
-### User Documentation
+#### User Documentation
 
 Linkage Checker can be used from Maven or Gradle.
 

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -172,7 +172,7 @@ public class LinkageCheckerMainIntegrationTest {
       LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 758 linkage errors", expected.getMessage());
+      assertEquals("Found 756 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();

--- a/enforcer-rules/src/it/bom-project-using-spring-repository/verify.groovy
+++ b/enforcer-rules/src/it/bom-project-using-spring-repository/verify.groovy
@@ -14,6 +14,6 @@ assert !buildLog.text.contains("NullPointerException")
 
 // 4 linkage errors are references to java.util.concurrent.Flow class, which does not exist in
 // Java 8 runtime yet.
-def expectedErrorCount = System.getProperty("java.version").startsWith("1.8.") ? 111 : 108
+def expectedErrorCount = System.getProperty("java.version").startsWith("1.8.") ? 111 : 107
 
 assert buildLog.text.contains("Linkage Checker rule found $expectedErrorCount errors:")


### PR DESCRIPTION
This reverts commit 02c26c9e270668fb926f00284d43da134a02ed2d.

This PR exists to trigger a conversation with @suztomo about whether these updates match with his expecations on how to handle the linkage errors seen in #2358