### PR TITLE
Release 9.0.0-lts: Bumping to next version post release

### DIFF
--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>gcp-lts-bom</artifactId>
-  <version>9.0.0-SNAPSHOT</version>
+  <version>9.0.0</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Long Term Support BOM</name>

--- a/boms/cloud-lts-bom/pom.xml
+++ b/boms/cloud-lts-bom/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>gcp-lts-bom</artifactId>
-  <version>9.0.0</version>
+  <version>9.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Google Cloud Long Term Support BOM</name>


### PR DESCRIPTION
1st commit marks 9.0.0-lts release with the Git tag. 2nd commit bumps the version in the branch with SNAPSHOT suffix.