### PR TITLE
chore: cleanup release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,9 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "separate-pull-requests": true,
   "include-component-in-tag": true,
-  "prerelease-type": "rc1",
-  "versioning": "prerelease",
-  "release-type": "java-yoshi",
   "packages": {
     "dependencies": {
       "component": "dependencies",
@@ -17,6 +14,4 @@
     }
   },
   "bootstrap-sha": "6b9240114536a03b72929d5fade85599fbdbbdd0"
-,
-  "prerelease": true
 }


### PR DESCRIPTION
This PR cleans up the .github/release-please.yml file by removing redundant options and the bump-minor-pre-major setting for major releases.