### PR TITLE
fix: add module-info to be ignored in unique classes test.

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -49,20 +49,20 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Layer 1: Core -->
-    <guava.version>33.1.0-jre</guava.version>
+    <guava.version>32.1.3-jre</guava.version>
     <autovalue.version>1.10.4</autovalue.version>
-    <protobuf.version>3.25.3</protobuf.version>
-    <io.grpc.version>1.62.2</io.grpc.version>
-    <google-http-client.version>1.44.1</google-http-client.version>
-    <google-oauth-client.version>1.35.0</google-oauth-client.version>
-    <google-auth-library.version>1.23.0</google-auth-library.version>
-    <google-api-client.version>2.4.0</google-api-client.version>
+    <protobuf.version>3.25.1</protobuf.version>
+    <io.grpc.version>1.59.1</io.grpc.version>
+    <google-http-client.version>1.43.3</google-http-client.version>
+    <google-oauth-client.version>1.34.1</google-oauth-client.version>
+    <google-auth-library.version>1.20.0</google-auth-library.version>
+    <google-api-client.version>2.2.0</google-api-client.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
     When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>2.46.1</gax.version>
-    <api-common.version>2.29.1</api-common.version>
-    <google-cloud-core.version>2.36.1</google-cloud-core.version>
-    <proto-google-common-protos.version>2.37.1</proto-google-common-protos.version>
+    <gax.version>2.38.0</gax.version>
+    <api-common.version>2.21.0</api-common.version>
+    <google-cloud-core.version>2.28.0</google-cloud-core.version>
+    <proto-google-common-protos.version>2.29.0</proto-google-common-protos.version>
 
     <!-- Layer 2: Cloud -->
     <google-cloud-container.version>2.34.0</google-cloud-container.version>

--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -49,20 +49,20 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Layer 1: Core -->
-    <guava.version>32.1.3-jre</guava.version>
+    <guava.version>33.1.0-jre</guava.version>
     <autovalue.version>1.10.4</autovalue.version>
-    <protobuf.version>3.25.1</protobuf.version>
-    <io.grpc.version>1.59.1</io.grpc.version>
-    <google-http-client.version>1.43.3</google-http-client.version>
-    <google-oauth-client.version>1.34.1</google-oauth-client.version>
-    <google-auth-library.version>1.20.0</google-auth-library.version>
-    <google-api-client.version>2.2.0</google-api-client.version>
+    <protobuf.version>3.25.3</protobuf.version>
+    <io.grpc.version>1.62.2</io.grpc.version>
+    <google-http-client.version>1.44.1</google-http-client.version>
+    <google-oauth-client.version>1.35.0</google-oauth-client.version>
+    <google-auth-library.version>1.23.0</google-auth-library.version>
+    <google-api-client.version>2.4.0</google-api-client.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
     When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>2.38.0</gax.version>
-    <api-common.version>2.21.0</api-common.version>
-    <google-cloud-core.version>2.28.0</google-cloud-core.version>
-    <proto-google-common-protos.version>2.29.0</proto-google-common-protos.version>
+    <gax.version>2.46.1</gax.version>
+    <api-common.version>2.29.1</api-common.version>
+    <google-cloud-core.version>2.36.1</google-cloud-core.version>
+    <proto-google-common-protos.version>2.37.1</proto-google-common-protos.version>
 
     <!-- Layer 2: Cloud -->
     <google-cloud-container.version>2.34.0</google-cloud-container.version>

--- a/boms/integration-tests/src/test/java/com/google/cloud/BomContentTest.java
+++ b/boms/integration-tests/src/test/java/com/google/cloud/BomContentTest.java
@@ -129,8 +129,10 @@ public class BomContentTest {
         if (className.contains("javax.annotation")
             || className.contains("$")
             || className.equals("com.google.cloud.location.LocationsGrpc")
-            || className.endsWith("package-info")) {
+            || className.endsWith("package-info")
+            || className.endsWith("module-info")) {
           // Ignore annotations, nested classes, and package-info files.
+          // Ignore module-info files.
           // Ignore LocationsGrpc classes which are duplicated in generated grpc libraries.
           continue;
         }


### PR DESCRIPTION
Fix test failure by ignoring `module-info` in unique class check.

see failed test [here](https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/2368#issuecomment-2034997118)

this test is trying to ensure there is no duplicate class names in classpath. We encountered error where  "META-INF.versions.9.module-info.class" exists in multiple artifacts.

This is a descriptive file part of Java Modules ( java >9), and thus duplicate by name in different artifacts is expected.

_Why do we started to observe this error now?_
I compared error_prone_annotations:2.26.1 vs 2.23.0 (brought in by google-cloud-core before the version update in pr), v2.23.0 does not contain this file. 

test case:
see ci result for [028ea64](https://github.com/GoogleCloudPlatform/cloud-opensource-java/pull/2369/commits/028ea64900ac01e75261813dd3408f733e21c07b), this commit brings in version updates same as in the original failed test above. It's [passing](https://github.com/GoogleCloudPlatform/cloud-opensource-java/actions/runs/8558175140/job/23452142967) after this fix.
