### PR TITLE
Release 1.5.15-dependencies: Bumping to next version post release

### DIFF
--- a/boms/integration-tests/pom.xml
+++ b/boms/integration-tests/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>dependencies</artifactId>
-      <version>1.5.14-SNAPSHOT</version>
+      <version>1.5.15</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/boms/integration-tests/pom.xml
+++ b/boms/integration-tests/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>dependencies</artifactId>
-      <version>1.5.15</version>
+      <version>1.5.16-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.5.15</version>
+    <version>1.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>dashboard</artifactId>
 

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.5.14-SNAPSHOT</version>
+    <version>1.5.15</version>
   </parent>
   <artifactId>dashboard</artifactId>
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.5.14-SNAPSHOT</version>
+    <version>1.5.15</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.5.15</version>
+    <version>1.5.16-SNAPSHOT</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.5.15</version>
+    <version>1.5.16-SNAPSHOT</version>
   </parent>
 
   <artifactId>linkage-checker-enforcer-rules</artifactId>

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.5.14-SNAPSHOT</version>
+    <version>1.5.15</version>
   </parent>
 
   <artifactId>linkage-checker-enforcer-rules</artifactId>

--- a/gradle-plugin/gradle.properties
+++ b/gradle-plugin/gradle.properties
@@ -1,2 +1,2 @@
 # scripts/prepare_release.sh maintains this value.
-version = 1.5.15
+version = 1.5.16-SNAPSHOT

--- a/gradle-plugin/gradle.properties
+++ b/gradle-plugin/gradle.properties
@@ -1,2 +1,2 @@
 # scripts/prepare_release.sh maintains this value.
-version = 1.5.14-SNAPSHOT
+version = 1.5.15

--- a/linkage-monitor/action.yml
+++ b/linkage-monitor/action.yml
@@ -7,7 +7,7 @@ runs:
       # scripts/release.sh updates the version part in the URL
       run: |
         curl --output /tmp/linkage-monitor.jar \
-        "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor/linkage-monitor-1.5.15-all-deps.jar"
+        "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor/linkage-monitor-1.5.16-SNAPSHOT-all-deps.jar"
       shell: bash
     - run: java -jar /tmp/linkage-monitor.jar com.google.cloud:libraries-bom
       shell: bash

--- a/linkage-monitor/action.yml
+++ b/linkage-monitor/action.yml
@@ -7,7 +7,7 @@ runs:
       # scripts/release.sh updates the version part in the URL
       run: |
         curl --output /tmp/linkage-monitor.jar \
-        "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor/linkage-monitor-1.5.14-SNAPSHOT-all-deps.jar"
+        "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor/linkage-monitor-1.5.15-all-deps.jar"
       shell: bash
     - run: java -jar /tmp/linkage-monitor.jar com.google.cloud:libraries-bom
       shell: bash

--- a/linkage-monitor/pom.xml
+++ b/linkage-monitor/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.5.15</version>
+    <version>1.5.16-SNAPSHOT</version>
   </parent>
 
   <artifactId>linkage-monitor</artifactId>

--- a/linkage-monitor/pom.xml
+++ b/linkage-monitor/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>dependencies-parent</artifactId>
-    <version>1.5.14-SNAPSHOT</version>
+    <version>1.5.15</version>
   </parent>
 
   <artifactId>linkage-monitor</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>dependencies-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.5.14-SNAPSHOT</version>
+  <version>1.5.15</version>
 
   <name>Cloud Tools Open Source Code Hygiene Tooling</name>
   <url>https://github.com/GoogleCloudPlatform/cloud-opensource-java/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>dependencies-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.5.15</version>
+  <version>1.5.16-SNAPSHOT</version>
 
   <name>Cloud Tools Open Source Code Hygiene Tooling</name>
   <url>https://github.com/GoogleCloudPlatform/cloud-opensource-java/</url>


### PR DESCRIPTION
1st commit marks 1.5.15-dependencies release with the Git tag. 2nd commit bumps the version in the branch with SNAPSHOT suffix.