### PR TITLE
ci: release-type should be read by release-please-config

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,22 +1,15 @@
 handleGHRelease: true
 manifest: true
-releaseType: java-yoshi
 branches:
   - bumpMinorPreMajor: true
     handleGHRelease: true
-    releaseType: java-backport
     branch: 9.0.x-lts
   - bumpMinorPreMajor: true
     handleGHRelease: true
-    releaseType: java-backport
     branch: 8.0.x-lts
   - bumpMinorPreMajor: true
     handleGHRelease: true
-    releaseType: java-backport
     branch: 7.0.x-lts
   - bumpMinorPreMajor: true
     handleGHRelease: true
-    releaseType: java-backport
     branch: 6.0.x-lts
-
-


### PR DESCRIPTION
I found that when the automation tries to specify release-type, Release Please does not respect release-please-config.json in the branch (b/452672128#comment14). In order for this multi-module repository to work with java-backport release type, we shouldn't specify the release-type in .github/release-please.yml.