### PR TITLE
ci: Update Github Action Cache to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,14 +11,14 @@ jobs:
       matrix:
         java: [8, 11]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: actions/setup-java@v1
       with:
         java-version: ${{matrix.java}}
     - name: Get current date
       id: date
       run: echo "date=$(date +'%Y-%m-%d' --utc)" >> "$GITHUB_OUTPUT"
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       id: mvn-cache
       with:
         path: ~/.m2/repository


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-opensource-java/actions/runs/13727600479/job/38397500613?pr=2398