### PR TITLE
ci: include 7.0.x-lts branch as release-please config

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -18,4 +18,5 @@ branches:
     handleGHRelease: true
     releaseType: java-lts
     branch: 6.0.x-lts
-  
+
+

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,5 +12,5 @@
         "release-type": "java-yoshi"
     }
   },
-  "bootstrap-sha": "8eb8233f0f402a52f9452ccc633fbce63904163d"
+  "bootstrap-sha": "6b9240114536a03b72929d5fade85599fbdbbdd0"
 }


### PR DESCRIPTION
The branch is still maintained.

The bootstrap_sha 6b9240114536a03b72929d5fade85599fbdbbdd0 is the commit older than LTS 6.
