### PR TITLE
chore: Add exec-linkage-checker Maven Profile to run linkage checker

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -122,6 +122,22 @@
 
   <profiles>
     <profile>
+      <id>exec-linkage-checker</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>3.5.0</version>
+            <configuration>
+              <skip>false</skip>
+              <mainClass>com.google.cloud.tools.opensource.classpath.LinkageCheckerMain</mainClass>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>java8-incompatible-reference-check</id>
       <build>
         <plugins>


### PR DESCRIPTION
Adds `exec-linkage-checker` Maven profile which allows `mvn exec:java` to not be skipped