### PR TITLE
deps: update protobuf to 3.25.5.

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -51,7 +51,7 @@
     <!-- Layer 1: Core -->
     <guava.version>32.1.3-jre</guava.version>
     <autovalue.version>1.10.4</autovalue.version>
-    <protobuf.version>3.25.4</protobuf.version>
+    <protobuf.version>3.25.5</protobuf.version>
     <io.grpc.version>1.59.1</io.grpc.version>
     <google-http-client.version>1.43.3</google-http-client.version>
     <google-oauth-client.version>1.34.1</google-oauth-client.version>


### PR DESCRIPTION
in response to https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-735f-pc8j-v9w8  