### PR TITLE
deps: upgrade enforcer rule to the latest 3.5.0

### DIFF
--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -172,7 +172,7 @@ public class LinkageCheckerMainIntegrationTest {
       LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 756 linkage errors", expected.getMessage());
+      assertEquals("Found 758 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();

--- a/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
+++ b/dependencies/src/test/java/com/google/cloud/tools/opensource/classpath/LinkageCheckerMainIntegrationTest.java
@@ -172,7 +172,7 @@ public class LinkageCheckerMainIntegrationTest {
       LinkageCheckerMain.main(new String[] {"-b", "com.google.cloud:libraries-bom:1.0.0"});
       fail("LinkageCheckerMain should throw LinkageCheckResultException upon errors");
     } catch (LinkageCheckResultException expected) {
-      assertEquals("Found 758 linkage errors", expected.getMessage());
+      assertEquals("Found 756 linkage errors", expected.getMessage());
     }
 
     String output = readCapturedStdout();

--- a/enforcer-rules/README.md
+++ b/enforcer-rules/README.md
@@ -17,8 +17,13 @@ $ mvn verify
 Listening for transport dt_socket at address: 5005
 ```
 
-When you debug one of the integration tests in the "src/it" directory, use the following
-command to specify the test case and to provide the debug parameter to Maven invoker plugin. 
+When you debug one of the integration tests in the "src/it" directory, check the
+`build.log` files in the `enforcer-rules/target/it` directory (run
+`find enforcer-rules -name 'build.log'`).
+The file is used in verification scripts and usually contains build errors.
+
+If you want to attach a debugger, use the following  command to specify the test
+case and to provide the debug parameter to Maven invoker plugin. 
 
 ```
 mvn install -Dmaven.test.skip -Dinvoker.test=bom-project-using-spring-repository \

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -48,7 +48,7 @@
   </licenses>
 
   <properties>
-    <enforcer.version>3.0.0-M3</enforcer.version>
+    <enforcer.version>3.5.0</enforcer.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -132,6 +132,20 @@
   <build>
     <plugins>
       <plugin>
+        <!-- generate index of project components, this enables users to
+            specify the rule as linkageCheckerRule via the Named annotation -->
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+        <version>0.9.0.M1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>main-index</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
         <version>3.2.2</version>
         <configuration>

--- a/enforcer-rules/src/it/abstract-method-errors/pom.xml
+++ b/enforcer-rules/src/it/abstract-method-errors/pom.xml
@@ -52,7 +52,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>@enforcer.version@</version>
         <dependencies>
           <dependency>
             <groupId>com.google.cloud.tools</groupId>
@@ -69,9 +69,7 @@
             </goals>
             <configuration>
               <rules>
-                <LinkageCheckerRule
-                  implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
-                </LinkageCheckerRule>
+                <linkageCheckerRule/>
               </rules>
             </configuration>
           </execution>

--- a/enforcer-rules/src/it/bom-project-error/pom.xml
+++ b/enforcer-rules/src/it/bom-project-error/pom.xml
@@ -54,7 +54,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>@enforcer.version@</version>
         <dependencies>
           <dependency>
             <groupId>com.google.cloud.tools</groupId>
@@ -71,10 +71,9 @@
             </goals>
             <configuration>
               <rules>
-                <LinkageCheckerRule
-                  implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
+                <linkageCheckerRule>
                   <dependencySection>DEPENDENCY_MANAGEMENT</dependencySection>
-                </LinkageCheckerRule>
+                </linkageCheckerRule>
               </rules>
             </configuration>
           </execution>

--- a/enforcer-rules/src/it/bom-project-no-error/pom.xml
+++ b/enforcer-rules/src/it/bom-project-no-error/pom.xml
@@ -50,7 +50,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>@enforcer.version@</version>
         <dependencies>
           <dependency>
             <groupId>com.google.cloud.tools</groupId>

--- a/enforcer-rules/src/it/bom-project-no-packaging/pom.xml
+++ b/enforcer-rules/src/it/bom-project-no-packaging/pom.xml
@@ -48,7 +48,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>@enforcer.version@</version>
         <dependencies>
           <dependency>
             <groupId>com.google.cloud.tools</groupId>
@@ -65,10 +65,9 @@
             </goals>
             <configuration>
               <rules>
-                <LinkageCheckerRule
-                  implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
+                <linkageCheckerRule>
                   <dependencySection>DEPENDENCY_MANAGEMENT</dependencySection>
-                </LinkageCheckerRule>
+                </linkageCheckerRule>
               </rules>
             </configuration>
           </execution>

--- a/enforcer-rules/src/it/bom-project-using-spring-repository/pom.xml
+++ b/enforcer-rules/src/it/bom-project-using-spring-repository/pom.xml
@@ -67,7 +67,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>@enforcer.version@</version>
         <dependencies>
           <dependency>
             <groupId>com.google.cloud.tools</groupId>
@@ -84,10 +84,9 @@
             </goals>
             <configuration>
               <rules>
-                <LinkageCheckerRule
-                  implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
+                <linkageCheckerRule>
                   <dependencySection>DEPENDENCY_MANAGEMENT</dependencySection>
-                </LinkageCheckerRule>
+                </linkageCheckerRule>
               </rules>
             </configuration>
           </execution>

--- a/enforcer-rules/src/it/fail-build-for-linkage-errors/pom.xml
+++ b/enforcer-rules/src/it/fail-build-for-linkage-errors/pom.xml
@@ -50,7 +50,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>@enforcer.version@</version>
         <dependencies>
           <dependency>
             <groupId>com.google.cloud.tools</groupId>
@@ -67,9 +67,7 @@
             </goals>
             <configuration>
               <rules>
-                <LinkageCheckerRule
-                  implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
-                </LinkageCheckerRule>
+                <linkageCheckerRule />
               </rules>
             </configuration>
           </execution>

--- a/enforcer-rules/src/it/inaccessible-class-error/pom.xml
+++ b/enforcer-rules/src/it/inaccessible-class-error/pom.xml
@@ -52,7 +52,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>@enforcer.version@</version>
         <dependencies>
           <dependency>
             <groupId>com.google.cloud.tools</groupId>
@@ -69,9 +69,7 @@
             </goals>
             <configuration>
               <rules>
-                <LinkageCheckerRule
-                  implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
-                </LinkageCheckerRule>
+                <linkageCheckerRule />
               </rules>
             </configuration>
           </execution>

--- a/enforcer-rules/src/it/missing-filter-file-error/pom.xml
+++ b/enforcer-rules/src/it/missing-filter-file-error/pom.xml
@@ -50,7 +50,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>@enforcer.version@</version>
         <dependencies>
           <dependency>
             <groupId>com.google.cloud.tools</groupId>

--- a/enforcer-rules/src/it/report-only-reachable-bom/pom.xml
+++ b/enforcer-rules/src/it/report-only-reachable-bom/pom.xml
@@ -59,7 +59,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>@enforcer.version@</version>
         <dependencies>
           <dependency>
             <groupId>com.google.cloud.tools</groupId>
@@ -76,11 +76,10 @@
             </goals>
             <configuration>
               <rules>
-                <LinkageCheckerRule
-                  implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
+                <linkageCheckerRule>
                   <dependencySection>DEPENDENCY_MANAGEMENT</dependencySection>
                   <reportOnlyReachable>true</reportOnlyReachable>
-                </LinkageCheckerRule>
+                </linkageCheckerRule>
               </rules>
             </configuration>
           </execution>

--- a/enforcer-rules/src/it/report-only-reachable/pom.xml
+++ b/enforcer-rules/src/it/report-only-reachable/pom.xml
@@ -51,7 +51,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>@enforcer.version@</version>
         <dependencies>
           <dependency>
             <groupId>com.google.cloud.tools</groupId>
@@ -68,10 +68,9 @@
             </goals>
             <configuration>
               <rules>
-                <LinkageCheckerRule
-                  implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
+                <linkageCheckerRule>
                   <reportOnlyReachable>true</reportOnlyReachable>
-                </LinkageCheckerRule>
+                </linkageCheckerRule>
               </rules>
             </configuration>
           </execution>

--- a/enforcer-rules/src/it/return-type-mismatch/pom.xml
+++ b/enforcer-rules/src/it/return-type-mismatch/pom.xml
@@ -47,7 +47,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>@enforcer.version@</version>
         <dependencies>
           <dependency>
             <groupId>com.google.cloud.tools</groupId>
@@ -64,9 +64,7 @@
             </goals>
             <configuration>
               <rules>
-                <LinkageCheckerRule
-                  implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
-                </LinkageCheckerRule>
+                <linkageCheckerRule/>
               </rules>
             </configuration>
           </execution>

--- a/enforcer-rules/src/it/test-scope/pom.xml
+++ b/enforcer-rules/src/it/test-scope/pom.xml
@@ -73,7 +73,9 @@
             </goals>
             <configuration>
               <rules>
-                <linkageCheckerRule/>
+                <linkageCheckerRule>
+                  <reportOnlyReachable>true</reportOnlyReachable>
+                </linkageCheckerRule>
               </rules>
             </configuration>
           </execution>

--- a/enforcer-rules/src/it/test-scope/pom.xml
+++ b/enforcer-rules/src/it/test-scope/pom.xml
@@ -56,7 +56,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>@enforcer.version@</version>
         <dependencies>
           <dependency>
             <groupId>com.google.cloud.tools</groupId>
@@ -73,10 +73,7 @@
             </goals>
             <configuration>
               <rules>
-                <LinkageCheckerRule
-                  implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
-                  <reportOnlyReachable>true</reportOnlyReachable>
-                </LinkageCheckerRule>
+                <linkageCheckerRule/>
               </rules>
             </configuration>
           </execution>

--- a/enforcer-rules/src/it/war-project-private-modifier/pom.xml
+++ b/enforcer-rules/src/it/war-project-private-modifier/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>@enforcer.version@</version>
         <dependencies>
           <dependency>
             <groupId>com.google.cloud.tools</groupId>

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -64,6 +64,7 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectDependenciesResolver;
 import org.eclipse.aether.DefaultRepositoryCache;
 import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.ArtifactTypeRegistry;
@@ -109,6 +110,31 @@ public class LinkageCheckerRule extends AbstractEnforcerRule {
 
   private ClassPathBuilder classPathBuilder;
 
+  // Properties managed by the dependency injection
+  private MavenProject project;
+
+  private MavenSession session;
+
+  private ProjectDependenciesResolver projectDependenciesResolver;
+
+  private MojoExecution execution;
+
+  private final RepositorySystem repoSystem;
+
+  @Inject
+  public LinkageCheckerRule(
+      MavenProject project,
+      MavenSession session,
+      MojoExecution execution,
+      ProjectDependenciesResolver projectDependenciesResolver,
+      RepositorySystem repoSystem) {
+    this.project = project;
+    this.session = session;
+    this.execution = execution;
+    this.projectDependenciesResolver = projectDependenciesResolver;
+    this.repoSystem = repoSystem;
+  }
+
   @VisibleForTesting
   void setDependencySection(DependencySection dependencySection) {
     this.dependencySection = dependencySection;
@@ -131,14 +157,6 @@ public class LinkageCheckerRule extends AbstractEnforcerRule {
   void setExclusionFile(String exclusionFile) {
     this.exclusionFile = exclusionFile;
   }
-
-  @Inject private MavenProject project;
-
-  @Inject private MavenSession session;
-
-  @Inject private ProjectDependenciesResolver projectDependenciesResolver;
-
-  @Inject private MojoExecution execution;
 
   private static EnforcerLogger logger;
 

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -271,8 +271,8 @@ public class LinkageCheckerRule extends AbstractEnforcerRule {
       }
     } catch (IOException ex) {
       // Maven's "-e" flag does not work for EnforcerRuleException
-      logger.warn("Failed to run Linkage Checker:" + ex.getMessage());
-      throw new EnforcerRuleException("Failed to run Linkage Checker", ex);
+      logger.warn("Failed to run Linkage Checker:" + ex);
+      throw new EnforcerRuleException("Failed to run Linkage Checker: " + ex, ex);
     }
   }
 

--- a/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
+++ b/enforcer-rules/src/main/java/com/google/cloud/tools/dependencies/enforcer/LinkageCheckerRule.java
@@ -48,22 +48,20 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import javax.inject.Named;
 import org.apache.maven.RepositoryUtils;
+import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecution;
-import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.plugins.enforcer.AbstractNonCacheableEnforcerRule;
 import org.apache.maven.project.DefaultDependencyResolutionRequest;
 import org.apache.maven.project.DependencyResolutionException;
 import org.apache.maven.project.DependencyResolutionRequest;
 import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectDependenciesResolver;
-import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.eclipse.aether.DefaultRepositoryCache;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
@@ -79,7 +77,8 @@ import org.eclipse.aether.util.graph.selector.OptionalDependencySelector;
 import org.eclipse.aether.version.InvalidVersionSpecificationException;
 
 /** Linkage Checker Maven Enforcer Rule. */
-public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
+@Named("linkageCheckerRule")
+public class LinkageCheckerRule extends AbstractEnforcerRule {
 
   /**
    * Maven packaging values known to be irrelevant to Linkage Check for non-BOM project.
@@ -133,139 +132,139 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
     this.exclusionFile = exclusionFile;
   }
 
-  private static Log logger;
+  @Inject private MavenProject project;
+
+  @Inject private MavenSession session;
+
+  @Inject private ProjectDependenciesResolver projectDependenciesResolver;
+
+  @Inject private MojoExecution execution;
+
+  private static EnforcerLogger logger;
 
   @Override
-  public void execute(@Nonnull EnforcerRuleHelper helper) throws EnforcerRuleException {
-    logger = helper.getLog();
+  public void execute() throws EnforcerRuleException {
+    logger = getLog();
 
-    try {
-      MavenProject project = (MavenProject) helper.evaluate("${project}");
-      MavenSession session = (MavenSession) helper.evaluate("${session}");
-      MojoExecution execution = (MojoExecution) helper.evaluate("${mojoExecution}");
-      RepositorySystemSession repositorySystemSession = session.getRepositorySession();
+    RepositorySystemSession repositorySystemSession = session.getRepositorySession();
 
-      ImmutableList<String> repositoryUrls =
-          project.getRemoteProjectRepositories().stream()
-              .map(RemoteRepository::getUrl)
-              .collect(toImmutableList());
-      DependencyGraphBuilder dependencyGraphBuilder = new DependencyGraphBuilder(repositoryUrls);
-      classPathBuilder = new ClassPathBuilder(dependencyGraphBuilder);
+    ImmutableList<String> repositoryUrls =
+        project.getRemoteProjectRepositories().stream()
+            .map(RemoteRepository::getUrl)
+            .collect(toImmutableList());
+    DependencyGraphBuilder dependencyGraphBuilder = new DependencyGraphBuilder(repositoryUrls);
+    classPathBuilder = new ClassPathBuilder(dependencyGraphBuilder);
 
-      boolean readingDependencyManagementSection =
-          dependencySection == DependencySection.DEPENDENCY_MANAGEMENT;
-      if (readingDependencyManagementSection
-          && (project.getDependencyManagement() == null
-              || project.getDependencyManagement().getDependencies() == null
-              || project.getDependencyManagement().getDependencies().isEmpty())) {
-        logger.warn("The rule is set to read dependency management section but it is empty.");
-      }
+    boolean readingDependencyManagementSection =
+        dependencySection == DependencySection.DEPENDENCY_MANAGEMENT;
+    if (readingDependencyManagementSection
+        && (project.getDependencyManagement() == null
+            || project.getDependencyManagement().getDependencies() == null
+            || project.getDependencyManagement().getDependencies().isEmpty())) {
+      logger.warn("The rule is set to read dependency management section but it is empty.");
+    }
 
-      String projectType = project.getArtifact().getType();
-      if (readingDependencyManagementSection) {
-        if (!"pom".equals(projectType)) {
-          logger.warn("A BOM should have packaging pom");
-          return;
-        }
-      } else {
-        if (UNSUPPORTED_NONBOM_PACKAGING.contains(projectType)) {
-          return;
-        }
-        if (!"verify".equals(execution.getLifecyclePhase())) {
-          throw new EnforcerRuleException(
-              "To run the check on the compiled class files, the linkage checker enforcer rule"
-                  + " should be bound to the 'verify' phase. Current phase: "
-                  + execution.getLifecyclePhase());
-        }
-        if (project.getArtifact().getFile() == null) {
-          // Skipping projects without a file, such as Guava's guava-tests module.
-          // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/850
-          return;
-        }
-      }
-
-      ClassPathResult classPathResult =
-          readingDependencyManagementSection
-              ? findBomClasspath(project, repositorySystemSession)
-              : findProjectClasspath(project, repositorySystemSession, helper);
-      ImmutableList<ClassPathEntry> classPath = classPathResult.getClassPath();
-      if (classPath.isEmpty()) {
-        logger.warn("Class path is empty.");
+    String projectType = project.getArtifact().getType();
+    if (readingDependencyManagementSection) {
+      if (!"pom".equals(projectType)) {
+        logger.warn("A BOM should have packaging pom");
         return;
       }
-
-      List<ClassPathEntry> entryPoints = entryPoints(project, classPath);
-
-      try {
-
-        // TODO LinkageChecker.create and LinkageChecker.findLinkageProblems
-        // should not be two separate public methods since we always call
-        // findLinkageProblems immediately after create.
-
-        Path exclusionFile = this.exclusionFile == null ? null : Paths.get(this.exclusionFile);
-        LinkageChecker linkageChecker =
-            LinkageChecker.create(classPath, entryPoints, exclusionFile);
-        ImmutableSet<LinkageProblem> linkageProblems = linkageChecker.findLinkageProblems();
-        if (reportOnlyReachable) {
-          ClassReferenceGraph classReferenceGraph = linkageChecker.getClassReferenceGraph();
-          linkageProblems =
-              linkageProblems.stream()
-                  .filter(
-                      entry ->
-                          classReferenceGraph.isReachable(entry.getSourceClass().getBinaryName()))
-                  .collect(toImmutableSet());
-        }
-
-        if (classPathResult != null) {
-          LinkageProblemCauseAnnotator.annotate(classPathBuilder, classPathResult, linkageProblems);
-        }
-
-        // Count unique LinkageProblems by their symbols
-        long errorCount =
-            linkageProblems.stream().map(LinkageProblem::formatSymbolProblem).distinct().count();
-
-        String foundError = reportOnlyReachable ? "reachable error" : "error";
-        if (errorCount > 1) {
-          foundError += "s";
-        }
-        if (errorCount > 0) {
-          String message =
-              String.format(
-                  "Linkage Checker rule found %d %s:\n%s",
-                  errorCount,
-                  foundError,
-                  LinkageProblem.formatLinkageProblems(linkageProblems, classPathResult));
-          if (getLevel() == WARN) {
-            logger.warn(message);
-          } else {
-            logger.error(message);
-            logger.info(
-                "For the details of the linkage errors, see "
-                    + "https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/Linkage-Checker-Messages");
-            throw new EnforcerRuleException(
-                "Failed while checking class path. See above error report.");
-          }
-        } else {
-          // arguably shouldn't log anything on success
-          logger.info("No " + foundError + " found");
-        }
-      } catch (IOException ex) {
-        // Maven's "-e" flag does not work for EnforcerRuleException. Print stack trace here.
-        logger.warn("Failed to run Linkage Checker:" + ex.getMessage(), ex);
-        throw new EnforcerRuleException("Failed to run Linkage Checker", ex);
+    } else {
+      if (UNSUPPORTED_NONBOM_PACKAGING.contains(projectType)) {
+        return;
       }
-    } catch (ExpressionEvaluationException ex) {
-      throw new EnforcerRuleException("Unable to lookup an expression " + ex.getMessage(), ex);
+      if (!"verify".equals(execution.getLifecyclePhase())) {
+        throw new EnforcerRuleException(
+            "To run the check on the compiled class files, the linkage checker enforcer rule"
+                + " should be bound to the 'verify' phase. Current phase: "
+                + execution.getLifecyclePhase());
+      }
+      if (project.getArtifact().getFile() == null) {
+        // Skipping projects without a file, such as Guava's guava-tests module.
+        // https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/850
+        return;
+      }
+    }
+
+    ClassPathResult classPathResult =
+        readingDependencyManagementSection
+            ? findBomClasspath(project, repositorySystemSession)
+            : findProjectClasspath(project, repositorySystemSession, projectDependenciesResolver);
+    ImmutableList<ClassPathEntry> classPath = classPathResult.getClassPath();
+    if (classPath.isEmpty()) {
+      logger.warn("Class path is empty.");
+      return;
+    }
+
+    List<ClassPathEntry> entryPoints = entryPoints(project, classPath);
+
+    try {
+
+      // TODO LinkageChecker.create and LinkageChecker.findLinkageProblems
+      // should not be two separate public methods since we always call
+      // findLinkageProblems immediately after create.
+
+      Path exclusionFile = this.exclusionFile == null ? null : Paths.get(this.exclusionFile);
+      LinkageChecker linkageChecker = LinkageChecker.create(classPath, entryPoints, exclusionFile);
+      ImmutableSet<LinkageProblem> linkageProblems = linkageChecker.findLinkageProblems();
+      if (reportOnlyReachable) {
+        ClassReferenceGraph classReferenceGraph = linkageChecker.getClassReferenceGraph();
+        linkageProblems =
+            linkageProblems.stream()
+                .filter(
+                    entry ->
+                        classReferenceGraph.isReachable(entry.getSourceClass().getBinaryName()))
+                .collect(toImmutableSet());
+      }
+
+      if (classPathResult != null) {
+        LinkageProblemCauseAnnotator.annotate(classPathBuilder, classPathResult, linkageProblems);
+      }
+
+      // Count unique LinkageProblems by their symbols
+      long errorCount =
+          linkageProblems.stream().map(LinkageProblem::formatSymbolProblem).distinct().count();
+
+      String foundError = reportOnlyReachable ? "reachable error" : "error";
+      if (errorCount > 1) {
+        foundError += "s";
+      }
+      if (errorCount > 0) {
+        String message =
+            String.format(
+                "Linkage Checker rule found %d %s:\n%s",
+                errorCount,
+                foundError,
+                LinkageProblem.formatLinkageProblems(linkageProblems, classPathResult));
+        if (getLevel() == WARN) {
+          logger.warn(message);
+        } else {
+          logger.error(message);
+          logger.info(
+              "For the details of the linkage errors, see "
+                  + "https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/Linkage-Checker-Messages");
+          throw new EnforcerRuleException(
+              "Failed while checking class path. See above error report.");
+        }
+      } else {
+        // arguably shouldn't log anything on success
+        logger.info("No " + foundError + " found");
+      }
+    } catch (IOException ex) {
+      // Maven's "-e" flag does not work for EnforcerRuleException
+      logger.warn("Failed to run Linkage Checker:" + ex.getMessage());
+      throw new EnforcerRuleException("Failed to run Linkage Checker", ex);
     }
   }
 
   /** Builds a class path for {@code mavenProject}. */
   private static ClassPathResult findProjectClasspath(
-      MavenProject mavenProject, RepositorySystemSession session, EnforcerRuleHelper helper)
+      MavenProject mavenProject,
+      RepositorySystemSession session,
+      ProjectDependenciesResolver projectDependenciesResolver)
       throws EnforcerRuleException {
     try {
-      ProjectDependenciesResolver projectDependenciesResolver =
-          helper.getComponent(ProjectDependenciesResolver.class);
       DefaultRepositorySystemSession fullDependencyResolutionSession =
           new DefaultRepositorySystemSession(session);
 
@@ -293,8 +292,6 @@ public class LinkageCheckerRule extends AbstractNonCacheableEnforcerRule {
           projectDependenciesResolver.resolve(dependencyResolutionRequest);
 
       return buildClassPathResult(resolutionResult);
-    } catch (ComponentLookupException e) {
-      throw new EnforcerRuleException("Unable to lookup a component " + e.getMessage(), e);
     } catch (DependencyResolutionException e) {
       return buildClasspathFromException(e);
     }


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/2378

Release note of the Maven enforcer rules: https://github.com/apache/maven-enforcer/releases

Based on the proposed changes by Robert Scholte in https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/2378#issuecomment-2340864202


